### PR TITLE
fix: terminal area overflow pushing input below viewport

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ const terminalArea = document.createElement("div");
 terminalArea.id = "terminal-area";
 terminalArea.style.cssText = `
   flex: 1; display: flex; flex-direction: column;
-  min-width: 0;
+  min-height: 0; min-width: 0;
 `;
 terminalWrapper.appendChild(terminalArea);
 


### PR DESCRIPTION
## Summary
- Adds `min-height: 0` to `#terminal-area` flex container to prevent it from overflowing beyond the viewport
- Regression from titlebar refactor (6ad35f1) — the nested flex layout requires `min-height: 0` for children to shrink properly
- Without this, the terminal content grows unbounded and pushes the input box off-screen

## Test plan
- [ ] Launch gnar-term and open a terminal pane
- [ ] Verify the input area is visible at the bottom of the window
- [ ] Resize the window to various sizes (including very small) — input should always remain visible
- [ ] Open multiple panes/splits and confirm layout stays within the viewport
- [ ] Open the find bar (⌘F) and confirm it appears at the top of the visible area, not off-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)