### PR TITLE
fix: Cmd+C/V copy-paste broken on macOS

### DIFF
--- a/src/terminal-manager.ts
+++ b/src/terminal-manager.ts
@@ -412,6 +412,20 @@ export class TerminalManager {
       const alt = e.altKey;
       const ctrl = e.ctrlKey;
 
+      // ⌘C — copy selection
+      if (!alt && !ctrl && k === "c") {
+        const sel = terminal.getSelection();
+        if (sel) navigator.clipboard.writeText(sel);
+        return false;
+      }
+      // ⌘V — paste
+      if (!alt && !ctrl && k === "v") {
+        navigator.clipboard.readText().then(text => {
+          if (surface.ptyId >= 0) invoke("write_pty", { ptyId: surface.ptyId, data: text });
+        });
+        return false;
+      }
+
       // ⌘+key (no alt)
       if (!alt && !ctrl) {
         if (["n","t","d","w","b","p","k","f","g"].includes(k)) return false;


### PR DESCRIPTION
## Summary
- Adds Cmd+C (copy) and Cmd+V (paste) handlers to the xterm.js custom key event handler
- These keys were missing from the intercepted shortcut list, so they fell through unhandled
- Uses `navigator.clipboard` API, matching the existing Ctrl+Shift+C/V Linux handlers

## Test plan
- [ ] Select text in the terminal with the mouse, press Cmd+C, then Cmd+V in the same or different pane — text should paste
- [ ] Select text, Cmd+C, then Cmd+V into an external app (e.g. TextEdit) — text should paste
- [ ] Copy text in an external app, Cmd+V into the terminal — text should appear at the cursor
- [ ] Right-click copy/paste should still work as before
- [ ] Ctrl+C should still send SIGINT (not copy)
- [ ] Ctrl+Shift+C/V should still work for copy/paste (Linux-style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)