### PR TITLE
fix: enable title bar window dragging

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "core:default",
     "core:event:default",
     "core:event:allow-listen",
-    "core:event:allow-emit"
+    "core:event:allow-emit",
+    "core:window:allow-start-dragging"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `core:window:allow-start-dragging` permission to the default Tauri capabilities file
- This permission is required in Tauri v2 for the `data-tauri-drag-region` HTML attribute to work — without it, clicking the title bar does nothing

## Test plan

1. Pull this branch and run `npm run tauri dev`
2. Wait for the app window to open
3. Click and hold on the **title bar area** (the top bar of the window) and drag — the window should move with your cursor
4. Release the mouse button — the window should stay in the new position
5. Click and hold on the **sidebar header** (which also has `data-tauri-drag-region`) and drag — this should also move the window
6. Verify that clicking buttons or interactive elements in the title bar area still works normally (they should not trigger dragging)
7. Verify the terminal area still accepts input and is not affected by the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)