### PR TITLE
fix: terminal content overflows viewport

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ sidebar.style.cssText = `
 const terminalWrapper = document.createElement("div");
 terminalWrapper.style.cssText = `
   flex: 1; display: flex; flex-direction: column;
-  background: ${theme.bg}; min-width: 0;
+  background: ${theme.bg}; min-height: 0; min-width: 0;
 `;
 
 // Title bar drag region above terminal area (matches sidebar header height)


### PR DESCRIPTION
## Summary

- Adds `min-height: 0` to the `terminalWrapper` flex container in `src/main.ts`
- The prior fix (302568a) added this to the child `#terminal-area` but missed the parent wrapper, so the terminal still overflowed on content-heavy sessions
- This is a one-line CSS change with no behavioral side effects

## Test plan

1. Launch GnarTerm (`npm run dev` or open the built app)
2. Open a terminal tab and run a command that produces output (e.g., `ls -la` or `cat` a long file)
3. Verify the terminal fills the window -- the bottom of the terminal where you type should be fully visible, not cut off below the window edge
4. Type a command and confirm you can see the cursor and what you are typing without scrolling the page
5. Resize the window smaller and larger -- the terminal should stay within bounds at all sizes, never overflowing below the visible area
6. Open multiple tabs and switch between them -- each tab's terminal should fit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)