### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gnar-term",
-  "version": "0.2.3",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnar-term",
-      "version": "0.2.3",
+      "version": "0.3.1",
       "dependencies": {
         "@embedpdf/snippet": "^2.12.1",
         "@sveltejs/vite-plugin-svelte": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnar-term",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "description": "Terminal workspace manager for AI coding agents",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1253,7 +1253,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gnar-term"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gnar-term"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegist/tauri-v2-schema/main/tauri.conf.json",
   "productName": "GnarTerm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.thegnar.gnar-term",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bumps version from 0.3.0 to 0.3.1 in package.json, tauri.conf.json, and Cargo.toml
- Fixes the broken v0.3.1 release where tauri-action uploaded assets to v0.3.0 because the version numbers were never bumped

## What happened
The v0.3.1 tag was pushed without bumping version numbers in the code. `tauri-action` reads `v__VERSION__` from tauri.conf.json, so it resolved to `v0.3.0` and uploaded all assets to the v0.3.0 release instead, leaving v0.3.1 empty. The Homebrew tap update then failed with "no assets to download".

## After merge
1. Tag `v0.3.1` on main and push the tag
2. The Release workflow will build and upload assets to the correct v0.3.1 release
3. The Homebrew tap workflow will then succeed

## Test plan
- [ ] Verify `package.json` version is `0.3.1`
- [ ] Verify `src-tauri/tauri.conf.json` version is `0.3.1`
- [ ] Verify `src-tauri/Cargo.toml` version is `0.3.1`
- [ ] After merge: push `v0.3.1` tag, confirm Release workflow uploads assets to v0.3.1 release
- [ ] Confirm Homebrew tap update workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)