### PR TITLE
fix: publish releases immediately instead of as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           tagName: v__VERSION__
           releaseName: 'GnarTerm v__VERSION__'
           releaseBody: 'Download the installer for your platform below.'
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}
 


### PR DESCRIPTION
## Summary
- Changes `releaseDraft: true` to `releaseDraft: false` in the Release workflow
- Draft releases are invisible to `gh release download`, which breaks the Homebrew tap update workflow
- This was the second reason v0.3.1's Homebrew tap update failed (first was the missing version bump)

## After merge
1. Publish the current v0.3.1 draft release manually (or delete and re-tag)
2. Manually trigger the Homebrew tap workflow with version `0.3.1`
3. Future releases will be published automatically and the Homebrew tap workflow will work

## Test plan
- [ ] Verify release.yml has `releaseDraft: false`
- [ ] After merge: manually publish the v0.3.1 draft release
- [ ] Run `gh workflow run update-homebrew.yml -f version=0.3.1` to trigger Homebrew tap update
- [ ] Verify Homebrew tap update succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)