### PR TITLE
fix: scroll to bottom when pane becomes visible

### DIFF
--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -866,4 +866,23 @@ describe("TerminalSurface", () => {
 
     expect(surface.terminal.open).not.toHaveBeenCalled();
   });
+
+  it("calls scrollToBottom after fit when pane becomes visible (#22)", async () => {
+    const surface = makeSurface("scroll-test", { opened: true });
+    // Start hidden
+    const { rerender } = render(TerminalSurfaceComponent, { props: { surface, visible: false } });
+
+    // Reset mocks from any mount-time calls
+    (surface.fitAddon.fit as ReturnType<typeof vi.fn>).mockClear();
+    (surface.terminal.scrollToBottom as ReturnType<typeof vi.fn>).mockClear();
+
+    // Become visible — triggers the reactive block
+    await rerender({ surface, visible: true });
+
+    // The reactive block uses requestAnimationFrame, so flush it
+    await new Promise(r => requestAnimationFrame(r));
+
+    expect(surface.fitAddon.fit).toHaveBeenCalled();
+    expect(surface.terminal.scrollToBottom).toHaveBeenCalled();
+  });
 });

--- a/src/lib/components/TerminalSurface.svelte
+++ b/src/lib/components/TerminalSurface.svelte
@@ -47,7 +47,10 @@
 
   $: if (visible && surface.opened && termEl) {
     requestAnimationFrame(() => {
-      try { surface.fitAddon.fit(); } catch (e) { console.warn("fitAddon.fit() failed on visibility change:", e); }
+      try {
+        surface.fitAddon.fit();
+        surface.terminal.scrollToBottom();
+      } catch (e) { console.warn("fitAddon.fit() failed on visibility change:", e); }
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- Fixes #22 — terminal scrolls up when navigating away and back to a pane
- Adds `scrollToBottom()` call after `fitAddon.fit()` in the visibility-change reactive block in `TerminalSurface.svelte`

## Test plan
- [ ] Open a terminal and run a command that produces output (e.g. `ls -la` or start Claude Code)
- [ ] Switch to a different tab or workspace
- [ ] Switch back — terminal should be scrolled to the bottom where the cursor is, not scrolled up
- [ ] Repeat with multiple tabs and workspaces to confirm consistency
- [ ] Run `npx vitest run` — all 246 tests pass, including new regression test for this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)