### PR TITLE
fix: derive release version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,16 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
 
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Set version from tag
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          # Update Cargo.toml so CARGO_PKG_VERSION matches the release tag
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml && rm -f src-tauri/Cargo.toml.bak
+
       - name: Install frontend dependencies
         run: npm install
 
@@ -64,10 +74,10 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: v__VERSION__
-          releaseName: 'GnarTerm v__VERSION__'
+          tagName: v${{ steps.version.outputs.VERSION }}
+          releaseName: 'GnarTerm v${{ steps.version.outputs.VERSION }}'
           releaseBody: 'Download the installer for your platform below.'
           releaseDraft: false
           prerelease: false
-          args: ${{ matrix.args }}
+          args: ${{ matrix.args }} --config {"version":"${{ steps.version.outputs.VERSION }}"}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -152,7 +152,7 @@ async fn spawn_pty(
     // keyboard protocol. Claude Code gates this on a hardcoded TERM_PROGRAM
     // allowlist with no capability negotiation fallback.
     cmd.env("TERM_PROGRAM", "ghostty");
-    cmd.env("TERM_PROGRAM_VERSION", "0.2.3");
+    cmd.env("TERM_PROGRAM_VERSION", env!("CARGO_PKG_VERSION"));
     // Inject OSC 7 cwd reporting for shells that don't do it automatically
     // This makes zsh/bash report the working directory on every prompt
     // Shell integration: inject OSC 7 cwd reporting (cross-platform)


### PR DESCRIPTION
## Summary
- Release workflow now extracts version from the git tag (`v0.3.2` → `0.3.2`) and injects it via `--config` override
- Replaced hardcoded `TERM_PROGRAM_VERSION` string with `env!("CARGO_PKG_VERSION")` (compile-time from Cargo.toml)
- CI step updates `Cargo.toml` version from tag before building

## Release process after this merges
```
git tag v0.3.2
git push origin v0.3.2
```
That's it. No file edits, no version bump commits, no branches.

## Test plan
- [ ] Merge this PR
- [ ] `git tag v0.3.2 && git push origin v0.3.2`
- [ ] Verify GitHub Actions Release workflow succeeds on all 4 platforms
- [ ] Verify GitHub Release page shows `GnarTerm v0.3.2` with installers
- [ ] Verify Homebrew tap updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)