### PR TITLE
fix: add shell: bash to release workflow for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,11 @@ jobs:
 
       - name: Get version from tag
         id: version
+        shell: bash
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Set version from tag
+        shell: bash
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
           # Update Cargo.toml so CARGO_PKG_VERSION matches the release tag


### PR DESCRIPTION
## Summary
- Windows runners default to PowerShell, which can't parse bash syntax (`sed`, `${GITHUB_REF#...}`)
- Adds `shell: bash` to the version extraction and Cargo.toml update steps
- Fixes the v0.3.2 release build failure on Windows

## Test plan
- [ ] Merge this PR
- [ ] Delete the v0.3.2 tag and re-tag: `git tag -d v0.3.2 && git push origin :refs/tags/v0.3.2 && git tag v0.3.2 && git push origin v0.3.2`
- [ ] Verify all 4 platform builds succeed in the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)