### PR TITLE
feat: add CLI argument support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -105,6 +105,7 @@ jobs:
             homepage \"https://github.com/TheGnarCo/gnar-term\"
 
             app \"GnarTerm.app\"
+            binary \"#{appdir}/GnarTerm.app/Contents/MacOS/gnar-term\"
 
             zap trash: [
               \"~/Library/Caches/com.thegnar.gnar-term\",

--- a/README.md
+++ b/README.md
@@ -192,6 +192,37 @@ Right-click in the terminal for contextual actions. File-specific actions appear
 - **Modular preview system** — add new file type previewers by dropping a plugin in `src/preview/`
 - **Cross-platform** — macOS, Linux, and Windows via Tauri v2
 
+## CLI Usage
+
+```bash
+gnar-term [PATH]                     # open with working directory
+gnar-term -e <COMMAND>               # run a command in the terminal
+gnar-term -d <DIR>                   # explicit working directory flag
+gnar-term --title <TITLE>            # set window/workspace title
+gnar-term -w <NAME>                  # load a named workspace from config
+gnar-term -c <FILE>                  # use a specific config file
+gnar-term --help                     # show all options
+gnar-term --version                  # print version
+```
+
+**Examples:**
+
+```bash
+# Open in a project directory (workspace named after the folder)
+gnar-term ~/projects/myapp
+
+# Open and run a dev server
+gnar-term ~/projects/myapp -e "npm run dev"
+
+# Load a saved workspace layout
+gnar-term -w Dev
+
+# Custom window title
+gnar-term --title "API Server" ~/projects/api
+```
+
+When launched without arguments, gnar-term loads workspaces from config (if `autoload` is set) or opens a default workspace.
+
 ## Install
 
 ### Homebrew (macOS)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +390,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +437,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1255,6 +1351,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "gnar-term"
 version = "0.3.1"
 dependencies = [
+ "clap",
  "libc",
  "portable-pty",
  "serde",
@@ -1707,6 +1804,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -2287,6 +2390,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -4380,6 +4489,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-build = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.8"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tauri-plugin-clipboard-manager = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -5,6 +6,60 @@ use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
+
+/// CLI arguments for GnarTerm.
+#[derive(Parser, Debug, Clone, Default, Serialize)]
+#[command(name = "gnar-term", version, about = "Terminal workspace manager")]
+pub struct CliArgs {
+    /// Directory to open in
+    #[arg(value_name = "PATH", conflicts_with = "working_directory")]
+    pub path: Option<String>,
+
+    /// Directory to open in (explicit flag)
+    #[arg(short = 'd', long = "working-directory")]
+    pub working_directory: Option<String>,
+
+    /// Command to execute in the terminal
+    #[arg(short = 'e', long = "command")]
+    pub command: Option<String>,
+
+    /// Window/workspace title
+    #[arg(long)]
+    pub title: Option<String>,
+
+    /// Load a named workspace from config
+    #[arg(short = 'w', long)]
+    pub workspace: Option<String>,
+
+    /// Path to config file
+    #[arg(short = 'c', long)]
+    pub config: Option<String>,
+}
+
+fn expand_path(path: &str) -> String {
+    let expanded = if path.starts_with("~/") {
+        let home = std::env::var("HOME").unwrap_or_default();
+        format!("{}/{}", home, &path[2..])
+    } else {
+        path.to_string()
+    };
+    std::fs::canonicalize(&expanded)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or(expanded)
+}
+
+fn resolve_cli_paths(mut args: CliArgs) -> CliArgs {
+    if let Some(ref p) = args.path {
+        args.path = Some(expand_path(p));
+    }
+    if let Some(ref p) = args.working_directory {
+        args.working_directory = Some(expand_path(p));
+    }
+    if let Some(ref p) = args.config {
+        args.config = Some(expand_path(p));
+    }
+    args
+}
 
 static NEXT_PTY_ID: AtomicU32 = AtomicU32::new(1);
 static NEXT_WATCH_ID: AtomicU32 = AtomicU32::new(1);
@@ -120,6 +175,12 @@ struct PtyTitle {
 #[derive(Clone, Serialize)]
 struct PtyExit {
     pty_id: u32,
+}
+
+/// Return CLI arguments passed to the app.
+#[tauri::command]
+fn get_cli_args(args: tauri::State<'_, CliArgs>) -> CliArgs {
+    args.inner().clone()
 }
 
 /// Spawn a new PTY with a shell
@@ -944,16 +1005,34 @@ async fn find_file(name: String) -> Result<String, String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Parse CLI args. Filter out macOS Finder's -psn_ process serial number arg.
+    let filtered_args: Vec<String> = std::env::args()
+        .filter(|a| !a.starts_with("-psn_"))
+        .collect();
+    let cli_args = resolve_cli_paths(CliArgs::parse_from(filtered_args));
+
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(AppState {
             ptys: Mutex::new(HashMap::new()),
             watch_flags: Mutex::new(HashMap::new()),
         })
+        .manage(cli_args)
         .invoke_handler(tauri::generate_handler![
-            spawn_pty, write_pty, resize_pty, kill_pty, pause_pty, resume_pty, detect_font, get_pty_cwd, get_pty_title, file_exists, list_dir, read_file, read_file_base64, write_file, ensure_dir, get_home, watch_file, unwatch_file, show_in_file_manager, open_with_default_app, find_file
+            get_cli_args, spawn_pty, write_pty, resize_pty, kill_pty, pause_pty, resume_pty, detect_font, get_pty_cwd, get_pty_title, file_exists, list_dir, read_file, read_file_base64, write_file, ensure_dir, get_home, watch_file, unwatch_file, show_in_file_manager, open_with_default_app, find_file
         ])
         .setup(|app| {
+            // Set window title from CLI --title flag
+            {
+                use tauri::Manager;
+                let cli = app.state::<CliArgs>();
+                if let Some(ref title) = cli.title {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.set_title(title);
+                    }
+                }
+            }
+
             // Rebuild macOS menu manually so Cmd+Q, Cmd+C, Cmd+V work,
             // but Cmd+T/Cmd+W/Cmd+N are passed down to JS.
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,70 @@ pub struct CliArgs {
     pub config: Option<String>,
 }
 
+/// Flags accepted by CliArgs that take a value argument.
+const VALUE_FLAGS: &[&str] = &[
+    "-d", "--working-directory",
+    "-e", "--command",
+    "--title",
+    "-w", "--workspace",
+    "-c", "--config",
+];
+
+/// Flags accepted by CliArgs that are standalone (no value).
+const STANDALONE_FLAGS: &[&str] = &["-h", "--help", "-V", "--version"];
+
+/// Filter argv to only args defined by CliArgs, dropping unknown flags
+/// that leak from Cargo/Tauri during `tauri dev` (e.g. --color, --no-default-features).
+fn filter_known_args(args: impl Iterator<Item = String>) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut args = args.peekable();
+
+    // Always keep the binary name.
+    if let Some(bin) = args.next() {
+        result.push(bin);
+    }
+
+    while let Some(arg) = args.next() {
+        if !arg.starts_with('-') || arg == "-" {
+            // Positional arg — keep it.
+            result.push(arg);
+        } else if arg == "--" {
+            // End-of-flags marker — keep it and everything after.
+            result.push(arg);
+            result.extend(args);
+            break;
+        } else if arg.contains('=') {
+            // --flag=value form: keep only if the flag part is known.
+            let flag = arg.split('=').next().unwrap_or("");
+            if VALUE_FLAGS.contains(&flag) {
+                result.push(arg);
+            }
+        } else if VALUE_FLAGS.contains(&arg.as_str()) {
+            // Known flag with a separate value — keep both.
+            result.push(arg);
+            if let Some(val) = args.next() {
+                result.push(val);
+            }
+        } else if STANDALONE_FLAGS.contains(&arg.as_str()) {
+            result.push(arg);
+        } else if arg.starts_with("-psn_") {
+            // macOS Finder process serial number — drop.
+        } else {
+            // Unknown flag — drop it, and also drop its value if the next
+            // arg looks like a flag-value (not starting with '-' or '/~.').
+            if let Some(next) = args.peek() {
+                if !next.starts_with('-') && !next.starts_with('/')
+                    && !next.starts_with('~') && !next.starts_with('.')
+                {
+                    args.next(); // consume the value too
+                }
+            }
+        }
+    }
+
+    result
+}
+
 fn expand_path(path: &str) -> String {
     let expanded = if path.starts_with("~/") {
         let home = std::env::var("HOME").unwrap_or_default();
@@ -1005,10 +1069,9 @@ async fn find_file(name: String) -> Result<String, String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Parse CLI args. Filter out macOS Finder's -psn_ process serial number arg.
-    let filtered_args: Vec<String> = std::env::args()
-        .filter(|a| !a.starts_with("-psn_"))
-        .collect();
+    // Parse CLI args. Use whitelist filter to drop unknown flags that leak
+    // from Cargo/Tauri during `tauri dev` (--color, --no-default-features, etc.).
+    let filtered_args = filter_known_args(std::env::args());
     let cli_args = resolve_cli_paths(CliArgs::parse_from(filtered_args));
 
     tauri::Builder::default()
@@ -1936,6 +1999,97 @@ mod tests {
         assert_eq!(
             classify_osc("9;42"),
             OscAction::Notification("42".into())
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // filter_known_args tests
+    // -----------------------------------------------------------------------
+
+    fn args(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn filter_keeps_positional_path() {
+        let input = args(&["gnar-term", "/home/user"]);
+        assert_eq!(filter_known_args(input.into_iter()), args(&["gnar-term", "/home/user"]));
+    }
+
+    #[test]
+    fn filter_keeps_known_flags() {
+        let input = args(&["gnar-term", "-d", "/tmp", "-e", "vim", "--title", "My Term"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn filter_keeps_flag_equals_form() {
+        let input = args(&["gnar-term", "--working-directory=/tmp"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn filter_drops_unknown_standalone_flags() {
+        let input = args(&["gnar-term", "--no-default-features", "/home/user"]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "/home/user"])
+        );
+    }
+
+    #[test]
+    fn filter_drops_unknown_flag_with_space_value() {
+        // --color always (space-separated) — both must be dropped.
+        let input = args(&["gnar-term", "--color", "always", "/home/user"]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "/home/user"])
+        );
+    }
+
+    #[test]
+    fn filter_drops_unknown_flag_followed_by_another_flag() {
+        // --color followed by --no-default-features — don't consume the next flag as a value.
+        let input = args(&["gnar-term", "--color", "--no-default-features", "/home/user"]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "/home/user"])
+        );
+    }
+
+    #[test]
+    fn filter_drops_unknown_equals_flag() {
+        let input = args(&["gnar-term", "--color=always", "/home/user"]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "/home/user"])
+        );
+    }
+
+    #[test]
+    fn filter_drops_psn_arg() {
+        let input = args(&["gnar-term", "-psn_0_12345", "/home/user"]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "/home/user"])
+        );
+    }
+
+    #[test]
+    fn filter_preserves_args_after_double_dash() {
+        let input = args(&["gnar-term", "--", "--not-a-flag", "foo"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn filter_mixed_known_unknown_and_positional() {
+        let input = args(&[
+            "gnar-term", "--color", "-w", "dev", "--no-default-features",
+            "-e", "bash", "--unknown", "~/Documents",
+        ]);
+        assert_eq!(
+            filter_known_args(input.into_iter()),
+            args(&["gnar-term", "-w", "dev", "-e", "bash", "~/Documents"])
         );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.thegnar.gnar-term",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://127.0.0.1:1420",
     "beforeDevCommand": "npm run vite",
     "beforeBuildCommand": "npm run vite:build"
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,6 +43,11 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/hooks.nsh"
+      }
+    },
     "macOS": {
       "signingIdentity": null,
       "entitlements": "entitlements.plist"

--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -1,0 +1,14 @@
+; Add gnar-term to the system PATH on install, remove on uninstall.
+; Uses the EnVar plugin bundled with Tauri's NSIS toolchain.
+
+!macro NSIS_HOOK_POSTINSTALL
+  ; Add the install directory to the user PATH so `gnar-term` works from any shell.
+  EnVar::SetHKCU
+  EnVar::AddValue "PATH" "$INSTDIR"
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  ; Clean up the PATH entry we added during install.
+  EnVar::SetHKCU
+  EnVar::DeleteValue "PATH" "$INSTDIR"
+!macroend

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -556,30 +556,76 @@
     if (e.key === "Escape" && $findBarVisible) { e.preventDefault(); findBarVisible.set(false); return; }
   }
 
+  // ---- CLI args type (matches Rust CliArgs struct) ----
+  interface CliArgs {
+    path: string | null;
+    working_directory: string | null;
+    command: string | null;
+    title: string | null;
+    workspace: string | null;
+    config: string | null;
+  }
+
   // ---- Initialization ----
   onMount(async () => {
     await fontReady;
     setupListeners();
     startCwdPolling();
 
-    const config = await loadConfig();
+    // Fetch CLI arguments from Rust backend
+    const cliArgs = await invoke<CliArgs>("get_cli_args");
+
+    const config = await loadConfig(cliArgs.config || undefined);
     if (config.theme) {
       theme.set(config.theme);
     }
 
-    // Autoload workspaces from config, or create a default one
-    let autoloaded = false;
-    if (config.autoload && config.autoload.length > 0 && config.commands) {
-      for (const name of config.autoload) {
-        const cmd = config.commands.find(c => c.name === name && c.workspace);
-        if (cmd?.workspace) {
-          await createWorkspaceFromDef(cmd.workspace);
-          autoloaded = true;
+    // CLI args take priority over config autoload
+    const cliCwd = cliArgs.path || cliArgs.working_directory;
+
+    if (cliArgs.workspace) {
+      // --workspace flag: load a named workspace from config
+      const cmd = config.commands?.find(
+        c => c.name === cliArgs.workspace && c.workspace
+      );
+      if (cmd?.workspace) {
+        await createWorkspaceFromDef(cmd.workspace);
+      } else {
+        console.warn(`[cli] Workspace "${cliArgs.workspace}" not found in config`);
+        await createWorkspace(cliArgs.title || "Workspace 1");
+      }
+    } else if (cliCwd || cliArgs.command) {
+      // CLI provided a cwd and/or command
+      const wsName = cliArgs.title || cliCwd?.split("/").pop() || "Workspace 1";
+      const def: WorkspaceDef = {
+        name: wsName,
+        cwd: cliCwd || undefined,
+        layout: {
+          pane: {
+            surfaces: [{
+              type: "terminal",
+              cwd: cliCwd || undefined,
+              command: cliArgs.command || undefined,
+            }]
+          }
+        }
+      };
+      await createWorkspaceFromDef(def);
+    } else {
+      // No CLI args — fall back to config autoload or default
+      let autoloaded = false;
+      if (config.autoload && config.autoload.length > 0 && config.commands) {
+        for (const name of config.autoload) {
+          const cmd = config.commands.find(c => c.name === name && c.workspace);
+          if (cmd?.workspace) {
+            await createWorkspaceFromDef(cmd.workspace);
+            autoloaded = true;
+          }
         }
       }
-    }
-    if (!autoloaded) {
-      await createWorkspace("Workspace 1");
+      if (!autoloaded) {
+        await createWorkspace("Workspace 1");
+      }
     }
 
     // Listen for menu events

--- a/src/__tests__/terminal-sizing.test.ts
+++ b/src/__tests__/terminal-sizing.test.ts
@@ -56,6 +56,105 @@ describe("connectPty uses real terminal dimensions", () => {
     expect(surface.ptyId).toBe(1);
   });
 
+  it("passes cwd from surface.cwd to spawn_pty", async () => {
+    const spawnCalls: { cols: number; rows: number; cwd: string | null }[] = [];
+
+    mockIPC((cmd, args) => {
+      if (cmd === "spawn_pty") {
+        spawnCalls.push({ cols: (args as any).cols, rows: (args as any).rows, cwd: (args as any).cwd });
+        return 3;
+      }
+      return undefined;
+    });
+
+    const { connectPty } = await import("../lib/terminal-service");
+
+    const surface = {
+      ptyId: -1,
+      terminal: { cols: 80, rows: 24 },
+      cwd: "/Users/test/Documents",
+    } as any;
+
+    await connectPty(surface);
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cwd).toBe("/Users/test/Documents");
+    expect(surface.ptyId).toBe(3);
+  });
+
+  it("passes cwd parameter to spawn_pty when surface.cwd is unset", async () => {
+    const spawnCalls: { cwd: string | null }[] = [];
+
+    mockIPC((cmd, args) => {
+      if (cmd === "spawn_pty") {
+        spawnCalls.push({ cwd: (args as any).cwd });
+        return 4;
+      }
+      return undefined;
+    });
+
+    const { connectPty } = await import("../lib/terminal-service");
+
+    const surface = {
+      ptyId: -1,
+      terminal: { cols: 80, rows: 24 },
+    } as any;
+
+    await connectPty(surface, "/tmp/fallback");
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cwd).toBe("/tmp/fallback");
+  });
+
+  it("surface.cwd takes priority over cwd parameter", async () => {
+    const spawnCalls: { cwd: string | null }[] = [];
+
+    mockIPC((cmd, args) => {
+      if (cmd === "spawn_pty") {
+        spawnCalls.push({ cwd: (args as any).cwd });
+        return 5;
+      }
+      return undefined;
+    });
+
+    const { connectPty } = await import("../lib/terminal-service");
+
+    const surface = {
+      ptyId: -1,
+      terminal: { cols: 80, rows: 24 },
+      cwd: "/Users/test/Documents",
+    } as any;
+
+    await connectPty(surface, "/tmp/ignored");
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cwd).toBe("/Users/test/Documents");
+  });
+
+  it("sends null cwd when neither surface.cwd nor parameter is set", async () => {
+    const spawnCalls: { cwd: string | null }[] = [];
+
+    mockIPC((cmd, args) => {
+      if (cmd === "spawn_pty") {
+        spawnCalls.push({ cwd: (args as any).cwd });
+        return 6;
+      }
+      return undefined;
+    });
+
+    const { connectPty } = await import("../lib/terminal-service");
+
+    const surface = {
+      ptyId: -1,
+      terminal: { cols: 80, rows: 24 },
+    } as any;
+
+    await connectPty(surface);
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cwd).toBeNull();
+  });
+
   it("does not spawn if already connected", async () => {
     const spawnCalls: any[] = [];
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -75,7 +75,19 @@ const CONFIG_FILENAMES = [
 let _config: GnarTermConfig = {};
 let _configPath = "";
 
-export async function loadConfig(): Promise<GnarTermConfig> {
+export async function loadConfig(explicitPath?: string): Promise<GnarTermConfig> {
+  // If an explicit config path was provided (e.g. via --config), try it first
+  if (explicitPath) {
+    try {
+      const content = await invoke<string>("read_file", { path: explicitPath });
+      _config = JSON.parse(content);
+      _configPath = explicitPath;
+      return _config;
+    } catch (e) {
+      console.warn(`[config] Failed to load ${explicitPath}:`, e);
+    }
+  }
+
   const home = await getHome();
 
   // Try per-project config first (higher priority), then global

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -564,13 +564,16 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
 }
 
 /** Spawn the PTY for a surface. Called after terminal.open() + fit() so the PTY
- *  gets the real terminal dimensions instead of hardcoded 80x24. */
+ *  gets the real terminal dimensions instead of hardcoded 80x24.
+ *  Uses surface.cwd as the working directory. The optional cwd parameter is
+ *  accepted for backwards compatibility but surface.cwd takes priority. */
 export async function connectPty(surface: TerminalSurface, cwd?: string): Promise<void> {
   if (surface.ptyId >= 0) return; // already connected
   const cols = surface.terminal.cols;
   const rows = surface.terminal.rows;
+  const effectiveCwd = surface.cwd || cwd || null;
   try {
-    surface.ptyId = await invoke<number>("spawn_pty", { cols, rows, cwd: cwd || null });
+    surface.ptyId = await invoke<number>("spawn_pty", { cols, rows, cwd: effectiveCwd });
   } catch (err) {
     console.error("Failed to spawn PTY:", err);
     surface.ptyId = -1;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   clearScreen: false,
   server: {
+    host: "127.0.0.1",
     port: 1420,
     strictPort: true,
   },


### PR DESCRIPTION
## Summary
- Adds CLI argument parsing via clap: positional path, `-d`/`-e`/`-w`/`-c`/`--title` flags
- Whitelist-based arg filter prevents Cargo/Tauri dev flags from crashing clap during `tauri dev`
- Wires `surface.cwd` through to `spawn_pty` so CLI-provided working directories take effect
- Fixes dev server to use `127.0.0.1` instead of `localhost`

## Test plan
- [x] `gnar-term --help` prints usage
- [x] `gnar-term /tmp` opens terminal in /tmp
- [x] `gnar-term -e "vim"` runs command
- [x] `gnar-term --title "Test"` sets window title
- [x] `tauri dev` no longer crashes from extra Cargo flags
- [x] 250 frontend tests pass
- [x] 46 Rust unit tests pass (including 10 new filter_known_args tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)