### PR TITLE
chore: add CLAUDE.md and release command

### DIFF
--- a/.claude/commands/create_new_release.md
+++ b/.claude/commands/create_new_release.md
@@ -1,0 +1,31 @@
+# Create a New Release
+
+Create a new GnarTerm release. Version is derived from the git tag — no code changes needed.
+
+## Usage
+
+Argument: version number (e.g. `0.4.0`)
+
+## Steps
+
+1. Confirm you are on the `main` branch with a clean working tree
+2. Pull latest from origin to ensure you're up to date
+3. Verify the version tag `v$ARGUMENTS` does not already exist
+4. Create the tag: `git tag v$ARGUMENTS`
+5. Push the tag: `git push origin v$ARGUMENTS`
+6. Confirm the tag was pushed successfully
+7. Report the release URL: `https://github.com/TheGnarCo/gnar-term/releases/tag/v$ARGUMENTS`
+
+## How it works
+
+- The `release.yml` workflow triggers on `v*` tag pushes
+- CI extracts the version from the tag and injects it via `sed` into `Cargo.toml` and `--config {"version":"..."}` into tauri-action
+- Builds run on macOS (aarch64 + x86_64), Ubuntu, and Windows
+- tauri-action creates the GitHub Release and uploads platform installers
+- The `update-homebrew.yml` workflow updates the Homebrew tap after release assets are published
+
+## Important
+
+- Do NOT edit version files (package.json, Cargo.toml, tauri.conf.json) — CI handles versioning from the tag
+- Do NOT create a branch or PR for the release — it's just a tag on main
+- If the release workflow fails, check the Actions tab: https://github.com/TheGnarCo/gnar-term/actions/workflows/release.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# GnarTerm
+
+Tauri v2 terminal workspace manager. Rust backend (portable-pty), Svelte frontend (xterm.js).
+
+## Build & Test
+
+```bash
+npm test                    # vitest unit tests (246 tests)
+npm run build               # full tauri build (frontend + Rust)
+cargo check                 # quick Rust compilation check
+```
+
+All tests must pass and `npm run build` must succeed before pushing any commit. Do not declare work complete without a green test suite.
+
+## Branching & PRs
+
+- All work on feature branches, never commit directly to main
+- Always `git checkout main` before creating a new branch — never branch off other feature branches
+- Every bug fix and feature must include regression tests
+- Use plan mode for audits, migrations, and multi-step tasks
+- Disable sandbox for SSH git ops (`git push/pull/fetch`) and `gh` commands
+
+### PR test plans
+
+Every PR must have a `## Test plan` section with step-by-step manual verification checkboxes. After running each verification step, check it off (`[x]`) in the PR body. The user is a manager who relies on the test plan to track QA progress — unchecked items mean unverified work.
+
+## Releases
+
+Releases are tag-based with zero code changes. Use the `/create_new_release` command or manually:
+
+```bash
+git tag v0.4.0
+git push origin v0.4.0
+```
+
+CI derives version from the tag. Do NOT edit version files for releases.
+
+See `.github/workflows/release.yml` for the full pipeline (macOS, Linux, Windows builds + signing + Homebrew tap update).
+
+## GitHub Actions
+
+The Claude GitHub App is installed on this repo. `@claude` mentions in PRs trigger Claude Code via GitHub Actions to review, implement, or respond to requests.
+
+## Commands
+
+Custom slash commands live in `.claude/commands/`:
+- `/create_new_release <version>` - tag and push a release
+
+## Testing Guidelines
+
+- Write tests alongside the fix, not as a separate phase
+- Tests must verify actual behavior, not just scan source code
+- Trace features end-to-end through real code paths
+- For PTY/terminal fixes, test with real terminal output, not just mocks
+- Do NOT use AppleScript/screenshot GUI tests (they interrupt the user's screen)
+- No `setTimeout` hacks to fix timing issues — diagnose root cause


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with build/test instructions, branching/PR workflow, release process, GitHub Actions reference, and testing guidelines
- Add `/create_new_release` slash command documenting the tag-based release flow
- Consolidates guidance previously spread across 15+ memory files

## Test plan
- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify `.claude/commands/create_new_release.md` is present and correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)