### PR TITLE
Fix Windows NSIS build: install EnVar plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,19 @@ jobs:
           # Update Cargo.toml so CARGO_PKG_VERSION matches the release tag
           sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml && rm -f src-tauri/Cargo.toml.bak
 
+      - name: Install NSIS EnVar plugin (Windows only)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $nsisPluginDir = "$env:LOCALAPPDATA\tauri\NSIS\Plugins"
+          New-Item -ItemType Directory -Force "$nsisPluginDir\x86-unicode"
+          New-Item -ItemType Directory -Force "$nsisPluginDir\amd64-unicode"
+          $zip = "$env:TEMP\EnVar.zip"
+          Invoke-WebRequest -Uri "https://github.com/GsNSIS/EnVar/releases/download/v0.3.1/EnVar-Plugin.zip" -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath "$env:TEMP\EnVar"
+          Copy-Item "$env:TEMP\EnVar\Plugins\x86-unicode\EnVar.dll" "$nsisPluginDir\x86-unicode\" -Force
+          Copy-Item "$env:TEMP\EnVar\Plugins\amd64-unicode\EnVar.dll" "$nsisPluginDir\amd64-unicode\" -Force
+
       - name: Install frontend dependencies
         run: npm install
 

--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -1,5 +1,5 @@
 ; Add gnar-term to the system PATH on install, remove on uninstall.
-; Uses the EnVar plugin bundled with Tauri's NSIS toolchain.
+; Requires the EnVar plugin (https://github.com/GsNSIS/EnVar) — installed via CI workflow.
 
 !macro NSIS_HOOK_POSTINSTALL
   ; Add the install directory to the user PATH so `gnar-term` works from any shell.


### PR DESCRIPTION
## Summary
- The v0.3.3 release failed on Windows because the NSIS `EnVar` plugin is not bundled with Tauri's NSIS toolchain
- Adds a CI step to download and install the [GsNSIS/EnVar](https://github.com/GsNSIS/EnVar) plugin into Tauri's NSIS plugin directory before the build
- Fixes misleading comment in `hooks.nsh`

## Test plan
- [ ] Merge PR to main
- [ ] Delete existing v0.3.3 tag: `git tag -d v0.3.3 && git push origin :refs/tags/v0.3.3`
- [ ] Delete the failed draft release on GitHub if one exists
- [ ] Re-tag and push: `git tag v0.3.3 && git push origin v0.3.3`
- [ ] Verify all four Release workflow jobs pass (macOS arm64, macOS x86_64, Linux, Windows)
- [ ] Verify the Windows job logs show EnVar.dll being copied successfully
- [ ] Verify the v0.3.3 release appears on GitHub with all platform assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)