### PR TITLE
Fix homebrew tap workflow f-string KeyError

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -105,7 +105,7 @@ jobs:
             homepage \"https://github.com/TheGnarCo/gnar-term\"
 
             app \"GnarTerm.app\"
-            binary \"#{appdir}/GnarTerm.app/Contents/MacOS/gnar-term\"
+            binary \"#{{appdir}}/GnarTerm.app/Contents/MacOS/gnar-term\"
 
             zap trash: [
               \"~/Library/Caches/com.thegnar.gnar-term\",


### PR DESCRIPTION
## Summary

- Release pipeline has been silently broken since the `binary` line was added to the cask template — every tap update since then crashes with `KeyError: 'appdir'` because Python's `.format()` was trying to interpret `#{appdir}` as a format placeholder.
- Escape it as `#{{appdir}}` so Python passes it through literally and Homebrew expands the Ruby interpolation at install time.
- This is why \`v0.3.3\` built and published to GitHub Releases successfully but brew users are still stuck on \`0.3.2\` (and still don't have the \`gnar-term\` CLI symlink, since that's exactly what this line adds).

After merge, trigger the tap update for the current release:

\`\`\`bash
gh workflow run update-homebrew.yml -f version=0.3.3
\`\`\`

## Test plan

- [ ] Merge PR
- [ ] Run \`gh workflow run update-homebrew.yml -f version=0.3.3\`
- [ ] Verify workflow succeeds: \`gh run list --workflow=update-homebrew.yml --limit 1\`
- [ ] Verify tap cask updated: \`gh api repos/thegnarco/homebrew-tap/contents/Casks/gnar-term.rb --jq '.content' | base64 -d | head -20\` shows \`version "0.3.3"\` and the \`binary\` line
- [ ] \`brew update && brew upgrade --cask gnar-term\` pulls 0.3.3
- [ ] \`which gnar-term\` returns a path in \`/opt/homebrew/bin\`
- [ ] \`gnar-term --version\` prints \`gnar-term 0.3.3\`
- [ ] Confirm next tagged release auto-updates the tap without manual workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)