### PR TITLE
fix(mcp): bind agent panes to host workspace, not user GUI focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ npm run build               # full tauri build (frontend + Rust)
 cargo check                 # quick Rust compilation check
 ```
 
-All tests must pass and `npm run build` must succeed before pushing any commit. Do not declare work complete without a green test suite.
+All tests must pass and `npm run build` must succeed before pushing any commit. Do not declare work complete without a green test suite. You must NEVER merge PR's, especially to main.
 
 ## Slack
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ with a pointer to its own binary. If the CLI isn't available, it falls
 back to an atomic write of `~/.claude.json`. After registration you only
 need to restart Claude Code once; no manual `claude mcp add` is needed.
 
-### The 19 tools
+### The 20 tools
 
 | Category | Tools |
 |---|---|
@@ -417,6 +417,7 @@ need to restart Claude Code once; no manual `claude mcp add` is needed.
 | Interaction | `send_prompt`, `send_keys`, `read_output` |
 | Orchestration | `dispatch_tasks` |
 | UI writes | `render_sidebar`, `remove_sidebar_section`, `create_preview` |
+| Agent introspection | `get_agent_context` |
 | UI introspection | `get_active_workspace`, `list_workspaces`, `get_active_pane`, `list_panes` |
 | Lifecycle events | `poll_events` |
 | Filesystem | `list_dir`, `read_file`, `file_exists` |
@@ -424,6 +425,28 @@ need to restart Claude Code once; no manual `claude mcp add` is needed.
 See the Spacebase spec (doc id `jzvBxDRrkevx`) for full argument schemas
 and the wire-level contract, or read `src/lib/services/mcp-server.ts` for
 the authoritative TypeScript definitions.
+
+### Connection binding (where do agent-spawned panes go?)
+
+When gnar-term spawns a PTY for any pane, it injects
+`GNAR_TERM_PANE_ID` and `GNAR_TERM_WORKSPACE_ID` into the child process's
+environment. Agents launched inside the pane (e.g. `claude`) inherit these
+vars; the `gnar-term --mcp-stdio` shim forwards them in a
+`$/gnar-term/hello` notification on connect. The webview binds the
+connection to that pane / workspace.
+
+UI-mutating tools then resolve their target deterministically:
+
+1. Explicit `pane_id` argument wins.
+2. Explicit `workspace_id` argument wins.
+3. Connection's bound `pane_id` (workspace re-derived in case the pane was moved).
+4. Connection's bound `workspace_id`.
+5. Otherwise: error. The server **never** falls back to "user GUI focus" for
+   write decisions — that's how the v1 routing-follows-focus bug shipped.
+
+Agents can call `get_agent_context` to learn their binding. UI introspection
+tools (`get_active_workspace`, `get_active_pane`) still report user GUI focus —
+they're observers, not authoritative for routing.
 
 ### Integration test harness
 
@@ -436,8 +459,12 @@ build end-to-end:
 node tests/mcp-integration.mjs
 ```
 
-The harness exercises `initialize`, `tools/list`, `list_workspaces`,
-`poll_events`, and `render_sidebar`/`remove_sidebar_section`.
+For the full mandatory scenario matrix from the spec (15 scenarios covering
+multi-connection isolation, binding rules, override semantics, error paths):
+
+```bash
+node tests/mcp-scenarios.mjs
+```
 
 ## Architecture
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -251,11 +251,18 @@ fn get_cli_args(args: tauri::State<'_, CliArgs>) -> CliArgs {
     args.inner().clone()
 }
 
-/// Spawn a new PTY with a shell. `on_output` is a Tauri v2 IPC Channel that
-/// carries raw PTY bytes to the webview. Using a per-pty Channel with
-/// `InvokeResponseBody::Raw` delivers bytes via the ipc custom-protocol path
-/// (ArrayBuffer in JS) instead of one `evaluateJavaScript` call per chunk, so
-/// bursty output no longer pegs the WebContent main thread on macOS.
+/// Spawn a new PTY with a shell.
+///
+/// `on_output` is a Tauri v2 IPC Channel that carries raw PTY bytes to the
+/// webview. Using a per-pty Channel with `InvokeResponseBody::Raw` delivers
+/// bytes via the ipc custom-protocol path (ArrayBuffer in JS) instead of one
+/// `evaluateJavaScript` call per chunk, so bursty output no longer pegs the
+/// WebContent main thread on macOS.
+///
+/// `extra_env` is an optional map of additional env vars merged into the
+/// child's environment after the shell-integration vars are set. Used to
+/// inject `GNAR_TERM_PANE_ID` and `GNAR_TERM_WORKSPACE_ID` so MCP agents
+/// running inside a pane can advertise their host context to the GUI.
 #[tauri::command]
 async fn spawn_pty(
     app: AppHandle,
@@ -264,6 +271,7 @@ async fn spawn_pty(
     rows: u16,
     cwd: Option<String>,
     on_output: Channel<InvokeResponseBody>,
+    extra_env: Option<HashMap<String, String>>,
 ) -> Result<u32, String> {
     let pty_system = native_pty_system();
 
@@ -327,6 +335,14 @@ PROMPT_COMMAND="_gnarterm_report_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
     if let Some(ref dir) = cwd {
         cmd.cwd(dir);
+    }
+
+    // Merge caller-provided env vars last so they win over our shell-integration
+    // defaults (e.g. allow MCP context vars or test harnesses to override).
+    if let Some(extra) = extra_env {
+        for (k, v) in extra {
+            cmd.env(&k, &v);
+        }
     }
 
     let child = pair.slave

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -1,15 +1,19 @@
-//! MCP UDS bridge. A tokio task inside the GUI process that binds a Unix
-//! domain socket, forwards newline-delimited JSON-RPC messages from the socket
-//! to the webview as `mcp-request` events, and writes `mcp-response` events
-//! back to the socket.
+//! MCP UDS bridge. A tokio server inside the GUI process that binds a Unix
+//! domain socket, accepts multiple concurrent connections, and forwards
+//! newline-delimited JSON-RPC messages between each connection's socket and
+//! the webview as `mcp-request` / `mcp-response` events.
 //!
 //! Rust has ZERO knowledge of MCP or JSON-RPC. It is a byte pipe between the
-//! `gnar-term --mcp-stdio` shim and the webview's MCP server.
+//! `gnar-term --mcp-stdio` shim and the webview's MCP server. The only
+//! metadata Rust adds is a per-connection `connection_id` so the webview can
+//! route requests, route responses, and isolate per-connection state.
 //!
 //! Security: the socket is chmod'd 600 so only the owning user can connect.
 //! Same-user threat boundary matches iTerm2/WezTerm local-IPC practice.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter, Listener};
@@ -18,6 +22,7 @@ use tokio::sync::mpsc;
 
 pub const REQUEST_EVENT: &str = "mcp-request";
 pub const RESPONSE_EVENT: &str = "mcp-response";
+pub const CONNECTION_CLOSED_EVENT: &str = "mcp-connection-closed";
 
 /// Resolve the UDS path for the current platform.
 ///
@@ -69,21 +74,50 @@ fn set_socket_perms(_path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Handle for the currently active connection's response writer side. When a
-/// connection is accepted, a new sender is installed here; responses emitted by
-/// the webview are routed to that sender and written to the connection's
-/// socket. When the connection drops, the sender is cleared.
-type ActiveWriter = Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>;
+/// Per-connection writer registry. The bridge supports multiple concurrent
+/// connections; each gets a unique `connection_id` and a writer channel that
+/// the response listener routes to.
+type ConnectionRegistry = Arc<Mutex<HashMap<u64, mpsc::UnboundedSender<String>>>>;
 
 #[derive(Clone)]
 pub struct BridgeState {
-    active_writer: ActiveWriter,
+    connections: ConnectionRegistry,
+    next_id: Arc<AtomicU64>,
 }
 
 impl BridgeState {
     pub fn new() -> Self {
         Self {
-            active_writer: Arc::new(Mutex::new(None)),
+            connections: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn next_connection_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn register(&self, id: u64, tx: mpsc::UnboundedSender<String>) {
+        if let Ok(mut guard) = self.connections.lock() {
+            guard.insert(id, tx);
+        }
+    }
+
+    fn unregister(&self, id: u64) {
+        if let Ok(mut guard) = self.connections.lock() {
+            guard.remove(&id);
+        }
+    }
+
+    fn send_to(&self, id: u64, payload: String) -> bool {
+        let tx = match self.connections.lock() {
+            Ok(g) => g.get(&id).cloned(),
+            Err(_) => None,
+        };
+        if let Some(tx) = tx {
+            tx.send(payload).is_ok()
+        } else {
+            false
         }
     }
 }
@@ -94,35 +128,49 @@ impl Default for BridgeState {
     }
 }
 
-/// Install the global `mcp-response` listener. Every response emitted by the
-/// webview is forwarded to the active connection's writer, if any. Safe to
-/// call once on startup.
+/// Install the global `mcp-response` listener. Each response carries a
+/// `connection_id` and is routed to that connection's writer.
+///
+/// Event payload shape (JSON object string emitted by the webview):
+/// ```json
+/// { "connection_id": 3, "payload": "<raw JSON-RPC line, no trailing newline>" }
+/// ```
 pub fn install_response_listener(app: AppHandle, state: BridgeState) {
-    let writer = state.active_writer.clone();
+    let state_clone = state.clone();
     app.listen(RESPONSE_EVENT, move |event| {
-        let payload = event.payload();
-        // Events arrive with the payload JSON-encoded by Tauri. Expected shape:
-        //   { "payload": "<raw json-rpc string>" }
-        // Extract the inner string without adding serde_derive churn for a
-        // tiny wrapper.
-        let inner: Option<String> = serde_json::from_str::<serde_json::Value>(payload)
+        let raw = event.payload();
+        // Tauri wraps event payloads as `{ "payload": <serialized> }`. Parse
+        // both the wrapper and the inner shape.
+        let inner_str: Option<String> = serde_json::from_str::<serde_json::Value>(raw)
             .ok()
             .and_then(|v| v.get("payload").and_then(|p| p.as_str()).map(String::from))
-            .or_else(|| serde_json::from_str::<String>(payload).ok());
-        let line = match inner {
+            .or_else(|| serde_json::from_str::<String>(raw).ok());
+        let payload = match inner_str {
             Some(s) => s,
             None => return,
         };
-        if let Ok(guard) = writer.lock() {
-            if let Some(tx) = guard.as_ref() {
-                let _ = tx.send(line);
-            }
-        }
+        // Inner is itself a JSON object: { connection_id: u64, payload: string }
+        let parsed: Option<(u64, String)> =
+            serde_json::from_str::<serde_json::Value>(&payload)
+                .ok()
+                .and_then(|v| {
+                    let id = v.get("connection_id")?.as_u64()?;
+                    let line = v.get("payload")?.as_str()?.to_string();
+                    Some((id, line))
+                });
+        let (connection_id, line) = match parsed {
+            Some(t) => t,
+            None => return,
+        };
+        // Route to the right connection. Drops silently if the connection
+        // closed between dispatch and response (legitimate race).
+        state_clone.send_to(connection_id, line);
     });
 }
 
 /// Bind the UDS and serve connections forever. Returns immediately after
-/// spawning the task. Only one connection is serviced at a time.
+/// spawning the task. Multiple connections are accepted concurrently — each
+/// runs in its own tokio task.
 #[cfg(unix)]
 pub fn spawn(app: AppHandle, state: BridgeState) -> Result<(), String> {
     use tokio::net::UnixListener;
@@ -167,7 +215,13 @@ pub fn spawn(app: AppHandle, state: BridgeState) -> Result<(), String> {
                     continue;
                 }
             };
-            handle_connection(stream, app_for_task.clone(), state.clone()).await;
+            // Spawn each connection as an independent task — concurrent, not
+            // serialized. Multi-agent scenarios depend on this.
+            let app_for_conn = app_for_task.clone();
+            let state_for_conn = state.clone();
+            tauri::async_runtime::spawn(async move {
+                handle_connection(stream, app_for_conn, state_for_conn).await;
+            });
         }
     });
 
@@ -183,8 +237,7 @@ pub fn spawn(app: AppHandle, state: BridgeState) -> Result<(), String> {
 #[cfg(not(unix))]
 pub fn spawn(_app: AppHandle, _state: BridgeState) -> Result<(), String> {
     // Windows uses AF_UNIX via the stdlib on Win10 1803+. tokio's UnixListener
-    // is unix-only, so we stub the MVP to the unix path and plan a Windows
-    // named-pipe fallback as a follow-up.
+    // is unix-only; named-pipe fallback is a follow-up.
     Err("MCP bridge UDS not yet supported on this platform".to_string())
 }
 
@@ -194,15 +247,10 @@ async fn handle_connection(
     app: AppHandle,
     state: BridgeState,
 ) {
+    let connection_id = state.next_connection_id();
     let (read_half, mut write_half) = stream.into_split();
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-
-    // Install this connection's writer as the active one. On drop it will be
-    // replaced; the guard below restores None on exit.
-    {
-        let mut guard = state.active_writer.lock().unwrap();
-        *guard = Some(tx.clone());
-    }
+    state.register(connection_id, tx.clone());
 
     // Task: pump responses from channel to socket.
     let writer_task = tauri::async_runtime::spawn(async move {
@@ -217,7 +265,8 @@ async fn handle_connection(
         }
     });
 
-    // Read loop: one line per JSON-RPC message; emit as Tauri event.
+    // Read loop: one line per JSON-RPC message; emit as Tauri event with
+    // connection_id metadata so the webview can route it.
     let mut reader = BufReader::new(read_half);
     let mut buf = String::new();
     loop {
@@ -225,30 +274,33 @@ async fn handle_connection(
         match reader.read_line(&mut buf).await {
             Ok(0) => break, // EOF
             Ok(_) => {
-                // Strip trailing newline, ignore empty heartbeat lines.
                 let trimmed = buf.trim_end_matches(['\r', '\n']).to_string();
                 if trimmed.is_empty() {
                     continue;
                 }
-                // Emit the raw line as the event payload. Webview receives
-                // `{ payload: "<raw json>" }`.
-                let _ = app.emit(REQUEST_EVENT, trimmed);
+                // Build the envelope: { connection_id, payload }
+                // Use serde_json to be robust against arbitrary payload contents.
+                let envelope = serde_json::json!({
+                    "connection_id": connection_id,
+                    "payload": trimmed,
+                });
+                let _ = app.emit(REQUEST_EVENT, envelope.to_string());
             }
             Err(_) => break,
         }
     }
 
-    // Connection closed. Clear active writer and terminate the writer task.
-    {
-        let mut guard = state.active_writer.lock().unwrap();
-        *guard = None;
-    }
+    // Connection closed. Notify webview, free per-connection state, drain.
+    state.unregister(connection_id);
+    let close_envelope = serde_json::json!({ "connection_id": connection_id });
+    let _ = app.emit(CONNECTION_CLOSED_EVENT, close_envelope.to_string());
     drop(tx);
     let _ = writer_task.await;
 }
 
-/// Run the `--mcp-stdio` byte pipe: open the UDS, copy stdin ↔ socket ↔ stdout.
-/// Blocks until one side closes. Returns a non-zero-worthy error on failure.
+/// Run the `--mcp-stdio` byte pipe: open the UDS, send the gnar-term hello
+/// notification carrying any pane/workspace context inherited from env vars,
+/// then copy stdin ↔ socket ↔ stdout. Blocks until one side closes.
 #[cfg(unix)]
 pub fn run_stdio_shim() -> i32 {
     use tokio::io::{stdin, stdout};
@@ -289,6 +341,15 @@ pub fn run_stdio_shim() -> i32 {
             }
         };
         let (mut sock_r, mut sock_w) = stream.into_split();
+
+        // Send the hello notification first so the GUI can bind this
+        // connection to the agent's host pane/workspace.
+        let hello = build_hello_message();
+        if sock_w.write_all(hello.as_bytes()).await.is_err() {
+            eprintln!("gnar-term: failed to send hello to GUI");
+            return 1;
+        }
+
         let mut stdin = stdin();
         let mut stdout = stdout();
 
@@ -311,67 +372,174 @@ pub fn run_stdio_shim() -> i32 {
     1
 }
 
+/// Build the `$/gnar-term/hello` notification line (with trailing newline).
+/// Reads `GNAR_TERM_PANE_ID` and `GNAR_TERM_WORKSPACE_ID` from env; both are
+/// optional. Always sends a hello (even when unbound) so the GUI can record
+/// the connection's binding state explicitly.
+pub fn build_hello_message() -> String {
+    let pane_id = std::env::var("GNAR_TERM_PANE_ID").ok();
+    let workspace_id = std::env::var("GNAR_TERM_WORKSPACE_ID").ok();
+    let client_pid = std::process::id();
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "$/gnar-term/hello",
+        "params": {
+            "pane_id": pane_id,
+            "workspace_id": workspace_id,
+            "client_pid": client_pid,
+        }
+    });
+    let mut s = payload.to_string();
+    s.push('\n');
+    s
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn uds_path_is_resolved() {
-        // On CI and dev machines, HOME/LOCALAPPDATA are set; the function should
-        // yield Some and the path should mention gnar-term.
         let p = uds_path().expect("uds_path should resolve");
         let s = p.to_string_lossy();
-        assert!(
-            s.contains("gnar-term"),
-            "uds path should contain gnar-term: {s}"
-        );
+        assert!(s.contains("gnar-term"), "uds path should contain gnar-term: {s}");
         assert!(s.ends_with("mcp.sock"), "uds path should end in mcp.sock: {s}");
+    }
+
+    #[test]
+    fn hello_message_includes_env_vars() {
+        // Use a separate process to control env without polluting other tests.
+        // We test the function directly by setting env, then unsetting.
+        std::env::set_var("GNAR_TERM_PANE_ID", "pane-abc");
+        std::env::set_var("GNAR_TERM_WORKSPACE_ID", "ws-xyz");
+        let line = build_hello_message();
+        assert!(line.ends_with('\n'), "hello must terminate with newline");
+        let parsed: serde_json::Value =
+            serde_json::from_str(line.trim_end()).expect("hello must be valid JSON");
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["method"], "$/gnar-term/hello");
+        assert_eq!(parsed["params"]["pane_id"], "pane-abc");
+        assert_eq!(parsed["params"]["workspace_id"], "ws-xyz");
+        assert!(parsed["params"]["client_pid"].is_number());
+        assert!(parsed.get("id").is_none(), "hello is a notification, no id");
+        std::env::remove_var("GNAR_TERM_PANE_ID");
+        std::env::remove_var("GNAR_TERM_WORKSPACE_ID");
+    }
+
+    #[test]
+    fn hello_message_when_unbound_uses_null() {
+        // Ensure clean env.
+        std::env::remove_var("GNAR_TERM_PANE_ID");
+        std::env::remove_var("GNAR_TERM_WORKSPACE_ID");
+        let line = build_hello_message();
+        let parsed: serde_json::Value =
+            serde_json::from_str(line.trim_end()).expect("valid JSON");
+        assert!(parsed["params"]["pane_id"].is_null());
+        assert!(parsed["params"]["workspace_id"].is_null());
+        assert!(parsed["params"]["client_pid"].is_number());
+    }
+
+    #[test]
+    fn connection_registry_isolates_writers() {
+        let state = BridgeState::new();
+        let (tx1, mut rx1) = mpsc::unbounded_channel::<String>();
+        let (tx2, mut rx2) = mpsc::unbounded_channel::<String>();
+        state.register(1, tx1);
+        state.register(2, tx2);
+
+        assert!(state.send_to(1, "to one".to_string()));
+        assert!(state.send_to(2, "to two".to_string()));
+        assert_eq!(rx1.try_recv().unwrap(), "to one");
+        assert_eq!(rx2.try_recv().unwrap(), "to two");
+        assert!(rx1.try_recv().is_err(), "conn 1 must not see conn 2's traffic");
+        assert!(rx2.try_recv().is_err(), "conn 2 must not see conn 1's traffic");
+
+        state.unregister(1);
+        assert!(!state.send_to(1, "after close".to_string()));
+        assert!(state.send_to(2, "still alive".to_string()));
+        assert_eq!(rx2.try_recv().unwrap(), "still alive");
+    }
+
+    #[test]
+    fn connection_ids_are_monotonic() {
+        let state = BridgeState::new();
+        let a = state.next_connection_id();
+        let b = state.next_connection_id();
+        let c = state.next_connection_id();
+        assert!(b > a && c > b, "ids must be monotonic: {a} {b} {c}");
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn uds_round_trip_bytes() {
+    async fn uds_two_concurrent_connections_each_round_trip() {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
         use tokio::net::{UnixListener, UnixStream};
 
         let dir = tempfile_dir();
-        let path = dir.join("test.sock");
+        let path = dir.join("multi.sock");
         let _ = std::fs::remove_file(&path);
         let listener = match UnixListener::bind(&path) {
             Ok(l) => l,
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                eprintln!("[test] skipping uds_round_trip_bytes: sandbox forbids bind ({e})");
+                eprintln!("[test] skipping multi-conn test: sandbox forbids bind ({e})");
                 return;
             }
             Err(e) => panic!("bind: {e}"),
         };
 
+        // Server: accept two connections concurrently. Each echoes the line
+        // it receives, prefixed with its accept order.
         let server = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            let (r, mut w) = stream.into_split();
-            let mut reader = BufReader::new(r);
-            let mut line = String::new();
-            reader.read_line(&mut line).await.unwrap();
-            assert!(line.contains("hello"));
-            w.write_all(b"{\"pong\":true}\n").await.unwrap();
+            for i in 0..2u32 {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let (r, mut w) = stream.into_split();
+                    let mut reader = BufReader::new(r);
+                    let mut line = String::new();
+                    reader.read_line(&mut line).await.unwrap();
+                    let resp = format!("conn{} echoed: {}", i, line.trim());
+                    w.write_all(resp.as_bytes()).await.unwrap();
+                    w.write_all(b"\n").await.unwrap();
+                    w.shutdown().await.unwrap();
+                });
+            }
         });
 
-        let client = UnixStream::connect(&path).await.expect("connect");
-        let (r, mut w) = client.into_split();
-        w.write_all(b"{\"hello\":1}\n").await.unwrap();
-        let mut reader = BufReader::new(r);
-        let mut line = String::new();
-        reader.read_line(&mut line).await.unwrap();
-        assert!(line.contains("pong"));
+        // Two clients in parallel.
+        let p1 = path.clone();
+        let p2 = path.clone();
+        let c1 = tokio::spawn(async move {
+            let s = UnixStream::connect(&p1).await.unwrap();
+            let (r, mut w) = s.into_split();
+            w.write_all(b"hi-from-1\n").await.unwrap();
+            w.shutdown().await.unwrap();
+            let mut line = String::new();
+            BufReader::new(r).read_line(&mut line).await.unwrap();
+            line
+        });
+        let c2 = tokio::spawn(async move {
+            let s = UnixStream::connect(&p2).await.unwrap();
+            let (r, mut w) = s.into_split();
+            w.write_all(b"hi-from-2\n").await.unwrap();
+            w.shutdown().await.unwrap();
+            let mut line = String::new();
+            BufReader::new(r).read_line(&mut line).await.unwrap();
+            line
+        });
 
+        let (r1, r2) = tokio::join!(c1, c2);
+        let r1 = r1.unwrap();
+        let r2 = r2.unwrap();
+        // Both clients must receive a response that mentions their own input —
+        // proving traffic was not cross-contaminated between connections.
+        assert!(r1.contains("hi-from-1"), "client 1 must see its own message: {r1}");
+        assert!(r2.contains("hi-from-2"), "client 2 must see its own message: {r2}");
         server.await.unwrap();
         let _ = std::fs::remove_file(&path);
     }
 
     #[cfg(unix)]
     fn tempfile_dir() -> std::path::PathBuf {
-        // Pick a writable tmp dir. TMPDIR honours the harness sandbox, and
-        // falls back to std::env::temp_dir otherwise.
         let base = std::env::var("TMPDIR")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|_| std::env::temp_dir());

--- a/src/__tests__/extension-sidebar.test.ts
+++ b/src/__tests__/extension-sidebar.test.ts
@@ -4,32 +4,58 @@ import {
   extensionSidebarSections,
   upsertSection,
   removeSection,
+  removeSectionsForWorkspace,
   primarySections,
   secondarySections,
   _resetExtensionSidebarForTest,
 } from "../lib/stores/extension-sidebar";
+import {
+  workspaces,
+  activeWorkspaceIdx,
+} from "../lib/stores/workspace";
+import type { Workspace, Pane } from "../lib/types";
 
-describe("extension-sidebar store", () => {
-  beforeEach(() => _resetExtensionSidebarForTest());
+function setActiveWorkspace(id: string): void {
+  const pane: Pane = { id: `${id}-pane`, surfaces: [], activeSurfaceId: null };
+  const ws: Workspace = {
+    id,
+    name: id,
+    splitRoot: { type: "pane", pane },
+    activePaneId: pane.id,
+  };
+  workspaces.set([ws]);
+  activeWorkspaceIdx.set(0);
+}
+
+describe("extension-sidebar store (per-workspace)", () => {
+  beforeEach(() => {
+    _resetExtensionSidebarForTest();
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+  });
 
   it("starts empty", () => {
+    setActiveWorkspace("ws-1");
     expect(get(extensionSidebarSections).size).toBe(0);
     expect(get(primarySections)).toEqual([]);
     expect(get(secondarySections)).toEqual([]);
   });
 
-  it("upserts primary and secondary sections separately", () => {
+  it("upserts primary and secondary sections separately within a workspace", () => {
+    setActiveWorkspace("ws-1");
     upsertSection({
       side: "primary",
       sectionId: "p1",
       title: "P1",
       items: [{ id: "a", label: "A" }],
+      workspaceId: "ws-1",
     });
     upsertSection({
       side: "secondary",
       sectionId: "s1",
       title: "S1",
       items: [{ id: "b", label: "B" }],
+      workspaceId: "ws-1",
     });
     expect(get(primarySections)).toHaveLength(1);
     expect(get(secondarySections)).toHaveLength(1);
@@ -37,13 +63,21 @@ describe("extension-sidebar store", () => {
     expect(get(secondarySections)[0].title).toBe("S1");
   });
 
-  it("replaces an existing section with the same id", () => {
-    upsertSection({ side: "secondary", sectionId: "s1", title: "first", items: [] });
+  it("replaces an existing section with the same id within the same workspace", () => {
+    setActiveWorkspace("ws-1");
+    upsertSection({
+      side: "secondary",
+      sectionId: "s1",
+      title: "first",
+      items: [],
+      workspaceId: "ws-1",
+    });
     upsertSection({
       side: "secondary",
       sectionId: "s1",
       title: "second",
       items: [{ id: "x", label: "X" }],
+      workspaceId: "ws-1",
     });
     const sections = get(secondarySections);
     expect(sections).toHaveLength(1);
@@ -52,17 +86,105 @@ describe("extension-sidebar store", () => {
   });
 
   it("removeSection is safe for non-existent IDs", () => {
-    removeSection("primary", "nope");
+    setActiveWorkspace("ws-1");
+    removeSection("ws-1", "primary", "nope");
     expect(get(primarySections)).toEqual([]);
   });
 
-  it("allows same section_id on different sides", () => {
-    upsertSection({ side: "primary", sectionId: "tools", title: "P", items: [] });
-    upsertSection({ side: "secondary", sectionId: "tools", title: "S", items: [] });
+  it("allows the same section_id on different sides", () => {
+    setActiveWorkspace("ws-1");
+    upsertSection({
+      side: "primary",
+      sectionId: "tools",
+      title: "P",
+      items: [],
+      workspaceId: "ws-1",
+    });
+    upsertSection({
+      side: "secondary",
+      sectionId: "tools",
+      title: "S",
+      items: [],
+      workspaceId: "ws-1",
+    });
     expect(get(primarySections)).toHaveLength(1);
     expect(get(secondarySections)).toHaveLength(1);
-    removeSection("primary", "tools");
+    removeSection("ws-1", "primary", "tools");
     expect(get(primarySections)).toHaveLength(0);
     expect(get(secondarySections)).toHaveLength(1);
+  });
+
+  it("scopes sections per workspace: a section in W2 is invisible from W1", () => {
+    // Two workspaces.
+    const p1: Pane = { id: "p-1", surfaces: [], activeSurfaceId: null };
+    const p2: Pane = { id: "p-2", surfaces: [], activeSurfaceId: null };
+    const w1: Workspace = {
+      id: "ws-1",
+      name: "W1",
+      splitRoot: { type: "pane", pane: p1 },
+      activePaneId: p1.id,
+    };
+    const w2: Workspace = {
+      id: "ws-2",
+      name: "W2",
+      splitRoot: { type: "pane", pane: p2 },
+      activePaneId: p2.id,
+    };
+    workspaces.set([w1, w2]);
+    activeWorkspaceIdx.set(0); // active = W1
+
+    upsertSection({
+      side: "secondary",
+      sectionId: "shared-id",
+      title: "in W1",
+      items: [],
+      workspaceId: "ws-1",
+    });
+    upsertSection({
+      side: "secondary",
+      sectionId: "shared-id",
+      title: "in W2",
+      items: [],
+      workspaceId: "ws-2",
+    });
+
+    // Looking at W1 — only the W1 section should be visible.
+    expect(get(secondarySections)).toHaveLength(1);
+    expect(get(secondarySections)[0].title).toBe("in W1");
+
+    // Switch to W2 — only the W2 section should be visible.
+    activeWorkspaceIdx.set(1);
+    expect(get(secondarySections)).toHaveLength(1);
+    expect(get(secondarySections)[0].title).toBe("in W2");
+  });
+
+  it("removeSectionsForWorkspace prunes everything tied to a destroyed workspace", () => {
+    setActiveWorkspace("ws-doomed");
+    upsertSection({
+      side: "primary",
+      sectionId: "a",
+      title: "A",
+      items: [],
+      workspaceId: "ws-doomed",
+    });
+    upsertSection({
+      side: "secondary",
+      sectionId: "b",
+      title: "B",
+      items: [],
+      workspaceId: "ws-doomed",
+    });
+    upsertSection({
+      side: "primary",
+      sectionId: "c",
+      title: "C",
+      items: [],
+      workspaceId: "ws-survivor",
+    });
+    expect(get(extensionSidebarSections).size).toBe(3);
+    removeSectionsForWorkspace("ws-doomed");
+    const remaining = Array.from(get(extensionSidebarSections).values());
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].workspaceId).toBe("ws-survivor");
   });
 });

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -152,13 +152,17 @@ describe("MCP server JSON-RPC", () => {
     });
   });
 
-  it("get_agent_context returns null when the agent is unbound", async () => {
+  it("get_agent_context returns null fields when the agent is unbound", async () => {
     const ctx = _testContext(null);
     const resp = await dispatch(
       rpc("tools/call", { name: "get_agent_context", arguments: {} }),
       ctx,
     );
-    expect((resp as any).result.structuredContent).toBeNull();
+    expect((resp as any).result.structuredContent).toEqual({
+      pane_id: null,
+      workspace_id: null,
+      client_pid: null,
+    });
   });
 
   it("render_sidebar with an explicit workspace_id stores in that workspace", async () => {
@@ -328,10 +332,63 @@ describe("MCP server JSON-RPC", () => {
     expect((r2 as any).result.structuredContent).toEqual({ exists: false });
   });
 
-  it("list_workspaces returns an array (possibly empty)", async () => {
+  it("list_workspaces wraps the list in a record (structuredContent must be an object)", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
     const r = await dispatch(rpc("tools/call", { name: "list_workspaces", arguments: {} }));
     const result = (r as any).result.structuredContent;
-    expect(Array.isArray(result)).toBe(true);
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result)).toBe(false);
+    expect(Array.isArray(result.workspaces)).toBe(true);
+    expect(result.workspaces[0].id).toBe("ws-A");
+  });
+
+  it("list_panes wraps the list in a record", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
+    const r = await dispatch(rpc("tools/call", { name: "list_panes", arguments: {} }));
+    const result = (r as any).result.structuredContent;
+    expect(Array.isArray(result)).toBe(false);
+    expect(Array.isArray(result.panes)).toBe(true);
+    expect(result.panes[0].id).toBe("ws-A-pane");
+  });
+
+  it("list_panes with an unknown workspace_id returns an empty record", async () => {
+    const r = await dispatch(
+      rpc("tools/call", {
+        name: "list_panes",
+        arguments: { workspace_id: "nope" },
+      }),
+    );
+    const result = (r as any).result.structuredContent;
+    expect(result).toEqual({ panes: [] });
+  });
+
+  it("list_sessions wraps the list in a record", async () => {
+    const r = await dispatch(rpc("tools/call", { name: "list_sessions", arguments: {} }));
+    const result = (r as any).result.structuredContent;
+    expect(Array.isArray(result)).toBe(false);
+    expect(Array.isArray(result.sessions)).toBe(true);
+  });
+
+  it("get_active_workspace returns nullable fields when no workspace is open", async () => {
+    const r = await dispatch(
+      rpc("tools/call", { name: "get_active_workspace", arguments: {} }),
+    );
+    expect((r as any).result.structuredContent).toEqual({
+      id: null,
+      name: null,
+      activePaneId: null,
+    });
+  });
+
+  it("get_active_pane returns { pane: null } when no pane is focused", async () => {
+    const r = await dispatch(
+      rpc("tools/call", { name: "get_active_pane", arguments: {} }),
+    );
+    expect((r as any).result.structuredContent).toEqual({ pane: null });
   });
 
   it("returns a JSON-RPC error when a tool handler throws", async () => {

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -464,6 +464,49 @@ describe("resolveTarget — connection-binding resolution rules (the v1 bug fenc
     expect(resolved.workspace.id).toBe("ws-1");
     expect(resolved.source).toBe("binding-workspace");
   });
+
+  it("PERF FENCE: rapid spawns chain off the last-spawned pane, not the binding pane", () => {
+    // Without this, dispatch_tasks with N tasks deeply nests N splits around
+    // the same binding pane. findParentSplit + DOM render become O(depth)
+    // per spawn → O(N²) total → UI freeze. The original freeze we hit on
+    // 2026-04-16. Regression test: resolveTarget must prefer lastSpawnedPaneId.
+    const { ws, pane: hostPane } = makeWorkspace("ws-host");
+    workspaces.set([ws]);
+    activeWorkspaceIdx.set(0);
+    const ctx = _testContext({ paneId: hostPane.id, workspaceId: "ws-host" });
+
+    // First resolution: no lastSpawnedPaneId yet → use binding pane.
+    const first = _resolveTargetForTest({}, ctx);
+    expect(first.hostPane?.id).toBe(hostPane.id);
+
+    // Simulate a successful spawn: push a new pane into the tree and record it.
+    const newPane: Pane = { id: "new-1", surfaces: [], activeSurfaceId: null };
+    ws.splitRoot = {
+      type: "split",
+      direction: "vertical",
+      ratio: 0.5,
+      children: [
+        { type: "pane", pane: hostPane },
+        { type: "pane", pane: newPane },
+      ],
+    };
+    workspaces.set([ws]);
+    ctx.lastSpawnedPaneId = newPane.id;
+
+    // Next resolution: must use the new pane, NOT the binding pane.
+    const second = _resolveTargetForTest({}, ctx);
+    expect(second.hostPane?.id).toBe(newPane.id);
+  });
+
+  it("lastSpawnedPaneId is ignored when the pane was closed (falls through to binding)", () => {
+    const { ws, pane: hostPane } = makeWorkspace("ws-host");
+    workspaces.set([ws]);
+    activeWorkspaceIdx.set(0);
+    const ctx = _testContext({ paneId: hostPane.id, workspaceId: "ws-host" });
+    ctx.lastSpawnedPaneId = "never-existed";
+    const resolved = _resolveTargetForTest({}, ctx);
+    expect(resolved.hostPane?.id).toBe(hostPane.id);
+  });
 });
 
 describe("tool metadata", () => {

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -1,7 +1,8 @@
 /**
- * MCP server unit tests. Exercises the JSON-RPC dispatcher and the handlers
- * that don't require a live PTY (tools/list, sidebar, poll_events, fs tools,
- * workspace introspection).
+ * MCP server unit tests. Adversarial coverage of the connection-binding
+ * contract: every test that exercises a UI-mutating tool sets ambient state
+ * (active workspace, user focus) DIFFERENTLY from the test's expectation, so
+ * that any future code that quietly reads ambient state for routing fails.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { get } from "svelte/store";
@@ -16,15 +17,38 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { dispatch, _getToolsForTest } from "../lib/services/mcp-server";
+import {
+  dispatch,
+  _getToolsForTest,
+  _testContext,
+  _resolveTargetForTest,
+  _resetMcpServerForTest,
+} from "../lib/services/mcp-server";
 import {
   extensionSidebarSections,
   _resetExtensionSidebarForTest,
 } from "../lib/stores/extension-sidebar";
 import { _resetEventBufferForTest } from "../lib/services/mcp-event-buffer";
+import {
+  workspaces,
+  activeWorkspaceIdx,
+} from "../lib/stores/workspace";
+import type { Workspace, Pane } from "../lib/types";
 
 function rpc(method: string, params?: unknown, id: number = 1) {
   return { jsonrpc: "2.0" as const, id, method, params };
+}
+
+/** Build a deterministic workspace fixture with a given id and a single pane. */
+function makeWorkspace(id: string, name = id): { ws: Workspace; pane: Pane } {
+  const pane: Pane = { id: `${id}-pane`, surfaces: [], activeSurfaceId: null };
+  const ws: Workspace = {
+    id,
+    name,
+    splitRoot: { type: "pane", pane },
+    activePaneId: pane.id,
+  };
+  return { ws, pane };
 }
 
 describe("MCP server JSON-RPC", () => {
@@ -32,6 +56,9 @@ describe("MCP server JSON-RPC", () => {
     invokeMock.mockReset();
     _resetExtensionSidebarForTest();
     _resetEventBufferForTest();
+    _resetMcpServerForTest();
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
   });
 
   it("responds to initialize with server info and protocol version", async () => {
@@ -42,7 +69,7 @@ describe("MCP server JSON-RPC", () => {
     expect((resp as any).result.capabilities.tools).toBeDefined();
   });
 
-  it("lists all 19 tools with correct names", async () => {
+  it("lists all 20 tools with correct names (includes get_agent_context)", async () => {
     const resp = await dispatch(rpc("tools/list"));
     const tools = (resp as any).result.tools as Array<{ name: string }>;
     const names = tools.map((t) => t.name).sort();
@@ -53,6 +80,7 @@ describe("MCP server JSON-RPC", () => {
         "file_exists",
         "get_active_pane",
         "get_active_workspace",
+        "get_agent_context",
         "get_session_info",
         "kill_session",
         "list_dir",
@@ -69,8 +97,7 @@ describe("MCP server JSON-RPC", () => {
         "spawn_agent",
       ].sort(),
     );
-    expect(names).toHaveLength(19);
-    // Every tool must ship a JSON Schema shaped object.
+    expect(names).toHaveLength(20);
     for (const t of tools) {
       expect(t).toHaveProperty("inputSchema");
     }
@@ -89,49 +116,166 @@ describe("MCP server JSON-RPC", () => {
     expect(resp).toBeNull();
   });
 
-  it("render_sidebar upserts a section into the store", async () => {
+  it("$/gnar-term/hello stores the binding on the connection context", async () => {
+    const ctx = _testContext(null);
+    const resp = await dispatch(
+      {
+        jsonrpc: "2.0",
+        method: "$/gnar-term/hello",
+        params: { pane_id: "p-1", workspace_id: "ws-1", client_pid: 42 },
+      } as any,
+      ctx,
+    );
+    expect(resp).toBeNull();
+    expect(ctx.binding).toEqual({
+      paneId: "p-1",
+      workspaceId: "ws-1",
+      clientPid: 42,
+    });
+  });
+
+  it("get_agent_context returns the connection's binding", async () => {
+    const ctx = _testContext({
+      paneId: "p-x",
+      workspaceId: "ws-x",
+      clientPid: 1234,
+    });
+    const resp = await dispatch(
+      rpc("tools/call", { name: "get_agent_context", arguments: {} }),
+      ctx,
+    );
+    const r = (resp as any).result.structuredContent;
+    expect(r).toEqual({
+      pane_id: "p-x",
+      workspace_id: "ws-x",
+      client_pid: 1234,
+    });
+  });
+
+  it("get_agent_context returns null when the agent is unbound", async () => {
+    const ctx = _testContext(null);
+    const resp = await dispatch(
+      rpc("tools/call", { name: "get_agent_context", arguments: {} }),
+      ctx,
+    );
+    expect((resp as any).result.structuredContent).toBeNull();
+  });
+
+  it("render_sidebar with an explicit workspace_id stores in that workspace", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+    activeWorkspaceIdx.set(0); // user is looking at A
+
+    // Adversarial: bind connection to A, then explicitly target B. Override
+    // must win — the section must end up in B, not A.
+    const ctx = _testContext({ workspaceId: "ws-A" });
     const resp = await dispatch(
       rpc("tools/call", {
         name: "render_sidebar",
         arguments: {
           side: "secondary",
-          section_id: "cwd-file-navigator",
-          title: "Files",
-          items: [
-            { id: "README.md", label: "README.md" },
-            {
-              id: "src",
-              label: "src",
-              children: [{ id: "src/App.svelte", label: "App.svelte" }],
-            },
-          ],
+          section_id: "s1",
+          title: "S1",
+          items: [{ id: "a", label: "A" }],
+          workspace_id: "ws-B",
         },
       }),
+      ctx,
     );
-    expect((resp as any).result.structuredContent).toEqual({ ok: true });
+    expect((resp as any).result.structuredContent).toEqual({
+      ok: true,
+      workspace_id: "ws-B",
+    });
     const map = get(extensionSidebarSections);
     expect(map.size).toBe(1);
-    const section = map.get("secondary:cwd-file-navigator");
-    expect(section?.title).toBe("Files");
-    expect(section?.items).toHaveLength(2);
+    const section = map.get("ws-B:secondary:s1");
+    expect(section?.workspaceId).toBe("ws-B");
+    expect(section?.title).toBe("S1");
   });
 
-  it("remove_sidebar_section is a no-op for unknown ids", async () => {
+  it("render_sidebar uses the connection binding when no workspace_id is passed", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+    activeWorkspaceIdx.set(0); // user looks at A
+
+    // Adversarial: bind connection to B but make A the active workspace. The
+    // render must follow the binding (B), not user focus (A).
+    const ctx = _testContext({ workspaceId: "ws-B" });
+    await dispatch(
+      rpc("tools/call", {
+        name: "render_sidebar",
+        arguments: {
+          side: "primary",
+          section_id: "s1",
+          title: "S1",
+          items: [],
+        },
+      }),
+      ctx,
+    );
+    const map = get(extensionSidebarSections);
+    expect(map.has("ws-B:primary:s1")).toBe(true);
+    expect(map.has("ws-A:primary:s1")).toBe(false);
+  });
+
+  it("render_sidebar errors clearly when unbound and no workspace_id passed", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0); // there IS an active workspace, but agent is unbound
+
+    const ctx = _testContext(null);
     const resp = await dispatch(
       rpc("tools/call", {
-        name: "remove_sidebar_section",
-        arguments: { side: "primary", section_id: "nope" },
+        name: "render_sidebar",
+        arguments: { side: "secondary", section_id: "x", title: "X", items: [] },
       }),
+      ctx,
     );
-    expect((resp as any).result.structuredContent).toEqual({ ok: true });
+    // Resolution rule 5: must error, NOT silently target the active workspace.
+    expect((resp as any).error?.code).toBe(-32000);
+    expect((resp as any).error?.message).toMatch(/no pane\/workspace context/);
+    expect(get(extensionSidebarSections).size).toBe(0);
   });
 
-  it("poll_events returns the cursor and truncated flag", async () => {
+  it("remove_sidebar_section uses the binding workspace", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
+
+    const ctx = _testContext({ workspaceId: "ws-A" });
     await dispatch(
       rpc("tools/call", {
         name: "render_sidebar",
         arguments: { side: "primary", section_id: "x", title: "X", items: [] },
       }),
+      ctx,
+    );
+    expect(get(extensionSidebarSections).size).toBe(1);
+
+    const resp = await dispatch(
+      rpc("tools/call", {
+        name: "remove_sidebar_section",
+        arguments: { side: "primary", section_id: "x" },
+      }),
+      ctx,
+    );
+    expect((resp as any).result.structuredContent.ok).toBe(true);
+    expect(get(extensionSidebarSections).size).toBe(0);
+  });
+
+  it("poll_events returns the cursor and events array", async () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
+    const ctx = _testContext({ workspaceId: "ws-A" });
+    await dispatch(
+      rpc("tools/call", {
+        name: "render_sidebar",
+        arguments: { side: "primary", section_id: "x", title: "X", items: [] },
+      }),
+      ctx,
     );
     const resp = await dispatch(rpc("tools/call", { name: "poll_events", arguments: {} }));
     const result = (resp as any).result.structuredContent;
@@ -207,6 +351,121 @@ describe("MCP server JSON-RPC", () => {
   });
 });
 
+describe("resolveTarget — connection-binding resolution rules (the v1 bug fence)", () => {
+  beforeEach(() => {
+    _resetMcpServerForTest();
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+  });
+
+  it("rule 1: explicit pane_id wins, returns its current workspace", () => {
+    const { ws: wsA, pane: paneA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+    activeWorkspaceIdx.set(1); // user looks at B (adversarial)
+
+    // Bind the agent to A, but pass an explicit pane in B.
+    const { pane: paneB } = makeWorkspace("ws-B"); // separate fixture
+    // Replace wsB to contain a pane we can target.
+    wsB.splitRoot = { type: "pane", pane: paneB };
+    wsB.activePaneId = paneB.id;
+    workspaces.set([wsA, wsB]);
+
+    const ctx = _testContext({ paneId: paneA.id, workspaceId: "ws-A" });
+    const resolved = _resolveTargetForTest({ pane_id: paneB.id }, ctx);
+    expect(resolved.workspace.id).toBe("ws-B");
+    expect(resolved.hostPane?.id).toBe(paneB.id);
+    expect(resolved.source).toBe("args-pane");
+  });
+
+  it("rule 1: explicit pane_id pointing at a closed pane errors (no fallback)", () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
+    const ctx = _testContext({ workspaceId: "ws-A" });
+    expect(() => _resolveTargetForTest({ pane_id: "ghost" }, ctx)).toThrow(/not found/);
+  });
+
+  it("rule 2: explicit workspace_id wins over binding", () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+    activeWorkspaceIdx.set(0); // user looks at A
+    const ctx = _testContext({ workspaceId: "ws-A" });
+    const resolved = _resolveTargetForTest({ workspace_id: "ws-B" }, ctx);
+    expect(resolved.workspace.id).toBe("ws-B");
+    expect(resolved.source).toBe("args-workspace");
+  });
+
+  it("rule 2: explicit but unknown workspace_id errors", () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    const ctx = _testContext({ workspaceId: "ws-A" });
+    expect(() => _resolveTargetForTest({ workspace_id: "ws-ghost" }, ctx)).toThrow(/not found/);
+  });
+
+  it("rule 3: binding pane wins when no args, ignores user focus on a different workspace", () => {
+    const { ws: wsA, pane: paneA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+    activeWorkspaceIdx.set(1); // ADVERSARIAL: user looks at B
+    const ctx = _testContext({ paneId: paneA.id, workspaceId: "ws-A" });
+    const resolved = _resolveTargetForTest({}, ctx);
+    expect(resolved.workspace.id).toBe("ws-A"); // binding wins
+    expect(resolved.hostPane?.id).toBe(paneA.id);
+    expect(resolved.source).toBe("binding-pane");
+  });
+
+  it("rule 3 with cross-workspace move: pane_id is stable, workspace re-derived", () => {
+    const { ws: wsA, pane: paneA } = makeWorkspace("ws-A");
+    const { ws: wsB } = makeWorkspace("ws-B");
+    workspaces.set([wsA, wsB]);
+
+    // Move paneA into wsB by mutating splitRoot.
+    wsA.splitRoot = { type: "pane", pane: { id: "wsA-empty", surfaces: [], activeSurfaceId: null } };
+    wsB.splitRoot = { type: "pane", pane: paneA };
+    workspaces.update((l) => [...l]);
+
+    // Connection still bound to paneA (originally in ws-A). After the move the
+    // resolver must report the pane's CURRENT workspace.
+    const ctx = _testContext({ paneId: paneA.id, workspaceId: "ws-A" });
+    const resolved = _resolveTargetForTest({}, ctx);
+    expect(resolved.workspace.id).toBe("ws-B");
+    expect(resolved.hostPane?.id).toBe(paneA.id);
+  });
+
+  it("rule 4: when bound pane is closed, falls through to bound workspace", () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0);
+    const ctx = _testContext({ paneId: "closed-pane", workspaceId: "ws-A" });
+    const resolved = _resolveTargetForTest({}, ctx);
+    expect(resolved.workspace.id).toBe("ws-A");
+    expect(resolved.hostPane).toBeNull();
+    expect(resolved.source).toBe("binding-workspace");
+  });
+
+  it("rule 5: unbound + no args = error (NEVER fall back to active workspace)", () => {
+    const { ws: wsA } = makeWorkspace("ws-A");
+    workspaces.set([wsA]);
+    activeWorkspaceIdx.set(0); // there IS an active workspace
+    const ctx = _testContext(null);
+    expect(() => _resolveTargetForTest({}, ctx)).toThrow(/no pane\/workspace context/);
+  });
+
+  it("THE V1 BUG FENCE: bound to W1, GUI focused on W2 → still resolves to W1", () => {
+    // This is the exact bug shipped on 2026-04-16. Permanent regression test.
+    const { ws: w1 } = makeWorkspace("ws-1");
+    const { ws: w2 } = makeWorkspace("ws-2");
+    workspaces.set([w1, w2]);
+    activeWorkspaceIdx.set(1); // focus is W2
+    const ctx = _testContext({ workspaceId: "ws-1" });
+    const resolved = _resolveTargetForTest({}, ctx);
+    expect(resolved.workspace.id).toBe("ws-1");
+    expect(resolved.source).toBe("binding-workspace");
+  });
+});
+
 describe("tool metadata", () => {
   it("every tool has a non-empty description", () => {
     const tools = _getToolsForTest();
@@ -215,7 +474,7 @@ describe("tool metadata", () => {
     }
   });
 
-  it("tool count matches spec (19)", () => {
-    expect(_getToolsForTest()).toHaveLength(19);
+  it("tool count matches spec (20)", () => {
+    expect(_getToolsForTest()).toHaveLength(20);
   });
 });

--- a/src/lib/components/TerminalSurface.svelte
+++ b/src/lib/components/TerminalSurface.svelte
@@ -58,10 +58,23 @@
         surface.startupCommand = undefined;
       }
 
+      // WebGL contexts are capped by the webview (WKWebView ~16). Under a
+      // burst of spawned panes, exceeding the cap evicts existing contexts
+      // and fires onContextLoss; an unbounded retry cascade wedges the
+      // compositor and freezes the app. Cap retries and fall back to the
+      // DOM renderer, which is slower but stable.
+      let webglAttempts = 0;
+      const MAX_WEBGL_ATTEMPTS = 3;
       const initWebGL = () => {
+        if (webglAttempts >= MAX_WEBGL_ATTEMPTS) return;
+        webglAttempts++;
         try {
           const addon = new WebglAddon();
-          addon.onContextLoss(() => setTimeout(initWebGL, 100));
+          addon.onContextLoss(() => {
+            if (webglAttempts < MAX_WEBGL_ATTEMPTS) {
+              setTimeout(initWebGL, 100);
+            }
+          });
           surface.terminal.loadAddon(addon);
         } catch (e) {
           console.warn("WebGL renderer failed, using DOM renderer", e);

--- a/src/lib/services/mcp-server.ts
+++ b/src/lib/services/mcp-server.ts
@@ -2,15 +2,22 @@
  * Gnar Term MCP server — runs in the Svelte webview and speaks JSON-RPC 2.0
  * over Tauri events to the Rust UDS bridge.
  *
- * Design note (2026-04-15): We hand-roll JSON-RPC 2.0 rather than pulling in
- * @modelcontextprotocol/sdk. The SDK isn't in package.json, the bundler
- * target is a Chromium/WebKit webview (not node), and the required surface
- * area is tiny: initialize, tools/list, tools/call, and MCP notifications.
- * Hand-rolling keeps the module ~500 LOC and sidesteps Node/ESM polyfills.
+ * Architecture (see Spacebase MCP spec § Connection binding):
  *
- * Rust emits `mcp-request` with `{ payload: <raw json-rpc string> }`. The
- * server dispatches and emits `mcp-response` with the same shape. Clients are
- * responsible for their own request ordering.
+ * - The Rust bridge accepts multiple concurrent connections, assigns each a
+ *   `connection_id`, and forwards `mcp-request` events as
+ *   `{ connection_id, payload }`. Responses are emitted back the same way.
+ * - The shim sends a `$/gnar-term/hello` notification on connect carrying
+ *   the `pane_id` and `workspace_id` env vars it inherited. The webview
+ *   stores the binding in a per-connection context map.
+ * - UI-mutating tools resolve their target workspace/pane via `resolveTarget`
+ *   which follows the spec's resolution rules deterministically (explicit args
+ *   first, then connection binding, then **error** — never silently fall back
+ *   to "active workspace"). The previous bug-class — panes following user GUI
+ *   focus — is impossible because no write tool consults `activeWorkspace`.
+ *
+ * We hand-roll JSON-RPC 2.0 rather than pulling in `@modelcontextprotocol/sdk`
+ * for two reasons: the SDK targets Node, and the surface area is tiny.
  */
 import { get } from "svelte/store";
 import { invoke } from "@tauri-apps/api/core";
@@ -29,10 +36,10 @@ import {
   type SplitNode,
   type Surface,
   type TerminalSurface,
+  type Workspace,
 } from "../types";
 import { findParentSplit } from "../types";
 import { createTerminalSurface } from "../terminal-service";
-import { createWorkspace } from "./workspace-service";
 import { safeFocus } from "./service-helpers";
 import {
   registerMcpPty,
@@ -87,6 +94,27 @@ interface JsonRpcError {
 
 type JsonRpcResponse = JsonRpcSuccess | JsonRpcError;
 
+/** Per-connection state recorded from the `$/gnar-term/hello` handshake. */
+export interface ConnectionBinding {
+  paneId: string | null;
+  workspaceId: string | null;
+  clientPid: number | null;
+}
+
+export interface ConnectionContext {
+  connectionId: number;
+  binding: ConnectionBinding | null;
+}
+
+/** Sentinel for callers that have no transport context (test code calling
+ *  dispatch directly, etc). Tools that require binding will error with the
+ *  standard "agent has no pane/workspace context" message — exactly the same
+ *  error path real unbound agents hit. */
+const ANONYMOUS_CONTEXT: ConnectionContext = {
+  connectionId: 0,
+  binding: null,
+};
+
 // ---- Agent command map ----
 
 const AGENT_COMMANDS: Record<AgentType, string | null> = {
@@ -120,51 +148,146 @@ const KEY_MAP: Record<string, string> = {
 const sessions = new Map<string, McpSession>();
 const ptyToSession = new Map<number, string>();
 
+/** Per-connection binding state. Keyed by connection_id from the bridge. */
+const connectionContexts = new Map<number, ConnectionContext>();
+
 function newSessionId(): string {
   return `mcp-${crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
 }
 
-// ---- Pane helpers (same semantics as the old bridge client) ----
+// ---- Workspace / pane resolution ----
 
-function getOrCreateActivePane(): Pane {
-  let ws = get(activeWorkspace);
-  if (!ws) {
-    createWorkspace("MCP");
-    ws = get(activeWorkspace)!;
+/** Find the workspace that currently contains a pane with the given id, or
+ *  null if no workspace contains it (pane was closed, or invalid id). */
+function findWorkspaceForPane(paneId: string): Workspace | null {
+  for (const ws of get(workspaces)) {
+    for (const pane of getAllPanes(ws.splitRoot)) {
+      if (pane.id === paneId) return ws;
+    }
   }
-  const existingActive = get(activePane);
-  if (existingActive) return existingActive;
-  const panes = getAllPanes(ws.splitRoot);
-  if (panes.length > 0) return panes[0];
+  return null;
+}
+
+function findPaneById(paneId: string): { workspace: Workspace; pane: Pane } | null {
+  for (const ws of get(workspaces)) {
+    for (const pane of getAllPanes(ws.splitRoot)) {
+      if (pane.id === paneId) return { workspace: ws, pane };
+    }
+  }
+  return null;
+}
+
+function findWorkspaceById(workspaceId: string): Workspace | null {
+  return get(workspaces).find((w) => w.id === workspaceId) ?? null;
+}
+
+/** Resolution result returned by `resolveTarget`. `hostPane` is non-null when
+ *  the caller expressed a specific host pane to split; null means "place in
+ *  the workspace's active pane (or first pane)." */
+interface ResolvedTarget {
+  workspace: Workspace;
+  hostPane: Pane | null;
+  source:
+    | "args-pane"
+    | "args-workspace"
+    | "binding-pane"
+    | "binding-workspace";
+}
+
+interface TargetArgs {
+  workspace_id?: string;
+  pane_id?: string;
+}
+
+/** Resolve which workspace (and optional host pane) a UI-mutating tool should
+ *  target. Implements the resolution rules in the MCP spec § Connection binding.
+ *  Throws with an actionable error message if no target can be resolved.
+ *  Critically: this function NEVER reads `activeWorkspace`. User GUI focus is
+ *  not an authoritative routing input. */
+function resolveTarget(args: TargetArgs, ctx: ConnectionContext): ResolvedTarget {
+  // Rule 1: explicit pane_id wins.
+  if (args.pane_id) {
+    const found = findPaneById(args.pane_id);
+    if (!found) {
+      throw new Error(
+        `pane_id "${args.pane_id}" not found (it may have been closed)`,
+      );
+    }
+    return { workspace: found.workspace, hostPane: found.pane, source: "args-pane" };
+  }
+  // Rule 2: explicit workspace_id.
+  if (args.workspace_id) {
+    const ws = findWorkspaceById(args.workspace_id);
+    if (!ws) {
+      throw new Error(`workspace_id "${args.workspace_id}" not found`);
+    }
+    return { workspace: ws, hostPane: null, source: "args-workspace" };
+  }
+  // Rule 3: connection-bound pane (re-derive workspace in case pane was moved).
+  const binding = ctx.binding;
+  if (binding?.paneId) {
+    const found = findPaneById(binding.paneId);
+    if (found) {
+      return {
+        workspace: found.workspace,
+        hostPane: found.pane,
+        source: "binding-pane",
+      };
+    }
+    // Bound pane was closed. Fall through to rule 4 (workspace-only binding).
+  }
+  // Rule 4: connection-bound workspace.
+  if (binding?.workspaceId) {
+    const ws = findWorkspaceById(binding.workspaceId);
+    if (ws) {
+      return { workspace: ws, hostPane: null, source: "binding-workspace" };
+    }
+  }
+  // Rule 5: no target. Error loudly — never fall back to active workspace.
+  throw new Error(
+    "agent has no pane/workspace context — pass workspace_id explicitly, or run the agent inside a gnar-term pane",
+  );
+}
+
+/** Pick a host pane to split off when the caller didn't supply one. Prefers
+ *  the workspace's active pane; falls back to the first pane in the tree. */
+function pickHostPane(workspace: Workspace): Pane {
+  const all = getAllPanes(workspace.splitRoot);
+  if (workspace.activePaneId) {
+    const active = all.find((p) => p.id === workspace.activePaneId);
+    if (active) return active;
+  }
+  if (all.length > 0) return all[0];
+  // Workspace exists but has no panes (shouldn't happen in practice; create one).
   const newPane: Pane = { id: uid(), surfaces: [], activeSurfaceId: null };
-  ws.splitRoot = { type: "pane", pane: newPane };
+  workspace.splitRoot = { type: "pane", pane: newPane };
   workspaces.update((l) => [...l]);
   return newPane;
 }
 
-function splitActivePane(direction: "horizontal" | "vertical"): Pane {
-  const wsVal = get(activeWorkspace);
-  if (!wsVal) createWorkspace("MCP");
-  const workspace = get(activeWorkspace)!;
-  const currentActive = get(activePane) ?? getAllPanes(workspace.splitRoot)[0];
-  if (!currentActive) return getOrCreateActivePane();
+/** Split `hostPane` off into a new sibling pane within its workspace. */
+function splitPaneInWorkspace(
+  workspace: Workspace,
+  hostPane: Pane,
+  direction: "horizontal" | "vertical",
+): Pane {
   const newPane: Pane = { id: uid(), surfaces: [], activeSurfaceId: null };
   const newSplit: SplitNode = {
     type: "split",
     direction,
     children: [
-      { type: "pane", pane: currentActive },
+      { type: "pane", pane: hostPane },
       { type: "pane", pane: newPane },
     ],
     ratio: 0.5,
   };
   if (
     workspace.splitRoot.type === "pane" &&
-    workspace.splitRoot.pane.id === currentActive.id
+    workspace.splitRoot.pane.id === hostPane.id
   ) {
     workspace.splitRoot = newSplit;
   } else {
-    const parentInfo = findParentSplit(workspace.splitRoot, currentActive.id);
+    const parentInfo = findParentSplit(workspace.splitRoot, hostPane.id);
     if (parentInfo && parentInfo.parent.type === "split") {
       parentInfo.parent.children[parentInfo.index] = newSplit;
     }
@@ -243,11 +366,7 @@ function reapDeadSessions(): void {
 // ---- Workspace introspection helpers ----
 
 function describeSurface(s: Surface) {
-  return {
-    id: s.id,
-    kind: s.kind,
-    title: s.title,
-  };
+  return { id: s.id, kind: s.kind, title: s.title };
 }
 
 function describePane(pane: Pane, workspaceId: string) {
@@ -265,13 +384,58 @@ function describePane(pane: Pane, workspaceId: string) {
   };
 }
 
+// ---- Observability: dispatch log ----
+
+interface DispatchLogEntry {
+  ts: string;
+  connectionId: number;
+  tool: string;
+  binding: ConnectionBinding | null;
+  args: unknown;
+  resolved?: { workspaceId: string; paneId: string | null; source: string };
+  result?: { kind: "ok"; summary: string } | { kind: "error"; message: string };
+}
+
+const DISPATCH_LOG_MAX = 500;
+const dispatchLog: DispatchLogEntry[] = [];
+
+function logDispatch(entry: DispatchLogEntry): void {
+  dispatchLog.push(entry);
+  if (dispatchLog.length > DISPATCH_LOG_MAX) {
+    dispatchLog.shift();
+  }
+  // Echo to console in a structured single line so devtools can grep.
+  const resolved = entry.resolved
+    ? `resolved={ws=${entry.resolved.workspaceId},pane=${entry.resolved.paneId ?? "-"},src=${entry.resolved.source}}`
+    : "resolved=<unresolved>";
+  const bind = entry.binding
+    ? `binding={ws=${entry.binding.workspaceId ?? "null"},pane=${entry.binding.paneId ?? "null"}}`
+    : "binding=<none>";
+  const result = entry.result
+    ? entry.result.kind === "ok"
+      ? `result=ok(${entry.result.summary})`
+      : `result=ERR(${entry.result.message})`
+    : "result=<pending>";
+  // eslint-disable-next-line no-console
+  console.log(
+    `[mcp] conn=#${entry.connectionId} tool=${entry.tool} ${bind} args=${JSON.stringify(entry.args)} ${resolved} ${result}`,
+  );
+}
+
+export function getDispatchLog(): readonly DispatchLogEntry[] {
+  return dispatchLog;
+}
+
 // ---- Tool definitions ----
 
 interface ToolDef {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
-  handler: (args: Record<string, unknown>) => Promise<unknown> | unknown;
+  handler: (
+    args: Record<string, unknown>,
+    ctx: ConnectionContext,
+  ) => Promise<unknown> | unknown;
 }
 
 const TOOLS: ToolDef[] = [];
@@ -285,7 +449,7 @@ function registerTool(t: ToolDef) {
 registerTool({
   name: "spawn_agent",
   description:
-    "Spawn a new gnar-term pane running an AI coding agent (claude-code, codex, aider) or a custom command.",
+    "Spawn a new gnar-term pane running an AI coding agent (claude-code, codex, aider) or a custom command. Targets the agent's host workspace by default (per connection binding); pass workspace_id/pane_id to override.",
   inputSchema: {
     type: "object",
     properties: {
@@ -297,22 +461,24 @@ registerTool({
       env: { type: "object", additionalProperties: { type: "string" } },
       cols: { type: "number" },
       rows: { type: "number" },
+      workspace_id: { type: "string" },
+      pane_id: { type: "string" },
     },
     required: ["name", "agent"],
   },
-  handler: async (args) => {
+  handler: async (args, ctx) => {
     const p = args as {
       name: string;
       agent: AgentType;
       task?: string;
       cwd?: string;
       command?: string;
+      workspace_id?: string;
+      pane_id?: string;
     };
     let startupCommand: string | undefined;
     if (p.agent === "custom") {
-      if (!p.command) {
-        throw new Error('agent "custom" requires a command parameter');
-      }
+      if (!p.command) throw new Error('agent "custom" requires a command parameter');
       startupCommand = p.command;
     } else {
       const agentCmd = AGENT_COMMANDS[p.agent];
@@ -320,13 +486,14 @@ registerTool({
       startupCommand = agentCmd;
     }
 
-    const existingActive = get(activePane);
-    const target = existingActive ? splitActivePane("vertical") : getOrCreateActivePane();
+    const target = resolveTarget(p, ctx);
+    const hostPane = target.hostPane ?? pickHostPane(target.workspace);
+    const newPane = splitPaneInWorkspace(target.workspace, hostPane, "vertical");
 
-    const surface = await createTerminalSurface(target, p.cwd);
+    const surface = await createTerminalSurface(newPane, p.cwd);
     surface.title = p.name;
     surface.startupCommand = startupCommand;
-    target.activeSurfaceId = surface.id;
+    newPane.activeSurfaceId = surface.id;
     workspaces.update((l) => [...l]);
     safeFocus(surface);
 
@@ -349,7 +516,7 @@ registerTool({
       status: "starting",
       cwd,
       createdAt: new Date().toISOString(),
-      paneId: target.id,
+      paneId: newPane.id,
       surfaceId: surface.id,
       ptyId,
     };
@@ -357,8 +524,8 @@ registerTool({
     ptyToSession.set(ptyId, session.session_id);
     pushEvent({
       type: "pane.created",
-      paneId: target.id,
-      workspaceId: get(activeWorkspace)?.id ?? "",
+      paneId: newPane.id,
+      workspaceId: target.workspace.id,
     });
     pushEvent({
       type: "session.statusChanged",
@@ -379,6 +546,8 @@ registerTool({
       pid: session.pid,
       status: session.status,
       cwd: session.cwd,
+      pane_id: newPane.id,
+      workspace_id: target.workspace.id,
     };
   },
 });
@@ -556,7 +725,8 @@ registerTool({
 
 registerTool({
   name: "dispatch_tasks",
-  description: "Spawn multiple agent sessions in parallel for fan-out workflows.",
+  description:
+    "Spawn multiple agent sessions in parallel. Each task resolves its target independently — pass workspace_id/pane_id per task to override the connection binding.",
   inputSchema: {
     type: "object",
     properties: {
@@ -570,6 +740,8 @@ registerTool({
             task: { type: "string" },
             cwd: { type: "string" },
             command: { type: "string" },
+            workspace_id: { type: "string" },
+            pane_id: { type: "string" },
           },
           required: ["name", "agent", "task"],
         },
@@ -577,7 +749,7 @@ registerTool({
     },
     required: ["tasks"],
   },
-  handler: async (args) => {
+  handler: async (args, ctx) => {
     const { tasks } = args as {
       tasks: Array<{
         name: string;
@@ -585,6 +757,8 @@ registerTool({
         task: string;
         cwd?: string;
         command?: string;
+        workspace_id?: string;
+        pane_id?: string;
       }>;
     };
     const results: Array<{
@@ -592,28 +766,39 @@ registerTool({
       name: string;
       agent: AgentType;
       pid: number | undefined;
+      pane_id?: string;
+      workspace_id?: string;
       error?: string;
     }> = [];
     const spawnTool = TOOLS.find((t) => t.name === "spawn_agent")!;
     for (const taskDef of tasks) {
       try {
-        const resp = (await spawnTool.handler({
-          name: taskDef.name,
-          agent: taskDef.agent,
-          task: taskDef.task,
-          cwd: taskDef.cwd,
-          command: taskDef.command,
-        })) as {
+        const resp = (await spawnTool.handler(
+          {
+            name: taskDef.name,
+            agent: taskDef.agent,
+            task: taskDef.task,
+            cwd: taskDef.cwd,
+            command: taskDef.command,
+            workspace_id: taskDef.workspace_id,
+            pane_id: taskDef.pane_id,
+          },
+          ctx,
+        )) as {
           session_id: string;
           name: string;
           agent: AgentType;
           pid: number | undefined;
+          pane_id: string;
+          workspace_id: string;
         };
         results.push({
           session_id: resp.session_id,
           name: resp.name,
           agent: resp.agent,
           pid: resp.pid,
+          pane_id: resp.pane_id,
+          workspace_id: resp.workspace_id,
         });
       } catch (err) {
         results.push({
@@ -638,7 +823,7 @@ registerTool({
 registerTool({
   name: "render_sidebar",
   description:
-    "Declare or replace an extension sidebar section. Side is 'primary' or 'secondary'; items are clickable.",
+    "Declare or replace an extension sidebar section in the resolved workspace. Sections are workspace-scoped: invisible from other workspaces.",
   inputSchema: {
     type: "object",
     properties: {
@@ -646,48 +831,59 @@ registerTool({
       section_id: { type: "string" },
       title: { type: "string" },
       items: { type: "array" },
+      workspace_id: { type: "string" },
     },
     required: ["side", "section_id", "title", "items"],
   },
-  handler: (args) => {
+  handler: (args, ctx) => {
     const p = args as {
       side: "primary" | "secondary";
       section_id: string;
       title: string;
       items: SidebarItem[];
+      workspace_id?: string;
     };
+    const target = resolveTarget({ workspace_id: p.workspace_id }, ctx);
     upsertSection({
       side: p.side,
       sectionId: p.section_id,
       title: p.title,
       items: p.items ?? [],
+      workspaceId: target.workspace.id,
     });
-    return { ok: true };
+    return { ok: true, workspace_id: target.workspace.id };
   },
 });
 
 registerTool({
   name: "remove_sidebar_section",
-  description: "Remove an extension-declared sidebar section. Safe for non-existent IDs.",
+  description:
+    "Remove an extension-declared sidebar section from the resolved workspace. Safe for non-existent IDs.",
   inputSchema: {
     type: "object",
     properties: {
       side: { type: "string", enum: ["primary", "secondary"] },
       section_id: { type: "string" },
+      workspace_id: { type: "string" },
     },
     required: ["side", "section_id"],
   },
-  handler: (args) => {
-    const p = args as { side: "primary" | "secondary"; section_id: string };
-    removeSection(p.side, p.section_id);
-    return { ok: true };
+  handler: (args, ctx) => {
+    const p = args as {
+      side: "primary" | "secondary";
+      section_id: string;
+      workspace_id?: string;
+    };
+    const target = resolveTarget({ workspace_id: p.workspace_id }, ctx);
+    removeSection(target.workspace.id, p.side, p.section_id);
+    return { ok: true, workspace_id: target.workspace.id };
   },
 });
 
 registerTool({
   name: "create_preview",
   description:
-    "Open a preview surface with markdown/text/code content. Placement controls where the preview appears.",
+    "Open a preview surface with markdown/text/code content. Targets the agent's host workspace by default; pass workspace_id/pane_id to override.",
   inputSchema: {
     type: "object",
     properties: {
@@ -699,39 +895,40 @@ registerTool({
         type: "string",
         enum: ["split-right", "split-down", "new-tab", "current-pane"],
       },
+      workspace_id: { type: "string" },
+      pane_id: { type: "string" },
     },
     required: ["content", "format"],
   },
-  handler: (args) => {
+  handler: (args, ctx) => {
     const p = args as {
       content: string;
       format: "markdown" | "text" | "code";
       language?: string;
       title?: string;
       placement?: "split-right" | "split-down" | "new-tab" | "current-pane";
+      workspace_id?: string;
+      pane_id?: string;
     };
+    const target = resolveTarget(p, ctx);
     const title = p.title ?? "Preview";
-    // Wrap text/code as markdown fenced blocks so the markdown previewer
-    // renders them with monospacing and syntax highlighting.
     let rendered: string;
-    if (p.format === "markdown") {
-      rendered = p.content;
-    } else if (p.format === "code") {
+    if (p.format === "markdown") rendered = p.content;
+    else if (p.format === "code")
       rendered = "```" + (p.language ?? "") + "\n" + p.content + "\n```";
-    } else {
-      rendered = "```\n" + p.content + "\n```";
-    }
+    else rendered = "```\n" + p.content + "\n```";
     const previewSurface = openPreviewFromContent(rendered, title);
 
     const placement = p.placement ?? "split-right";
+    const hostPane = target.hostPane ?? pickHostPane(target.workspace);
     let targetPane: Pane;
     if (placement === "split-right") {
-      targetPane = get(activePane) ? splitActivePane("horizontal") : getOrCreateActivePane();
+      targetPane = splitPaneInWorkspace(target.workspace, hostPane, "horizontal");
     } else if (placement === "split-down") {
-      targetPane = get(activePane) ? splitActivePane("vertical") : getOrCreateActivePane();
+      targetPane = splitPaneInWorkspace(target.workspace, hostPane, "vertical");
     } else {
-      // new-tab and current-pane both drop into the active pane's surface list
-      targetPane = getOrCreateActivePane();
+      // new-tab and current-pane drop into the host pane's surface list.
+      targetPane = hostPane;
     }
 
     const surface = {
@@ -747,15 +944,38 @@ registerTool({
     targetPane.activeSurfaceId = surface.id;
     workspaces.update((l) => [...l]);
 
-    return { preview_id: surface.id, pane_id: targetPane.id };
+    return {
+      preview_id: surface.id,
+      pane_id: targetPane.id,
+      workspace_id: target.workspace.id,
+    };
   },
 });
 
-// ---- UI introspection ----
+// ---- Agent introspection ----
+
+registerTool({
+  name: "get_agent_context",
+  description:
+    "Return the connection's bound {pane_id, workspace_id, client_pid} from the $/gnar-term/hello handshake. Returns null when the agent is unbound (was not run inside a gnar-term pane). Agents should call this once on startup to learn their context.",
+  inputSchema: { type: "object", properties: {} },
+  handler: (_args, ctx) => {
+    const b = ctx.binding;
+    if (!b) return null;
+    return {
+      pane_id: b.paneId,
+      workspace_id: b.workspaceId,
+      client_pid: b.clientPid,
+    };
+  },
+});
+
+// ---- UI introspection (observers; report user GUI focus) ----
 
 registerTool({
   name: "get_active_workspace",
-  description: "Return the currently active workspace, or null if none.",
+  description:
+    "Return the workspace the user is currently focused on. Reports user GUI focus, NOT the agent's binding — agents should use get_agent_context for routing.",
   inputSchema: { type: "object", properties: {} },
   handler: () => {
     const ws = get(activeWorkspace);
@@ -779,7 +999,8 @@ registerTool({
 
 registerTool({
   name: "get_active_pane",
-  description: "Return the currently active pane with its surfaces, or null.",
+  description:
+    "Return the user-focused pane and its surfaces. Reports user GUI focus, NOT the agent's binding.",
   inputSchema: { type: "object", properties: {} },
   handler: () => {
     const ws = get(activeWorkspace);
@@ -889,9 +1110,21 @@ registerTool({
 const PROTOCOL_VERSION = "2025-11-25";
 const SERVER_INFO = { name: "gnar-term", version: "0.3.1" };
 
-export async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+/** Tools that mutate UI surfaces — these are the ones that get logged to
+ *  dispatchLog with binding/resolution metadata. */
+const UI_MUTATING_TOOLS = new Set([
+  "spawn_agent",
+  "dispatch_tasks",
+  "create_preview",
+  "render_sidebar",
+  "remove_sidebar_section",
+]);
+
+export async function dispatch(
+  req: JsonRpcRequest,
+  ctx: ConnectionContext = ANONYMOUS_CONTEXT,
+): Promise<JsonRpcResponse | null> {
   const id = req.id ?? null;
-  // Notifications (no id) are fire-and-forget.
   const isNotification = req.id === undefined || req.id === null;
 
   try {
@@ -903,6 +1136,20 @@ export async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse | n
           serverInfo: SERVER_INFO,
         };
         return isNotification ? null : { jsonrpc: "2.0", id, result };
+      }
+      case "$/gnar-term/hello": {
+        // Connection-binding handshake. Always a notification (no id).
+        const params = (req.params ?? {}) as {
+          pane_id?: string | null;
+          workspace_id?: string | null;
+          client_pid?: number | null;
+        };
+        ctx.binding = {
+          paneId: params.pane_id ?? null,
+          workspaceId: params.workspace_id ?? null,
+          clientPid: params.client_pid ?? null,
+        };
+        return null;
       }
       case "notifications/initialized":
       case "initialized":
@@ -929,16 +1176,54 @@ export async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse | n
             error: { code: -32601, message: `unknown tool: ${params.name}` },
           };
         }
-        const value = await tool.handler(params.arguments ?? {});
-        if (isNotification) return null;
-        return {
-          jsonrpc: "2.0",
-          id,
-          result: {
-            content: [{ type: "text", text: JSON.stringify(value) }],
-            structuredContent: value,
-          },
-        };
+        const args = params.arguments ?? {};
+        const shouldLog = UI_MUTATING_TOOLS.has(tool.name);
+        const logEntry: DispatchLogEntry | null = shouldLog
+          ? {
+              ts: new Date().toISOString(),
+              connectionId: ctx.connectionId,
+              tool: tool.name,
+              binding: ctx.binding,
+              args,
+            }
+          : null;
+        try {
+          const value = await tool.handler(args, ctx);
+          if (logEntry) {
+            // Try to surface the resolution metadata when the result includes it.
+            const v = value as
+              | { workspace_id?: string; pane_id?: string }
+              | undefined
+              | null;
+            if (v && v.workspace_id) {
+              logEntry.resolved = {
+                workspaceId: v.workspace_id,
+                paneId: v.pane_id ?? null,
+                source: "tool-result",
+              };
+            }
+            logEntry.result = { kind: "ok", summary: JSON.stringify(value).slice(0, 120) };
+            logDispatch(logEntry);
+          }
+          if (isNotification) return null;
+          return {
+            jsonrpc: "2.0",
+            id,
+            result: {
+              content: [{ type: "text", text: JSON.stringify(value) }],
+              structuredContent: value,
+            },
+          };
+        } catch (err) {
+          if (logEntry) {
+            logEntry.result = {
+              kind: "error",
+              message: err instanceof Error ? err.message : String(err),
+            };
+            logDispatch(logEntry);
+          }
+          throw err;
+        }
       }
       case "ping":
         return isNotification ? null : { jsonrpc: "2.0", id, result: {} };
@@ -968,19 +1253,31 @@ export async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse | n
 
 let initialized = false;
 
-/**
- * Initialize the MCP server. Honors the `mcp` config setting:
- * - "off": no-op, module is fully dormant
- * - otherwise: install pty listeners and subscribe to mcp-request events
- */
+interface RequestEnvelope {
+  connection_id: number;
+  payload: string;
+}
+
+interface ConnectionClosedEnvelope {
+  connection_id: number;
+}
+
+function getOrCreateContext(connectionId: number): ConnectionContext {
+  let ctx = connectionContexts.get(connectionId);
+  if (!ctx) {
+    ctx = { connectionId, binding: null };
+    connectionContexts.set(connectionId, ctx);
+  }
+  return ctx;
+}
+
+/** Initialize the MCP server. Honors the `mcp` config setting. */
 export async function initMcpServer(): Promise<void> {
   if (initialized) return;
   initialized = true;
 
   const setting = getMcpSetting();
-  if (setting === "off") {
-    return;
-  }
+  if (setting === "off") return;
 
   // Bridge pty-exit to session status updates.
   await listen<{ pty_id: number }>("pty-exit", (event) => {
@@ -999,23 +1296,51 @@ export async function initMcpServer(): Promise<void> {
     ptyToSession.delete(event.payload.pty_id);
   });
 
-  // mcp-request from Rust bridge — each event carries one JSON-RPC message.
   await listen<string>("mcp-request", async (event) => {
-    const raw = event.payload;
-    let req: JsonRpcRequest;
+    let envelope: RequestEnvelope;
     try {
-      req = JSON.parse(raw) as JsonRpcRequest;
+      envelope = JSON.parse(event.payload) as RequestEnvelope;
     } catch {
-      console.warn("[mcp] malformed request:", raw);
+      console.warn("[mcp] malformed request envelope:", event.payload);
       return;
     }
-    const resp = await dispatch(req);
+    if (
+      typeof envelope.connection_id !== "number" ||
+      typeof envelope.payload !== "string"
+    ) {
+      console.warn("[mcp] invalid request envelope shape:", envelope);
+      return;
+    }
+    let req: JsonRpcRequest;
+    try {
+      req = JSON.parse(envelope.payload) as JsonRpcRequest;
+    } catch {
+      console.warn("[mcp] malformed request payload:", envelope.payload);
+      return;
+    }
+    const ctx = getOrCreateContext(envelope.connection_id);
+    const resp = await dispatch(req, ctx);
     if (resp) {
-      await emit("mcp-response", JSON.stringify(resp));
+      const out = {
+        connection_id: envelope.connection_id,
+        payload: JSON.stringify(resp),
+      };
+      await emit("mcp-response", JSON.stringify(out));
     }
   });
 
-  // Track workspace/pane focus changes → lifecycle events.
+  await listen<string>("mcp-connection-closed", (event) => {
+    let envelope: ConnectionClosedEnvelope;
+    try {
+      envelope = JSON.parse(event.payload) as ConnectionClosedEnvelope;
+    } catch {
+      console.warn("[mcp] malformed close envelope:", event.payload);
+      return;
+    }
+    connectionContexts.delete(envelope.connection_id);
+  });
+
+  // Lifecycle events for user GUI focus changes (observers).
   let lastWorkspaceId: string | null = null;
   let lastPaneId: string | null = null;
   activeWorkspace.subscribe((ws) => {
@@ -1049,8 +1374,41 @@ export function _getSessionsForTest(): Map<string, McpSession> {
   return sessions;
 }
 
+export function _getConnectionContextsForTest(): Map<number, ConnectionContext> {
+  return connectionContexts;
+}
+
+/** Build a connection context for tests. Pass binding=null for an unbound
+ *  agent (will hit resolution rule 5); pass partial binding for the bound
+ *  cases. The connectionId is auto-assigned to a synthetic value. */
+export function _testContext(
+  binding: Partial<ConnectionBinding> | null = null,
+): ConnectionContext {
+  const ctx: ConnectionContext = {
+    connectionId: -1,
+    binding: binding
+      ? {
+          paneId: binding.paneId ?? null,
+          workspaceId: binding.workspaceId ?? null,
+          clientPid: binding.clientPid ?? null,
+        }
+      : null,
+  };
+  return ctx;
+}
+
+/** Test-only wrapper that exposes resolveTarget for unit testing. */
+export function _resolveTargetForTest(
+  args: TargetArgs,
+  ctx: ConnectionContext,
+): ResolvedTarget {
+  return resolveTarget(args, ctx);
+}
+
 export function _resetMcpServerForTest(): void {
   sessions.clear();
   ptyToSession.clear();
+  connectionContexts.clear();
+  dispatchLog.length = 0;
   initialized = false;
 }

--- a/src/lib/services/mcp-server.ts
+++ b/src/lib/services/mcp-server.ts
@@ -104,6 +104,11 @@ export interface ConnectionBinding {
 export interface ConnectionContext {
   connectionId: number;
   binding: ConnectionBinding | null;
+  /** Most-recent pane this connection spawned into. Used as the split host for
+   *  the *next* spawn so rapid-fire `dispatch_tasks` produces a shallow
+   *  right-chain instead of an N-deep left spine around the binding pane —
+   *  the latter exploded `findParentSplit` + DOM render cost into O(N²). */
+  lastSpawnedPaneId: string | null;
 }
 
 /** Sentinel for callers that have no transport context (test code calling
@@ -113,6 +118,7 @@ export interface ConnectionContext {
 const ANONYMOUS_CONTEXT: ConnectionContext = {
   connectionId: 0,
   binding: null,
+  lastSpawnedPaneId: null,
 };
 
 // ---- Agent command map ----
@@ -223,7 +229,21 @@ function resolveTarget(args: TargetArgs, ctx: ConnectionContext): ResolvedTarget
     }
     return { workspace: ws, hostPane: null, source: "args-workspace" };
   }
-  // Rule 3: connection-bound pane (re-derive workspace in case pane was moved).
+  // Rule 3a: chain off the most recent pane this connection spawned, if any.
+  // Keeps the split tree shallow under rapid-fire spawns — see the comment on
+  // `ConnectionContext.lastSpawnedPaneId`.
+  if (ctx.lastSpawnedPaneId) {
+    const found = findPaneById(ctx.lastSpawnedPaneId);
+    if (found) {
+      return {
+        workspace: found.workspace,
+        hostPane: found.pane,
+        source: "binding-pane",
+      };
+    }
+    // Last pane was closed. Fall through.
+  }
+  // Rule 3b: connection-bound pane (re-derive workspace in case pane was moved).
   const binding = ctx.binding;
   if (binding?.paneId) {
     const found = findPaneById(binding.paneId);
@@ -489,6 +509,7 @@ registerTool({
     const target = resolveTarget(p, ctx);
     const hostPane = target.hostPane ?? pickHostPane(target.workspace);
     const newPane = splitPaneInWorkspace(target.workspace, hostPane, "vertical");
+    ctx.lastSpawnedPaneId = newPane.id;
 
     const surface = await createTerminalSurface(newPane, p.cwd);
     surface.title = p.name;
@@ -924,8 +945,10 @@ registerTool({
     let targetPane: Pane;
     if (placement === "split-right") {
       targetPane = splitPaneInWorkspace(target.workspace, hostPane, "horizontal");
+      ctx.lastSpawnedPaneId = targetPane.id;
     } else if (placement === "split-down") {
       targetPane = splitPaneInWorkspace(target.workspace, hostPane, "vertical");
+      ctx.lastSpawnedPaneId = targetPane.id;
     } else {
       // new-tab and current-pane drop into the host pane's surface list.
       targetPane = hostPane;
@@ -1265,7 +1288,7 @@ interface ConnectionClosedEnvelope {
 function getOrCreateContext(connectionId: number): ConnectionContext {
   let ctx = connectionContexts.get(connectionId);
   if (!ctx) {
-    ctx = { connectionId, binding: null };
+    ctx = { connectionId, binding: null, lastSpawnedPaneId: null };
     connectionContexts.set(connectionId, ctx);
   }
   return ctx;
@@ -1393,6 +1416,7 @@ export function _testContext(
           clientPid: binding.clientPid ?? null,
         }
       : null,
+    lastSpawnedPaneId: null,
   };
   return ctx;
 }

--- a/src/lib/services/mcp-server.ts
+++ b/src/lib/services/mcp-server.ts
@@ -39,7 +39,7 @@ import {
   type Workspace,
 } from "../types";
 import { findParentSplit } from "../types";
-import { createTerminalSurface } from "../terminal-service";
+import { createTerminalSurface, waitForPtyReady } from "../terminal-service";
 import { safeFocus } from "./service-helpers";
 import {
   registerMcpPty,
@@ -321,14 +321,7 @@ async function waitForPtyId(
   surface: TerminalSurface,
   timeoutMs = 5000,
 ): Promise<number> {
-  const start = Date.now();
-  while (surface.ptyId < 0) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error("timed out waiting for PTY to spawn");
-    }
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  return surface.ptyId;
+  return waitForPtyReady(surface, timeoutMs);
 }
 
 async function getPtyCwd(ptyId: number): Promise<string> {

--- a/src/lib/services/mcp-server.ts
+++ b/src/lib/services/mcp-server.ts
@@ -579,7 +579,7 @@ registerTool({
   inputSchema: { type: "object", properties: {} },
   handler: () => {
     reapDeadSessions();
-    return Array.from(sessions.values()).map((s) => ({
+    const list = Array.from(sessions.values()).map((s) => ({
       session_id: s.session_id,
       name: s.name,
       agent: s.agent,
@@ -588,6 +588,7 @@ registerTool({
       cwd: s.cwd,
       createdAt: s.createdAt,
     }));
+    return { sessions: list };
   },
 });
 
@@ -980,15 +981,14 @@ registerTool({
 registerTool({
   name: "get_agent_context",
   description:
-    "Return the connection's bound {pane_id, workspace_id, client_pid} from the $/gnar-term/hello handshake. Returns null when the agent is unbound (was not run inside a gnar-term pane). Agents should call this once on startup to learn their context.",
+    "Return the connection's bound {pane_id, workspace_id, client_pid} from the $/gnar-term/hello handshake. All fields are null when the agent is unbound (was not run inside a gnar-term pane). Agents should call this once on startup to learn their context.",
   inputSchema: { type: "object", properties: {} },
   handler: (_args, ctx) => {
     const b = ctx.binding;
-    if (!b) return null;
     return {
-      pane_id: b.paneId,
-      workspace_id: b.workspaceId,
-      client_pid: b.clientPid,
+      pane_id: b?.paneId ?? null,
+      workspace_id: b?.workspaceId ?? null,
+      client_pid: b?.clientPid ?? null,
     };
   },
 });
@@ -998,12 +998,15 @@ registerTool({
 registerTool({
   name: "get_active_workspace",
   description:
-    "Return the workspace the user is currently focused on. Reports user GUI focus, NOT the agent's binding — agents should use get_agent_context for routing.",
+    "Return the workspace the user is currently focused on. Reports user GUI focus, NOT the agent's binding — agents should use get_agent_context for routing. Fields are null when no workspace is open.",
   inputSchema: { type: "object", properties: {} },
   handler: () => {
     const ws = get(activeWorkspace);
-    if (!ws) return null;
-    return { id: ws.id, name: ws.name, activePaneId: ws.activePaneId };
+    return {
+      id: ws?.id ?? null,
+      name: ws?.name ?? null,
+      activePaneId: ws?.activePaneId ?? null,
+    };
   },
 });
 
@@ -1012,24 +1015,25 @@ registerTool({
   description: "List all open workspaces.",
   inputSchema: { type: "object", properties: {} },
   handler: () => {
-    return get(workspaces).map((ws) => ({
+    const list = get(workspaces).map((ws) => ({
       id: ws.id,
       name: ws.name,
       activePaneId: ws.activePaneId,
     }));
+    return { workspaces: list };
   },
 });
 
 registerTool({
   name: "get_active_pane",
   description:
-    "Return the user-focused pane and its surfaces. Reports user GUI focus, NOT the agent's binding.",
+    "Return the user-focused pane and its surfaces. Reports user GUI focus, NOT the agent's binding. `pane` is null when no pane is focused.",
   inputSchema: { type: "object", properties: {} },
   handler: () => {
     const ws = get(activeWorkspace);
     const pane = get(activePane);
-    if (!ws || !pane) return null;
-    return describePane(pane, ws.id);
+    if (!ws || !pane) return { pane: null };
+    return { pane: describePane(pane, ws.id) };
   },
 });
 
@@ -1045,8 +1049,9 @@ registerTool({
     const target = p.workspace_id
       ? get(workspaces).find((w) => w.id === p.workspace_id)
       : get(activeWorkspace);
-    if (!target) return [];
-    return getAllPanes(target.splitRoot).map((pane) => describePane(pane, target.id));
+    if (!target) return { panes: [] };
+    const list = getAllPanes(target.splitRoot).map((pane) => describePane(pane, target.id));
+    return { panes: list };
   },
 });
 
@@ -1229,12 +1234,18 @@ export async function dispatch(
             logDispatch(logEntry);
           }
           if (isNotification) return null;
+          // MCP spec requires `structuredContent` to be a JSON object (record).
+          // Arrays, null, and primitives are rejected by client-side Zod
+          // validators, so only attach structuredContent when the tool returned
+          // a plain object. Text `content` still carries the full JSON payload.
+          const isRecord =
+            value !== null && typeof value === "object" && !Array.isArray(value);
           return {
             jsonrpc: "2.0",
             id,
             result: {
               content: [{ type: "text", text: JSON.stringify(value) }],
-              structuredContent: value,
+              ...(isRecord ? { structuredContent: value } : {}),
             },
           };
         } catch (err) {

--- a/src/lib/stores/extension-sidebar.ts
+++ b/src/lib/stores/extension-sidebar.ts
@@ -1,12 +1,17 @@
 /**
- * Extension-declared sidebar sections.
+ * Extension-declared sidebar sections, scoped per workspace.
  *
  * MCP extensions call the `render_sidebar` tool to declare or replace a
- * section in either the primary or secondary sidebar. The section is a
- * hierarchical tree of items; clicks on items fire `sidebar.item_clicked`
- * lifecycle events that extensions poll for.
+ * section in either the primary or secondary sidebar of a specific workspace.
+ * Sections are workspace-scoped: a section rendered in workspace A is invisible
+ * in workspace B. This matches the connection-binding contract — each agent's
+ * UI artifacts belong to its host workspace.
+ *
+ * Click events are emitted as `sidebar.item_clicked` lifecycle events the
+ * extension polls for via `poll_events`.
  */
 import { writable, derived } from "svelte/store";
+import { activeWorkspace } from "./workspace";
 
 export interface SidebarItem {
   id: string;
@@ -21,42 +26,76 @@ export interface SidebarSection {
   sectionId: string;
   title: string;
   items: SidebarItem[];
+  workspaceId: string;
 }
 
-/** Map keyed by `${side}:${sectionId}` so each section is a single upsert. */
+/** Map keyed by `${workspaceId}:${side}:${sectionId}`. */
 export const extensionSidebarSections = writable<Map<string, SidebarSection>>(
   new Map(),
 );
 
-function keyOf(side: "primary" | "secondary", sectionId: string): string {
-  return `${side}:${sectionId}`;
+function keyOf(
+  workspaceId: string,
+  side: "primary" | "secondary",
+  sectionId: string,
+): string {
+  return `${workspaceId}:${side}:${sectionId}`;
 }
 
 export function upsertSection(section: SidebarSection): void {
   extensionSidebarSections.update((map) => {
     const next = new Map(map);
-    next.set(keyOf(section.side, section.sectionId), section);
+    next.set(keyOf(section.workspaceId, section.side, section.sectionId), section);
     return next;
   });
 }
 
-export function removeSection(side: "primary" | "secondary", sectionId: string): void {
+export function removeSection(
+  workspaceId: string,
+  side: "primary" | "secondary",
+  sectionId: string,
+): void {
   extensionSidebarSections.update((map) => {
-    if (!map.has(keyOf(side, sectionId))) return map;
+    const k = keyOf(workspaceId, side, sectionId);
+    if (!map.has(k)) return map;
     const next = new Map(map);
-    next.delete(keyOf(side, sectionId));
+    next.delete(k);
     return next;
   });
 }
 
+/** Remove every section that belongs to a workspace (called on workspace
+ *  destruction so dead sections don't accumulate forever). */
+export function removeSectionsForWorkspace(workspaceId: string): void {
+  extensionSidebarSections.update((map) => {
+    const next = new Map<string, SidebarSection>();
+    for (const [k, v] of map) {
+      if (v.workspaceId !== workspaceId) next.set(k, v);
+    }
+    return next;
+  });
+}
+
+/** Sections in the active workspace's primary sidebar. */
 export const primarySections = derived(
-  extensionSidebarSections,
-  ($map) => Array.from($map.values()).filter((s) => s.side === "primary"),
+  [extensionSidebarSections, activeWorkspace],
+  ([$map, $ws]) => {
+    if (!$ws) return [];
+    return Array.from($map.values()).filter(
+      (s) => s.side === "primary" && s.workspaceId === $ws.id,
+    );
+  },
 );
 
+/** Sections in the active workspace's secondary sidebar. */
 export const secondarySections = derived(
-  extensionSidebarSections,
-  ($map) => Array.from($map.values()).filter((s) => s.side === "secondary"),
+  [extensionSidebarSections, activeWorkspace],
+  ([$map, $ws]) => {
+    if (!$ws) return [];
+    return Array.from($map.values()).filter(
+      (s) => s.side === "secondary" && s.workspaceId === $ws.id,
+    );
+  },
 );
 
 export function _resetExtensionSidebarForTest(): void {

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -27,6 +27,51 @@ import "@xterm/xterm/css/xterm.css";
 /** Platform detection — used for Cmd (macOS) vs Ctrl (Linux/Windows) shortcuts. */
 export const isMac = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
 
+// Per-surface PTY-ready signal. connectPty() resolves the deferred once the
+// Rust spawn_pty call returns; waitForPtyReady() awaits it instead of polling
+// surface.ptyId every 50ms. The polling version created a 50ms timer storm
+// during spawn bursts that contributed to a compositor freeze.
+interface PtyReadyDeferred {
+  promise: Promise<number>;
+  resolve: (ptyId: number) => void;
+  reject: (err: Error) => void;
+}
+const ptyReady = new Map<string, PtyReadyDeferred>();
+
+function makeDeferred(): PtyReadyDeferred {
+  let resolve!: (n: number) => void;
+  let reject!: (e: Error) => void;
+  const promise = new Promise<number>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export function waitForPtyReady(surface: TerminalSurface, timeoutMs = 5000): Promise<number> {
+  if (surface.ptyId >= 0) return Promise.resolve(surface.ptyId);
+  let d = ptyReady.get(surface.id);
+  if (!d) {
+    d = makeDeferred();
+    ptyReady.set(surface.id, d);
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("timed out waiting for PTY to spawn"));
+    }, timeoutMs);
+    d!.promise.then(
+      (n) => {
+        clearTimeout(timer);
+        resolve(n);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 /** Shortcut label helpers for platform-appropriate display. */
 export const modLabel = isMac ? "⌘" : "Ctrl+";
 export const shiftModLabel = isMac ? "⇧⌘" : "Ctrl+Shift+";
@@ -666,6 +711,7 @@ export async function connectPty(surface: TerminalSurface, cwd?: string): Promis
     extraEnv.GNAR_TERM_WORKSPACE_ID = ctx.workspaceId;
   }
 
+  const deferred = ptyReady.get(surface.id);
   try {
     const ptyId = await invoke<number>("spawn_pty", {
       cols,
@@ -678,9 +724,13 @@ export async function connectPty(surface: TerminalSurface, cwd?: string): Promis
     resolvedPtyId = ptyId;
     for (const bytes of pending) handlePtyChunk(ptyId, bytes);
     pending.length = 0;
+    deferred?.resolve(ptyId);
+    ptyReady.delete(surface.id);
   } catch (err) {
     console.error("Failed to spawn PTY:", err);
     surface.ptyId = -1;
+    deferred?.reject(err instanceof Error ? err : new Error(String(err)));
+    ptyReady.delete(surface.id);
   }
 }
 

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -610,10 +610,34 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
   return surface;
 }
 
+/** Find the workspace + pane currently containing a given surface. Used to
+ *  inject `GNAR_TERM_PANE_ID` / `GNAR_TERM_WORKSPACE_ID` into the PTY's env so
+ *  any MCP-aware agent run inside the pane (claude, codex, etc.) can advertise
+ *  its host context to the gnar-term GUI via the `$/gnar-term/hello` handshake.
+ *
+ *  Returns null if the surface isn't yet attached (rare race during creation). */
+function findContextForSurface(
+  surfaceId: string,
+): { paneId: string; workspaceId: string } | null {
+  for (const ws of get(workspaces)) {
+    for (const pane of getAllPanes(ws.splitRoot)) {
+      if (pane.surfaces.some((s) => s.id === surfaceId)) {
+        return { paneId: pane.id, workspaceId: ws.id };
+      }
+    }
+  }
+  return null;
+}
+
 /** Spawn the PTY for a surface. Called after terminal.open() + fit() so the PTY
  *  gets the real terminal dimensions instead of hardcoded 80x24.
  *  Uses surface.cwd as the working directory. The optional cwd parameter is
- *  accepted for backwards compatibility but surface.cwd takes priority. */
+ *  accepted for backwards compatibility but surface.cwd takes priority.
+ *
+ *  Injects `GNAR_TERM_PANE_ID` and `GNAR_TERM_WORKSPACE_ID` into the PTY env
+ *  when the surface is already attached to a workspace pane. This is the
+ *  delivery mechanism for the MCP connection-binding contract — see the
+ *  Spacebase MCP spec § Connection binding. */
 export async function connectPty(surface: TerminalSurface, cwd?: string): Promise<void> {
   if (surface.ptyId >= 0) return; // already connected
   const cols = surface.terminal.cols;
@@ -635,12 +659,20 @@ export async function connectPty(surface: TerminalSurface, cwd?: string): Promis
     handlePtyChunk(resolvedPtyId, bytes);
   };
 
+  const ctx = findContextForSurface(surface.id);
+  const extraEnv: Record<string, string> = {};
+  if (ctx) {
+    extraEnv.GNAR_TERM_PANE_ID = ctx.paneId;
+    extraEnv.GNAR_TERM_WORKSPACE_ID = ctx.workspaceId;
+  }
+
   try {
     const ptyId = await invoke<number>("spawn_pty", {
       cols,
       rows,
       cwd: effectiveCwd,
       onOutput,
+      extraEnv,
     });
     surface.ptyId = ptyId;
     resolvedPtyId = ptyId;

--- a/tests/mcp-integration.mjs
+++ b/tests/mcp-integration.mjs
@@ -183,8 +183,8 @@ async function main() {
   });
   assert(workspaces?.structuredContent !== undefined, "tools/call returns structuredContent");
   assert(
-    Array.isArray(workspaces.structuredContent),
-    "list_workspaces result is an array",
+    Array.isArray(workspaces.structuredContent?.workspaces),
+    "list_workspaces result has workspaces array",
   );
 
   // poll_events — should return a cursor regardless of state
@@ -204,7 +204,7 @@ async function main() {
     name: "list_workspaces",
     arguments: {},
   });
-  const wsId = wsList?.structuredContent?.[0]?.id;
+  const wsId = wsList?.structuredContent?.workspaces?.[0]?.id;
   assert(typeof wsId === "string", "list_workspaces returned a workspace id for the harness");
   const render = await client.call("tools/call", {
     name: "render_sidebar",

--- a/tests/mcp-integration.mjs
+++ b/tests/mcp-integration.mjs
@@ -148,7 +148,7 @@ async function main() {
   // tools/list
   const list = await client.call("tools/list", {});
   assert(Array.isArray(list.tools), "tools/list returns array");
-  assert(list.tools.length === 19, `expected 19 tools, got ${list.tools.length}`);
+  assert(list.tools.length === 20, `expected 20 tools, got ${list.tools.length}`);
   const names = new Set(list.tools.map((t) => t.name));
   const required = [
     "spawn_agent",
@@ -162,6 +162,7 @@ async function main() {
     "render_sidebar",
     "remove_sidebar_section",
     "create_preview",
+    "get_agent_context",
     "get_active_workspace",
     "list_workspaces",
     "get_active_pane",
@@ -196,7 +197,15 @@ async function main() {
     "poll_events returns numeric cursor",
   );
 
-  // render_sidebar + remove_sidebar_section — write path smoke test
+  // render_sidebar + remove_sidebar_section — write path smoke test.
+  // The harness is unbound (no $/gnar-term/hello), so it MUST pass an
+  // explicit workspace_id per the resolution rules. Use the first known one.
+  const wsList = await client.call("tools/call", {
+    name: "list_workspaces",
+    arguments: {},
+  });
+  const wsId = wsList?.structuredContent?.[0]?.id;
+  assert(typeof wsId === "string", "list_workspaces returned a workspace id for the harness");
   const render = await client.call("tools/call", {
     name: "render_sidebar",
     arguments: {
@@ -204,6 +213,7 @@ async function main() {
       section_id: "harness-smoke",
       title: "Harness",
       items: [{ id: "ok", label: "OK" }],
+      workspace_id: wsId,
     },
   });
   assert(
@@ -212,7 +222,7 @@ async function main() {
   );
   const removed = await client.call("tools/call", {
     name: "remove_sidebar_section",
-    arguments: { side: "secondary", section_id: "harness-smoke" },
+    arguments: { side: "secondary", section_id: "harness-smoke", workspace_id: wsId },
   });
   assert(
     removed?.structuredContent?.ok === true,

--- a/tests/mcp-scenarios.mjs
+++ b/tests/mcp-scenarios.mjs
@@ -177,6 +177,63 @@ async function scenario(num, title, fn) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Watchdog: periodically ping the server with a cheap tools/call. Two
+// consecutive misses = the app is wedged; dump diagnostics and exit non-zero
+// so CI / the developer does not have to observe the freeze manually.
+// See project_mcp_testing_strategy.md.
+function startWatchdog(probeConn, intervalMs = 2000, pingTimeoutMs = 3000) {
+  let misses = 0;
+  let stopped = false;
+  const pingOnce = async () => {
+    try {
+      const id = ++probeConn.id;
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          probeConn.pending.delete(id);
+          reject(new Error("watchdog ping timeout"));
+        }, pingTimeoutMs);
+        probeConn.pending.set(id, {
+          resolve: (v) => {
+            clearTimeout(timer);
+            resolve(v);
+          },
+          reject: (e) => {
+            clearTimeout(timer);
+            reject(e);
+          },
+        });
+        probeConn.sock.write(
+          JSON.stringify({ jsonrpc: "2.0", id, method: "ping", params: {} }) + "\n",
+        );
+      });
+      misses = 0;
+    } catch {
+      misses++;
+      if (misses >= 2) {
+        console.error(
+          `\n!!! WATCHDOG: app appears frozen (${misses} consecutive ping misses).`,
+        );
+        console.error(
+          `!!! This is the freeze pattern described in project_mcp_freeze_investigation.md.`,
+        );
+        console.error(`!!! Killing test with non-zero exit so CI fails loud.`);
+        process.exit(3);
+      }
+    }
+  };
+  const loop = async () => {
+    while (!stopped) {
+      await sleep(intervalMs);
+      if (stopped) break;
+      await pingOnce();
+    }
+  };
+  loop();
+  return () => {
+    stopped = true;
+  };
+}
+
 // ------------------------------------------------------------------
 // Helpers shared across scenarios
 // ------------------------------------------------------------------
@@ -188,12 +245,12 @@ async function getActiveWorkspaceId(c) {
 
 async function listWorkspaceIds(c) {
   const list = await c.tool("list_workspaces", {});
-  return (list ?? []).map((w) => w.id);
+  return (list?.workspaces ?? []).map((w) => w.id);
 }
 
 async function paneCountInWorkspace(c, wsId) {
   const panes = await c.tool("list_panes", { workspace_id: wsId });
-  return Array.isArray(panes) ? panes.length : 0;
+  return Array.isArray(panes?.panes) ? panes.panes.length : 0;
 }
 
 async function spawnProbe(c, name, extra = {}) {
@@ -230,6 +287,11 @@ console.log(`MCP scenarios -> ${sock}`);
 
 // Probe connection used to read state across the suite.
 const probe = await newConn("probe");
+
+// Watchdog fires against the probe connection. If it misses twice, the suite
+// aborts so a hung app is a hard test failure rather than a user-observed
+// freeze.
+const stopWatchdog = startWatchdog(probe);
 
 // Pre-flight: capture baseline workspaces.
 const wsIds = await listWorkspaceIds(probe);
@@ -358,11 +420,12 @@ await scenario(5, "pane_id wins over a stale workspace_id binding", async () => 
   }
   // Find a pane in W2.
   const w2Panes = await probe.tool("list_panes", { workspace_id: W2 });
-  if (!Array.isArray(w2Panes) || w2Panes.length === 0) {
+  const w2PaneList = w2Panes?.panes;
+  if (!Array.isArray(w2PaneList) || w2PaneList.length === 0) {
     console.log("  SKIP — W2 has no panes");
     return;
   }
-  const targetPane = w2Panes[0].id;
+  const targetPane = w2PaneList[0].id;
 
   const c = await newConn("scn5");
   // Bind to a stale workspace (W1) but pass an explicit pane_id in W2.
@@ -615,6 +678,7 @@ await scenario(15, "render_sidebar is workspace-scoped (per-workspace visibility
 // ------------------------------------------------------------------
 console.log(`\nCleanup: killing ${spawnedSessions.length} spawned sessions`);
 await killAll(probe, spawnedSessions);
+stopWatchdog();
 probe.close();
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/mcp-scenarios.mjs
+++ b/tests/mcp-scenarios.mjs
@@ -1,0 +1,625 @@
+#!/usr/bin/env node
+/**
+ * Gnar Term MCP scenario suite.
+ *
+ * Runs the 15 mandatory scenarios from the MCP spec § Testing strategy
+ * against a live gnar-term instance, over the UDS bridge, with multiple
+ * concurrent connections.
+ *
+ * Usage:
+ *   1. Start gnar-term with `mcp: "on"` (or `auto` with Claude Code installed).
+ *   2. Run: node tests/mcp-scenarios.mjs
+ *
+ * Each scenario opens its own UDS connection, sends a synthetic
+ * `$/gnar-term/hello` to bind the connection (since this harness is not run
+ * inside a gnar-term pane and so doesn't naturally inherit the env vars), and
+ * exercises the contract.
+ *
+ * NOTE: This harness is NOT part of `npm test` — it requires a running GUI and
+ * cannot run headlessly without xvfb + a built Tauri binary.
+ */
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+function udsPath() {
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library/Application Support/gnar-term/mcp.sock");
+  }
+  if (process.platform === "linux") {
+    const runtime = process.env.XDG_RUNTIME_DIR;
+    if (runtime) return path.join(runtime, "gnar-term/mcp.sock");
+    return path.join(home, ".config/gnar-term/mcp.sock");
+  }
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA;
+    if (!local) throw new Error("LOCALAPPDATA not set");
+    return path.join(local, "gnar-term", "mcp.sock");
+  }
+  throw new Error(`unsupported platform: ${process.platform}`);
+}
+
+class Conn {
+  constructor(label = "anon") {
+    this.label = label;
+    this.sock = null;
+    this.buf = "";
+    this.id = 0;
+    this.pending = new Map();
+    this.notifications = [];
+  }
+
+  async open() {
+    const sock = path.normalize(udsPath());
+    this.sock = await new Promise((resolve, reject) => {
+      const s = net.createConnection(sock);
+      s.once("connect", () => resolve(s));
+      s.once("error", reject);
+    });
+    this.sock.setEncoding("utf8");
+    this.sock.on("data", (c) => this._onData(c));
+    this.sock.on("close", () => {
+      for (const { reject } of this.pending.values()) reject(new Error("conn closed"));
+    });
+  }
+
+  _onData(chunk) {
+    this.buf += chunk;
+    let i;
+    while ((i = this.buf.indexOf("\n")) !== -1) {
+      const line = this.buf.slice(0, i);
+      this.buf = this.buf.slice(i + 1);
+      if (!line.trim()) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id === undefined || msg.id === null) {
+        this.notifications.push(msg);
+        continue;
+      }
+      const p = this.pending.get(msg.id);
+      if (p) {
+        this.pending.delete(msg.id);
+        msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+      }
+    }
+  }
+
+  send(method, params) {
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timeout ${method} on ${this.label}`));
+      }, 8000);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      this.sock.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  /** Send a JSON-RPC notification (no id, no response expected). */
+  notify(method, params) {
+    this.sock.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+
+  /** Bind this connection to the given pane / workspace via the hello handshake. */
+  hello({ pane_id = null, workspace_id = null, client_pid = process.pid } = {}) {
+    this.notify("$/gnar-term/hello", { pane_id, workspace_id, client_pid });
+  }
+
+  async tool(name, args = {}) {
+    const r = await this.send("tools/call", { name, arguments: args });
+    return r.structuredContent;
+  }
+
+  async toolError(name, args = {}) {
+    try {
+      await this.tool(name, args);
+      return null;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  close() {
+    if (this.sock) this.sock.destroy();
+  }
+}
+
+async function newConn(label) {
+  const c = new Conn(label);
+  await c.open();
+  await c.send("initialize", {
+    protocolVersion: "2025-11-25",
+    capabilities: {},
+    clientInfo: { name: `scenario:${label}`, version: "0" },
+  });
+  return c;
+}
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+function ok(cond, name) {
+  if (cond) {
+    pass++;
+    console.log(`  PASS ${name}`);
+  } else {
+    fail++;
+    failures.push(name);
+    console.log(`  FAIL ${name}`);
+  }
+}
+async function scenario(num, title, fn) {
+  console.log(`\nScenario ${num}: ${title}`);
+  try {
+    await fn();
+  } catch (e) {
+    fail++;
+    failures.push(`#${num} ${title}: ${e.message}`);
+    console.log(`  FAIL scenario crashed: ${e.message}`);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ------------------------------------------------------------------
+// Helpers shared across scenarios
+// ------------------------------------------------------------------
+
+async function getActiveWorkspaceId(c) {
+  const ws = await c.tool("get_active_workspace", {});
+  return ws?.id ?? null;
+}
+
+async function listWorkspaceIds(c) {
+  const list = await c.tool("list_workspaces", {});
+  return (list ?? []).map((w) => w.id);
+}
+
+async function paneCountInWorkspace(c, wsId) {
+  const panes = await c.tool("list_panes", { workspace_id: wsId });
+  return Array.isArray(panes) ? panes.length : 0;
+}
+
+async function spawnProbe(c, name, extra = {}) {
+  return await c.tool("spawn_agent", {
+    name,
+    agent: "custom",
+    command: "bash --noprofile --norc -i",
+    ...extra,
+  });
+}
+
+async function killAll(c, sessionIds) {
+  for (const sid of sessionIds) {
+    try {
+      await c.tool("kill_session", { session_id: sid, signal: "TERM" });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ------------------------------------------------------------------
+// Main
+// ------------------------------------------------------------------
+
+const sock = udsPath();
+if (!fs.existsSync(sock)) {
+  console.error(`gnar-term MCP socket not found at ${sock}.`);
+  console.error(`Start gnar-term with mcp: "on" in gnar-term.json and re-run.`);
+  process.exit(2);
+}
+
+console.log(`MCP scenarios -> ${sock}`);
+
+// Probe connection used to read state across the suite.
+const probe = await newConn("probe");
+
+// Pre-flight: capture baseline workspaces.
+const wsIds = await listWorkspaceIds(probe);
+if (wsIds.length === 0) {
+  console.error("No workspaces in gnar-term. Open at least one workspace and re-run.");
+  process.exit(2);
+}
+const W1 = wsIds[0];
+const W2 = wsIds[1] ?? wsIds[0]; // fall back to W1 if only one exists
+console.log(`Using workspaces W1=${W1} W2=${W2}`);
+
+// ------------------------------------------------------------------
+// Scenario 1: Connection bound to W1; mid-call we don't *actually* switch
+// GUI focus from this harness, but we assert the call lands on W1
+// regardless of which workspace is currently active.
+// ------------------------------------------------------------------
+const spawnedSessions = [];
+await scenario(1, "Connection bound to W1; spawn lands in W1 regardless of GUI focus", async () => {
+  const c = await newConn("c1");
+  c.hello({ workspace_id: W1 });
+  await sleep(50); // let hello be processed
+  const before = await paneCountInWorkspace(probe, W1);
+  const spawn = await spawnProbe(c, "scn1");
+  spawnedSessions.push(spawn.session_id);
+  ok(spawn.workspace_id === W1, `spawn.workspace_id == W1 (got ${spawn.workspace_id})`);
+  const after = await paneCountInWorkspace(probe, W1);
+  ok(after === before + 1, `W1 pane count +1 (${before} -> ${after})`);
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 2: Two connections bound to W1 and W2; interleaved spawns.
+// Each must land in its own workspace.
+// ------------------------------------------------------------------
+await scenario(2, "Two connections bound to different workspaces, interleaved spawns", async () => {
+  if (W1 === W2) {
+    console.log("  SKIP — only one workspace available");
+    return;
+  }
+  const cA = await newConn("cA");
+  const cB = await newConn("cB");
+  cA.hello({ workspace_id: W1 });
+  cB.hello({ workspace_id: W2 });
+  await sleep(50);
+
+  const sA1 = await spawnProbe(cA, "scn2-a1");
+  const sB1 = await spawnProbe(cB, "scn2-b1");
+  const sA2 = await spawnProbe(cA, "scn2-a2");
+  const sB2 = await spawnProbe(cB, "scn2-b2");
+  spawnedSessions.push(sA1.session_id, sB1.session_id, sA2.session_id, sB2.session_id);
+
+  ok(sA1.workspace_id === W1 && sA2.workspace_id === W1, "cA spawns landed in W1");
+  ok(sB1.workspace_id === W2 && sB2.workspace_id === W2, "cB spawns landed in W2");
+  cA.close();
+  cB.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 3: Five concurrent connections, three spawns each, fully parallel.
+// ------------------------------------------------------------------
+await scenario(3, "Five concurrent connections, fan-out spawns, no cross-talk", async () => {
+  const N_CONNS = 5;
+  const N_SPAWNS = 3;
+  const conns = await Promise.all(
+    Array.from({ length: N_CONNS }, (_, i) => newConn(`scn3-${i}`)),
+  );
+  // Round-robin bind to W1/W2 so we exercise both workspaces.
+  for (let i = 0; i < conns.length; i++) {
+    conns[i].hello({ workspace_id: i % 2 === 0 ? W1 : W2 });
+  }
+  await sleep(50);
+
+  const all = await Promise.all(
+    conns.flatMap((c, i) =>
+      Array.from({ length: N_SPAWNS }, (_, j) =>
+        spawnProbe(c, `scn3-${i}-${j}`).then((r) => ({ conn: i, ...r })),
+      ),
+    ),
+  );
+  for (const r of all) spawnedSessions.push(r.session_id);
+
+  let bad = 0;
+  for (const r of all) {
+    const expected = r.conn % 2 === 0 ? W1 : W2;
+    if (r.workspace_id !== expected) bad++;
+  }
+  ok(bad === 0, `all ${N_CONNS * N_SPAWNS} spawns landed in expected workspace (bad=${bad})`);
+  for (const c of conns) c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 4: Connection bound to a closed pane → spawn errors clearly.
+// ------------------------------------------------------------------
+await scenario(4, "Bound pane is closed; spawn errors clearly", async () => {
+  const c = await newConn("scn4");
+  c.hello({ pane_id: "ghost-pane-id-that-does-not-exist", workspace_id: W1 });
+  await sleep(50);
+  // Even though pane_id is invalid, workspace_id is, so resolution rule 4
+  // applies and we land in W1. To test the strict rule-1-failure-then-error
+  // path we send a connection bound to a ghost pane and NO workspace_id.
+  c.hello({ pane_id: "ghost-pane", workspace_id: null });
+  await sleep(50);
+  const err = await c.toolError("spawn_agent", {
+    name: "scn4",
+    agent: "custom",
+    command: "bash --noprofile --norc -i",
+  });
+  ok(err !== null, "spawn_agent threw");
+  ok(
+    err && /no pane\/workspace context/.test(err.message),
+    `error mentions missing context (got: ${err?.message})`,
+  );
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 5: pane_id is stable across workspace moves (workspace re-derived).
+// We can't move panes from this harness, but we exercise the resolution by
+// passing a known existing pane_id and observing that it lands in that pane's
+// workspace regardless of the connection's stale workspace_id binding.
+// ------------------------------------------------------------------
+await scenario(5, "pane_id wins over a stale workspace_id binding", async () => {
+  if (W1 === W2) {
+    console.log("  SKIP — only one workspace available");
+    return;
+  }
+  // Find a pane in W2.
+  const w2Panes = await probe.tool("list_panes", { workspace_id: W2 });
+  if (!Array.isArray(w2Panes) || w2Panes.length === 0) {
+    console.log("  SKIP — W2 has no panes");
+    return;
+  }
+  const targetPane = w2Panes[0].id;
+
+  const c = await newConn("scn5");
+  // Bind to a stale workspace (W1) but pass an explicit pane_id in W2.
+  c.hello({ workspace_id: W1 });
+  await sleep(50);
+  const spawn = await spawnProbe(c, "scn5", { pane_id: targetPane });
+  spawnedSessions.push(spawn.session_id);
+  ok(spawn.workspace_id === W2, `spawn followed pane_id into W2 (got ${spawn.workspace_id})`);
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 6: Unbound + no workspace_id arg → error.
+// ------------------------------------------------------------------
+await scenario(6, "Unbound connection; spawn without workspace_id errors", async () => {
+  const c = await newConn("scn6");
+  // Send hello with both null so binding is "explicitly unbound."
+  c.hello({ pane_id: null, workspace_id: null });
+  await sleep(50);
+  const err = await c.toolError("spawn_agent", {
+    name: "scn6",
+    agent: "custom",
+    command: "bash --noprofile --norc -i",
+  });
+  ok(err !== null, "spawn_agent threw");
+  ok(
+    err && /no pane\/workspace context/.test(err.message),
+    `error mentions missing context (got: ${err?.message})`,
+  );
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 7: Unbound + explicit workspace_id → succeeds.
+// ------------------------------------------------------------------
+await scenario(7, "Unbound connection; spawn with explicit workspace_id succeeds", async () => {
+  const c = await newConn("scn7");
+  c.hello({ pane_id: null, workspace_id: null });
+  await sleep(50);
+  const spawn = await spawnProbe(c, "scn7", { workspace_id: W1 });
+  spawnedSessions.push(spawn.session_id);
+  ok(spawn.workspace_id === W1, `landed in W1 (got ${spawn.workspace_id})`);
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 8: Bound to W1, override with workspace_id=W2 → override wins.
+// ------------------------------------------------------------------
+await scenario(8, "Override args win over connection binding", async () => {
+  if (W1 === W2) {
+    console.log("  SKIP — only one workspace available");
+    return;
+  }
+  const c = await newConn("scn8");
+  c.hello({ workspace_id: W1 });
+  await sleep(50);
+  const spawn = await spawnProbe(c, "scn8", { workspace_id: W2 });
+  spawnedSessions.push(spawn.session_id);
+  ok(spawn.workspace_id === W2, `override took precedence (got ${spawn.workspace_id})`);
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 9: dispatch_tasks with mixed bindings.
+// ------------------------------------------------------------------
+await scenario(9, "dispatch_tasks resolves each task independently", async () => {
+  const c = await newConn("scn9");
+  c.hello({ workspace_id: W1 });
+  await sleep(50);
+  const result = await c.tool("dispatch_tasks", {
+    tasks: [
+      { name: "scn9-default", agent: "custom", task: "echo SCN9_A", command: "bash --noprofile --norc -i" },
+      { name: "scn9-explicit", agent: "custom", task: "echo SCN9_B", command: "bash --noprofile --norc -i", workspace_id: W2 },
+    ],
+  });
+  ok(result.dispatched === 2 && result.failed === 0, "both tasks dispatched");
+  for (const s of result.sessions ?? []) if (s.session_id) spawnedSessions.push(s.session_id);
+  const wsForTask = (i) => result.sessions?.[i]?.workspace_id;
+  ok(wsForTask(0) === W1, `task 0 used binding default (W1) (got ${wsForTask(0)})`);
+  if (W1 !== W2) {
+    ok(wsForTask(1) === W2, `task 1 used override (W2) (got ${wsForTask(1)})`);
+  }
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 10: Output buffer caps (smoke; actual cap test is in unit suite).
+// ------------------------------------------------------------------
+await scenario(10, "read_output returns text and a cursor for an alive session", async () => {
+  const c = await newConn("scn10");
+  c.hello({ workspace_id: W1 });
+  await sleep(50);
+  const spawn = await spawnProbe(c, "scn10");
+  spawnedSessions.push(spawn.session_id);
+  await c.tool("send_prompt", {
+    session_id: spawn.session_id,
+    text: "echo SCN10_MARKER",
+  });
+  await sleep(700);
+  const out = await c.tool("read_output", {
+    session_id: spawn.session_id,
+    lines: 200,
+    strip_ansi: true,
+  });
+  ok(typeof out?.output === "string", "read_output returns string");
+  ok(out.output.includes("SCN10_MARKER"), "marker echoed");
+  ok(typeof out?.cursor === "number", "cursor is numeric");
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 11: GUI restart simulation — closing this harness's connection
+// must drop server-side state for that connection without affecting other
+// open connections.
+// ------------------------------------------------------------------
+await scenario(11, "Connection close frees per-connection state, others unaffected", async () => {
+  const cA = await newConn("scn11-a");
+  const cB = await newConn("scn11-b");
+  cA.hello({ workspace_id: W1 });
+  cB.hello({ workspace_id: W1 });
+  await sleep(50);
+  const sA = await spawnProbe(cA, "scn11-a");
+  spawnedSessions.push(sA.session_id);
+  // Drop A.
+  cA.close();
+  await sleep(150);
+  // B must continue working.
+  const sB = await spawnProbe(cB, "scn11-b");
+  spawnedSessions.push(sB.session_id);
+  ok(sB.workspace_id === W1, "second connection still works after first closed");
+  cB.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 12: Force-error mid-flight — server returns clean error to caller.
+// ------------------------------------------------------------------
+await scenario(12, "Tool call against a dead session returns a clean error, no leak", async () => {
+  const c = await newConn("scn12");
+  c.hello({ workspace_id: W1 });
+  await sleep(50);
+  const err = await c.toolError("send_prompt", {
+    session_id: "nope-not-real",
+    text: "x",
+  });
+  ok(err !== null && /not found/.test(err.message), `clean 'not found' error (got: ${err?.message})`);
+  c.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 13: tools/list snapshot — exactly 20 tools.
+// ------------------------------------------------------------------
+await scenario(13, "tools/list returns the documented 20 tools", async () => {
+  const r = await probe.send("tools/list", {});
+  const tools = r.tools ?? [];
+  ok(tools.length === 20, `expected 20 tools, got ${tools.length}`);
+  const required = [
+    "spawn_agent",
+    "list_sessions",
+    "get_session_info",
+    "kill_session",
+    "send_prompt",
+    "send_keys",
+    "read_output",
+    "dispatch_tasks",
+    "render_sidebar",
+    "remove_sidebar_section",
+    "create_preview",
+    "get_agent_context",
+    "get_active_workspace",
+    "list_workspaces",
+    "get_active_pane",
+    "list_panes",
+    "poll_events",
+    "list_dir",
+    "read_file",
+    "file_exists",
+  ];
+  const names = new Set(tools.map((t) => t.name));
+  let missing = 0;
+  for (const r of required) if (!names.has(r)) missing++;
+  ok(missing === 0, `every documented tool is present (missing=${missing})`);
+});
+
+// ------------------------------------------------------------------
+// Scenario 14: get_agent_context returns binding when bound, null when not.
+// ------------------------------------------------------------------
+await scenario(14, "get_agent_context returns binding or null", async () => {
+  const cBound = await newConn("scn14-bound");
+  cBound.hello({ pane_id: "fake-pane", workspace_id: W1, client_pid: 9999 });
+  await sleep(50);
+  const ctxBound = await cBound.tool("get_agent_context", {});
+  ok(ctxBound?.workspace_id === W1, "bound: workspace_id matches hello");
+  ok(ctxBound?.pane_id === "fake-pane", "bound: pane_id matches hello");
+  ok(ctxBound?.client_pid === 9999, "bound: client_pid matches hello");
+  cBound.close();
+
+  const cUnbound = await newConn("scn14-unbound");
+  cUnbound.hello({ pane_id: null, workspace_id: null });
+  await sleep(50);
+  const ctxUnbound = await cUnbound.tool("get_agent_context", {});
+  ok(ctxUnbound?.workspace_id === null && ctxUnbound?.pane_id === null, "unbound: both nulls");
+  cUnbound.close();
+});
+
+// ------------------------------------------------------------------
+// Scenario 15: render_sidebar in W1 is invisible from W2.
+// ------------------------------------------------------------------
+await scenario(15, "render_sidebar is workspace-scoped (per-workspace visibility)", async () => {
+  if (W1 === W2) {
+    console.log("  SKIP — only one workspace available");
+    return;
+  }
+  const cA = await newConn("scn15-a");
+  const cB = await newConn("scn15-b");
+  cA.hello({ workspace_id: W1 });
+  cB.hello({ workspace_id: W2 });
+  await sleep(50);
+  // Render the same section_id from each connection, but they target
+  // different workspaces. Both should succeed without conflict.
+  const a = await cA.tool("render_sidebar", {
+    side: "secondary",
+    section_id: "scn15-shared",
+    title: "in W1",
+    items: [{ id: "x", label: "X" }],
+  });
+  const b = await cB.tool("render_sidebar", {
+    side: "secondary",
+    section_id: "scn15-shared",
+    title: "in W2",
+    items: [{ id: "y", label: "Y" }],
+  });
+  ok(a.workspace_id === W1, "first render landed in W1");
+  ok(b.workspace_id === W2, "second render landed in W2");
+  // Cleanup.
+  await cA.tool("remove_sidebar_section", {
+    side: "secondary",
+    section_id: "scn15-shared",
+  });
+  await cB.tool("remove_sidebar_section", {
+    side: "secondary",
+    section_id: "scn15-shared",
+  });
+  cA.close();
+  cB.close();
+});
+
+// ------------------------------------------------------------------
+// Cleanup: kill all spawned sessions so we don't leave residue in the user's
+// workspaces.
+// ------------------------------------------------------------------
+console.log(`\nCleanup: killing ${spawnedSessions.length} spawned sessions`);
+await killAll(probe, spawnedSessions);
+probe.close();
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (failures.length > 0) {
+  console.log("Failures:");
+  for (const f of failures) console.log(`  - ${f}`);
+}
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes the v1 MCP routing-follows-focus bug. Agent-spawned panes now belong to the agent's host workspace (per the binding contract), not whichever workspace the user happens to be looking at. Implements MCP spec v2 (Spacebase doc [`jzvBxDRrkevx`](https://spacebase.thegnar.com/clients/X_g3eOCQuBTDGbEqQN8d9/projects/bEC8ecacLTsF2y1Q1uHxG/docs/jzvBxDRrkevx)).

The single most important behavior change: **the server never reads `activeWorkspace` (user GUI focus) for routing decisions.** Resolution rules are deterministic — explicit args win, then connection binding, then loud error. No silent fallback.

## What changed

**Transport (Rust):**
- `mcp_bridge.rs`: single-connection `ActiveWriter` replaced with multi-connection registry. Each accept gets a `connection_id`; `mcp-request` / `mcp-response` / `mcp-connection-closed` events all carry it. Per-conn writer channels.
- `run_stdio_shim`: now sends `$/gnar-term/hello` notification on connect with `pane_id` + `workspace_id` from env vars + `client_pid`.
- `spawn_pty`: gains `extra_env` param so callers can inject env vars (used to set `GNAR_TERM_PANE_ID` / `GNAR_TERM_WORKSPACE_ID` on the PTY).

**Webview (TS):**
- `terminal-service.ts::connectPty`: derives the pane's workspace and injects the env vars into every PTY spawn.
- `mcp-server.ts`: per-connection `ConnectionContext` map. New `resolveTarget()` helper implements the spec's resolution rules. Tool handlers take `(args, ctx)`. `spawn_agent`, `dispatch_tasks`, `create_preview`, `render_sidebar`, `remove_sidebar_section` accept optional `workspace_id` / `pane_id`.
- New tool: `get_agent_context` — returns the connection's binding (or null when unbound).
- `extension-sidebar.ts`: sections are now per-workspace; W1 sections invisible from W2.
- `dispatchLog` ring buffer (last 500 UI mutations) records binding/args/resolution/result for debugging.

**Perf fix (6318579) — UI freeze at ~20–30 panes:**
- Without this, every spawn on a bound connection resolved the host pane back to the original binding. `dispatch_tasks` with N tasks wrapped N splits around the *same* pane reference → left-deep tree. `findParentSplit` became O(depth) and Svelte re-rendered the whole tree every spawn → per-spawn cost grew linearly, total O(N²), UI thread saturated at ~20–30 panes.
- `ConnectionContext` now tracks `lastSpawnedPaneId`. `resolveTarget` prefers it over the binding pane, so rapid spawns form a shallow right-chain (matching pre-branch behavior on main). Binding is still honored for the first spawn and whenever the last pane was closed.
- Reproduced in a live dev build: per-spawn latency went 66ms → 8100ms over 15 iterations pre-fix. Unit test covers the resolver preference.

**Spec / docs:**
- Spacebase spec `jzvBxDRrkevx` already updated to v2 (Connection binding § added, multi-connection wire protocol, env var contract, hello handshake, 20-tool surface, 15-scenario test matrix).
- `README.md` MCP section: tool count 19→20, binding contract documented.

## Test plan

Automated suites — all green pre-merge:

- [x] `npm test` — **338/338** vitest pass (was 320; +18 new adversarial tests including the permanent V1 BUG FENCE regression test, all 5 resolution rules, the O(N²) perf fence, per-workspace sidebar visibility, hello handshake parsing)
- [x] `cargo test` — **63/63** pass (was 59; +4 new tests: env-var hello, unbound hello, connection-registry isolation, monotonic IDs, multi-conn UDS round-trip proving no cross-talk)
- [x] `npm run build` — release build green

Manual verification on the new build (run after quitting any old gnar-term, mounting the new `.app`, and launching it):

- [ ] `node tests/mcp-integration.mjs` — smoke harness (29 assertions) returns 0
- [ ] `node tests/mcp-scenarios.mjs` — full 15-scenario matrix from the spec returns 0. Covers:
  - Scenario 1: bound to W1 + GUI focus elsewhere → spawn lands in W1 (the V1 bug)
  - Scenario 2: two connections bound to different workspaces, interleaved spawns → no cross-talk
  - Scenario 3: 5 concurrent connections × 3 spawns each → all land correctly
  - Scenario 4: bound pane closed → clear error, no silent fallback
  - Scenario 5: pane_id stable across workspace moves
  - Scenario 6: unbound + no args → error
  - Scenario 7: unbound + explicit workspace_id → success
  - Scenario 8: override args win over binding
  - Scenario 9: dispatch_tasks resolves each task independently
  - Scenario 10: read_output buffer
  - Scenario 11: connection close frees per-conn state
  - Scenario 12: clean errors on dead session
  - Scenario 13: tools/list returns exactly 20
  - Scenario 14: get_agent_context returns binding or null
  - Scenario 15: render_sidebar is workspace-scoped (W1 invisible from W2)
- [ ] **Perf sanity**: `dispatch_tasks` with 20 bash tasks in one call — all 20 panes appear within ~2s total, UI remains responsive (open/close tabs still work). Pre-fix this wedged the UI thread; post-fix each spawn is constant-time.
- [ ] Real Claude Code session: open Claude in a pane in workspace 2, ask it to spawn an agent. Pane appears in workspace 2, not wherever your eyes happen to be.

## Notes

- The bridge multi-connection rewrite is a fundamental capability gain — single-connection serialization is removed, so concurrent agents are now first-class.
- Permanent regression tests are named with the date and one-line description and must never be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)