### PR TITLE
perf(pty): stream output via IPC Channel instead of emit/listen

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
+use tauri::ipc::{Channel, InvokeResponseBody};
 use tauri::{AppHandle, Emitter};
 
 pub mod mcp_bridge;
@@ -228,12 +229,6 @@ struct AppState {
 }
 
 #[derive(Clone, Serialize)]
-struct PtyOutput {
-    pty_id: u32,
-    data: String, // base64-encoded for efficient IPC
-}
-
-#[derive(Clone, Serialize)]
 struct PtyNotification {
     pty_id: u32,
     text: String,
@@ -256,7 +251,11 @@ fn get_cli_args(args: tauri::State<'_, CliArgs>) -> CliArgs {
     args.inner().clone()
 }
 
-/// Spawn a new PTY with a shell
+/// Spawn a new PTY with a shell. `on_output` is a Tauri v2 IPC Channel that
+/// carries raw PTY bytes to the webview. Using a per-pty Channel with
+/// `InvokeResponseBody::Raw` delivers bytes via the ipc custom-protocol path
+/// (ArrayBuffer in JS) instead of one `evaluateJavaScript` call per chunk, so
+/// bursty output no longer pegs the WebContent main thread on macOS.
 #[tauri::command]
 async fn spawn_pty(
     app: AppHandle,
@@ -264,6 +263,7 @@ async fn spawn_pty(
     cols: u16,
     rows: u16,
     cwd: Option<String>,
+    on_output: Channel<InvokeResponseBody>,
 ) -> Result<u32, String> {
     let pty_system = native_pty_system();
 
@@ -456,15 +456,12 @@ PROMPT_COMMAND="_gnarterm_report_cwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
                         }
                     }
 
-                    // Base64 encode to preserve raw bytes (terminal escape sequences
-                    // contain bytes that aren't valid UTF-8)
-                    let _ = app_handle.emit(
-                        "pty-output",
-                        PtyOutput {
-                            pty_id: id,
-                            data: b64_encode(data),
-                        },
-                    );
+                    if on_output
+                        .send(InvokeResponseBody::Raw(data.to_vec()))
+                        .is_err()
+                    {
+                        break;
+                    }
                 }
                 Err(_) => {
                     let _ = app_handle.emit("pty-exit", PtyExit { pty_id: id });

--- a/src/__tests__/flow-control.test.ts
+++ b/src/__tests__/flow-control.test.ts
@@ -193,6 +193,37 @@ describe("Flow control — rAF batching", () => {
     expect(mockInvoke).toHaveBeenCalledWith("resume_pty", { ptyId: 1 });
   });
 
+  it("pty-exit flushes buffered bytes synchronously before teardown", () => {
+    // Mirrors the exit-grace path in terminal-service.ts: a trailing chunk may
+    // sit in the buffer when pty-exit arrives on a different transport than
+    // the Channel. The handler must drain it to the captured terminal before
+    // clearing flow-control state.
+    emitPtyOutput(1, 100);
+    emitPtyOutput(1, 50);
+
+    const chunks = ptyBuffers.get(1)!;
+    const bytesBuffered = ptyBufferBytes.get(1) || 0;
+    expect(bytesBuffered).toBe(150);
+
+    // Simulate the sync flush step from the pty-exit handler.
+    const merged = new Uint8Array(bytesBuffered);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    mockTerminal.write(merged);
+
+    ptyBuffers.delete(1);
+    ptyBufferBytes.delete(1);
+    ptyFlushScheduled.delete(1);
+    ptyPaused.delete(1);
+
+    expect(mockTerminal.write).toHaveBeenCalledTimes(1);
+    expect((mockTerminal.write.mock.calls[0][0] as Uint8Array).length).toBe(150);
+    expect(ptyBuffers.has(1)).toBe(false);
+  });
+
   it("stress test: sustained high-throughput output (2MB)", () => {
     const TOTAL_CHUNKS = 500;
     const BURST_SIZE = 50;

--- a/src/__tests__/mcp-tee.test.ts
+++ b/src/__tests__/mcp-tee.test.ts
@@ -1,0 +1,67 @@
+/**
+ * MCP output tee tests — the Channel-based PTY pipeline must still feed the
+ * McpOutputBuffer after the `pty-output` emit/listen path was removed.
+ *
+ * Guards R2 from the refactor: if terminal-service stops calling
+ * appendMcpOutput, read_output goes silent for MCP-spawned panes and the
+ * five-concurrent-connections scenario regresses hard.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  appendMcpOutput,
+  registerMcpPty,
+  unregisterMcpPty,
+  getMcpBuffer,
+} from "../lib/services/mcp-output-buffer";
+
+function encode(s: string): Uint8Array {
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  return bytes;
+}
+
+describe("appendMcpOutput", () => {
+  beforeEach(() => {
+    unregisterMcpPty(42);
+    unregisterMcpPty(7);
+  });
+
+  it("buffers bytes for registered ptyIds", () => {
+    registerMcpPty(42);
+    appendMcpOutput(42, encode("hello\nworld\n"));
+
+    const buf = getMcpBuffer(42);
+    expect(buf).toBeDefined();
+    const r = buf!.read({ lines: 10 });
+    expect(r.output).toContain("hello");
+    expect(r.output).toContain("world");
+  });
+
+  it("is a cheap no-op for unregistered ptyIds", () => {
+    expect(() => appendMcpOutput(999, encode("should be ignored"))).not.toThrow();
+    expect(getMcpBuffer(999)).toBeUndefined();
+  });
+
+  it("preserves byte values 0-255 through the decode path", () => {
+    registerMcpPty(7);
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    appendMcpOutput(7, bytes);
+
+    const r = getMcpBuffer(7)!.read({ lines: 1000, strip_ansi: false });
+    // Raw decode should include every non-LF/CR byte as a character.
+    // The buffer splits on \n and \r so we only check length is plausible.
+    expect(r.total_lines).toBeGreaterThan(0);
+  });
+
+  it("handles multiple sequential chunks", () => {
+    registerMcpPty(42);
+    appendMcpOutput(42, encode("chunk one "));
+    appendMcpOutput(42, encode("chunk two "));
+    appendMcpOutput(42, encode("chunk three"));
+
+    const r = getMcpBuffer(42)!.read({ lines: 10 });
+    expect(r.output).toBe("chunk one chunk two chunk three");
+  });
+});

--- a/src/__tests__/startup-command.test.ts
+++ b/src/__tests__/startup-command.test.ts
@@ -10,6 +10,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
+  Channel: vi.fn().mockImplementation(() => ({
+    onmessage: undefined,
+  })),
 }));
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),

--- a/src/lib/services/mcp-output-buffer.ts
+++ b/src/lib/services/mcp-output-buffer.ts
@@ -1,14 +1,11 @@
 /**
  * Programmatic output buffer for MCP-spawned terminal sessions.
  *
- * Taps into the existing Tauri `pty-output` event stream (the same stream
- * terminal-service listens to for xterm rendering) and maintains a parallel
- * plain-text ring buffer that MCP `read_output` calls can query. Only ptyIds
- * explicitly registered via registerMcpPty() are buffered — plain user-spawned
- * terminals pay nothing for this.
+ * terminal-service routes each PTY chunk through `appendMcpOutput()` after
+ * writing to xterm; this maintains a parallel plain-text ring buffer that MCP
+ * `read_output` calls can query. Only ptyIds explicitly registered via
+ * `registerMcpPty()` are buffered — plain user-spawned terminals pay nothing.
  */
-import { listen } from "@tauri-apps/api/event";
-
 const MAX_LINES_DEFAULT = 5000;
 const ANSI_REGEX =
   // eslint-disable-next-line no-control-regex
@@ -102,7 +99,6 @@ export class McpOutputBuffer {
 }
 
 const buffers = new Map<number, McpOutputBuffer>();
-let listenerInstalled = false;
 
 export function registerMcpPty(ptyId: number): McpOutputBuffer {
   if (ptyId < 0) {
@@ -125,22 +121,16 @@ export function getMcpBuffer(ptyId: number): McpOutputBuffer | undefined {
 }
 
 /**
- * Install the Tauri pty-output listener. Safe to call multiple times — the
- * listener is installed exactly once per page load.
+ * Feed raw PTY bytes into the per-pty MCP buffer, if one is registered.
+ * Cheap no-op for ptys that no MCP caller is observing. Called from
+ * terminal-service's channel onmessage handler.
  */
-export async function installMcpOutputListener(): Promise<void> {
-  if (listenerInstalled) return;
-  listenerInstalled = true;
-  await listen<{ pty_id: number; data: string }>("pty-output", (event) => {
-    const { pty_id, data } = event.payload;
-    const buffer = buffers.get(pty_id);
-    if (!buffer) return;
-    // data is base64-encoded raw bytes, matching terminal-service's decode
-    const bin = atob(data);
-    let text = "";
-    for (let i = 0; i < bin.length; i++) {
-      text += String.fromCharCode(bin.charCodeAt(i));
-    }
-    buffer.append(text);
-  });
+export function appendMcpOutput(ptyId: number, bytes: Uint8Array): void {
+  const buffer = buffers.get(ptyId);
+  if (!buffer) return;
+  let text = "";
+  for (let i = 0; i < bytes.length; i++) {
+    text += String.fromCharCode(bytes[i]);
+  }
+  buffer.append(text);
 }

--- a/src/lib/services/mcp-server.ts
+++ b/src/lib/services/mcp-server.ts
@@ -35,7 +35,6 @@ import { createTerminalSurface } from "../terminal-service";
 import { createWorkspace } from "./workspace-service";
 import { safeFocus } from "./service-helpers";
 import {
-  installMcpOutputListener,
   registerMcpPty,
   unregisterMcpPty,
   getMcpBuffer,
@@ -982,9 +981,6 @@ export async function initMcpServer(): Promise<void> {
   if (setting === "off") {
     return;
   }
-
-  // pty-output taps (for McpOutputBuffer)
-  await installMcpOutputListener();
 
   // Bridge pty-exit to session status updates.
   await listen<{ pty_id: number }>("pty-exit", (event) => {

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -10,8 +10,9 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, Channel } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { appendMcpOutput } from "./services/mcp-output-buffer";
 import { readText as clipboardRead, writeText as clipboardWrite } from "@tauri-apps/plugin-clipboard-manager";
 import { get } from "svelte/store";
 import { xtermTheme } from "./stores/theme";
@@ -94,6 +95,29 @@ function scheduleFlush(ptyId: number) {
   requestAnimationFrame(() => flushPtyBuffer(ptyId));
 }
 
+/** Append a raw PTY chunk to the per-pty buffer, tee it to the MCP buffer
+ *  if one is registered, and schedule an rAF flush to xterm.js. Exported for
+ *  tests; in production this is called from the Channel onmessage handler
+ *  created in connectPty(). */
+export function handlePtyChunk(ptyId: number, bytes: Uint8Array): void {
+  let chunks = ptyBuffers.get(ptyId);
+  if (!chunks) {
+    chunks = [];
+    ptyBuffers.set(ptyId, chunks);
+  }
+  chunks.push(bytes);
+  const buffered = (ptyBufferBytes.get(ptyId) || 0) + bytes.length;
+  ptyBufferBytes.set(ptyId, buffered);
+
+  if (!ptyPaused.has(ptyId) && buffered >= BUFFER_HIGH_WATER) {
+    ptyPaused.add(ptyId);
+    invoke("pause_pty", { ptyId }).catch(() => {});
+  }
+
+  appendMcpOutput(ptyId, bytes);
+  scheduleFlush(ptyId);
+}
+
 function flushPtyBuffer(ptyId: number) {
   ptyFlushScheduled.delete(ptyId);
   const chunks = ptyBuffers.get(ptyId);
@@ -149,36 +173,26 @@ export async function setupListeners() {
       }
     }, { capture: true });
   }
-  await listen<{ pty_id: number; data: string }>("pty-output", (event) => {
-    const { pty_id, data } = event.payload;
-    // Decode base64 to preserve raw terminal escape sequences
-    const bin = atob(data);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-
-    // Append to buffer
-    let chunks = ptyBuffers.get(pty_id);
-    if (!chunks) {
-      chunks = [];
-      ptyBuffers.set(pty_id, chunks);
-    }
-    chunks.push(bytes);
-    const buffered = (ptyBufferBytes.get(pty_id) || 0) + bytes.length;
-    ptyBufferBytes.set(pty_id, buffered);
-
-    // Pause PTY reader if buffer is getting large
-    if (!ptyPaused.has(pty_id) && buffered >= BUFFER_HIGH_WATER) {
-      ptyPaused.add(pty_id);
-      invoke("pause_pty", { ptyId: pty_id }).catch(() => {});
-    }
-
-    // Schedule a flush on the next animation frame
-    scheduleFlush(pty_id);
-  });
-
   await listen<{ pty_id: number }>("pty-exit", (event) => {
     const { pty_id } = event.payload;
-    // Clean up flow control state for the dead PTY
+    // pty-exit arrives via emit while chunks arrive via Channel — different
+    // transports, so a trailing chunk may already be in the per-pty buffer.
+    // Flush it synchronously to the surface's terminal before we tear down
+    // flow-control state and remove the surface from the workspace tree.
+    const chunks = ptyBuffers.get(pty_id);
+    const bytesBuffered = ptyBufferBytes.get(pty_id) || 0;
+    if (chunks && chunks.length > 0 && bytesBuffered > 0) {
+      const surface = findSurfaceByPty(pty_id);
+      if (surface) {
+        const merged = new Uint8Array(bytesBuffered);
+        let offset = 0;
+        for (const chunk of chunks) {
+          merged.set(chunk, offset);
+          offset += chunk.length;
+        }
+        surface.terminal.write(merged);
+      }
+    }
     ptyBuffers.delete(pty_id);
     ptyBufferBytes.delete(pty_id);
     ptyFlushScheduled.delete(pty_id);
@@ -605,8 +619,33 @@ export async function connectPty(surface: TerminalSurface, cwd?: string): Promis
   const cols = surface.terminal.cols;
   const rows = surface.terminal.rows;
   const effectiveCwd = surface.cwd || cwd || null;
+
+  // Per-pty Channel carries raw output bytes from the Rust reader thread to
+  // xterm.js. Holds a pending ptyId in a closure so chunks delivered before
+  // spawn_pty resolves are still routable once the id is known.
+  let resolvedPtyId = -1;
+  const pending: Uint8Array[] = [];
+  const onOutput = new Channel<ArrayBuffer>();
+  onOutput.onmessage = (buf) => {
+    const bytes = new Uint8Array(buf);
+    if (resolvedPtyId < 0) {
+      pending.push(bytes);
+      return;
+    }
+    handlePtyChunk(resolvedPtyId, bytes);
+  };
+
   try {
-    surface.ptyId = await invoke<number>("spawn_pty", { cols, rows, cwd: effectiveCwd });
+    const ptyId = await invoke<number>("spawn_pty", {
+      cols,
+      rows,
+      cwd: effectiveCwd,
+      onOutput,
+    });
+    surface.ptyId = ptyId;
+    resolvedPtyId = ptyId;
+    for (const bytes of pending) handlePtyChunk(ptyId, bytes);
+    pending.length = 0;
   } catch (err) {
     console.error("Failed to spawn PTY:", err);
     surface.ptyId = -1;


### PR DESCRIPTION
## Summary
- Replace the global `pty-output` event stream with a per-pty Tauri v2 `Channel<Raw>` that delivers raw bytes as `ArrayBuffer` via the ipc custom protocol, bypassing `evaluateJavaScript` and unblocking the WebContent main thread on macOS during bursty output.
- Fold `McpOutputBuffer` onto the same pipeline — terminal-service tees each chunk into `appendMcpOutput()` instead of the buffer running its own event listener.
- Drain the trailing chunk synchronously on `pty-exit` so the exit transport (emit) can't race the data transport (Channel) and lose bytes at the end of short-lived commands.

## Test plan
- [x] `npm test` — 325/325 pass, including new `mcp-tee.test.ts` (4 cases) and the `pty-exit` sync-flush case in `flow-control.test.ts`.
- [x] `npm run build` — release build completes; `GnarTerm.app` produced at `src-tauri/target/release/bundle/macos/GnarTerm.app`.
- [x] Launch release `.app`; open a shell pane and verify normal keystroke/render — verified via MCP bash session.
- [x] `yes | head -n 200000` — 200000 lines streamed without hang; UI remains responsive.
- [x] `printf 'x%.0s' {1..2000000}; echo TAIL_OK_END` — full 2M chars + `TAIL_OK_END` delivered, no truncation from exit race.
- [x] MCP `spawn_agent` + `read_output` — text appears via the `appendMcpOutput` tee (every verification step in this plan exercised it).
- [x] Five panes streaming simultaneously — no cross-talk; each pane shows only its own prefix (BBB/CCC/DDD/EEE isolation).
- [x] Pane exits mid-output — `LAST_LINE_BEFORE_EXIT` visible after process exit (exit-flush path verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)