### PR TITLE
feat(sidebar): project header polish + rail grips + fullscreen alignment

### DIFF
--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -986,7 +986,8 @@ describe("PrimarySidebar", () => {
       handler: noop,
     });
     render(PrimarySidebar, { props: sidebarProps });
-    expect(screen.getByText("New Workspace")).toBeTruthy();
+    expect(screen.getByText("+ New")).toBeTruthy();
+    expect(screen.getByText("Workspaces")).toBeTruthy();
     expect(screen.queryByTitle("Toggle Primary Sidebar (⌘B)")).toBeNull();
     expect(screen.queryByTitle("Toggle Secondary Sidebar")).toBeNull();
   });
@@ -1067,7 +1068,7 @@ describe("PrimarySidebar", () => {
       props: { ...sidebarProps },
     });
     // Only 1 button (main), no caret
-    const splitContainer = screen.getByText("New Workspace").closest("div")!;
+    const splitContainer = screen.getByText("+ New").closest("div")!;
     const buttons = splitContainer.querySelectorAll("button");
     expect(buttons.length).toBe(1);
   });
@@ -1115,8 +1116,9 @@ describe("PrimarySidebar", () => {
     render(PrimarySidebar, { props: sidebarProps });
     // Sidebar-zone action renders as a button in the top row
     expect(screen.getByTitle("New Project")).toBeTruthy();
-    // It should NOT appear in the workspace dropdown
-    expect(screen.getByText("New Workspace")).toBeTruthy();
+    // Main split button now reads "+ New"; section label reads "Workspaces"
+    expect(screen.getByText("+ New")).toBeTruthy();
+    expect(screen.getByText("Workspaces")).toBeTruthy();
   });
 
   it("dropdown includes default action when workspace-zone extensions exist", async () => {
@@ -1136,17 +1138,15 @@ describe("PrimarySidebar", () => {
       handler: noop,
     });
     render(PrimarySidebar, { props: sidebarProps });
-    // Open the dropdown — use getAllByText since "New Workspace" appears
-    // both as the main button label and as a dropdown entry
-    const allNewWs = screen.getAllByText("New Workspace");
-    const caretBtn = allNewWs[0]
+    // Open the dropdown by clicking the caret next to the "+ New" main button.
+    // "New Workspace" is present only inside the dropdown menu items.
+    const mainBtn = screen.getByText("+ New");
+    const caretBtn = mainBtn
       .closest("div")!
       .querySelector("button:last-child") as HTMLElement;
     await fireEvent.click(caretBtn);
     // Dropdown includes both the default action and the extension action
-    expect(screen.getAllByText("New Workspace").length).toBeGreaterThanOrEqual(
-      2,
-    );
+    expect(screen.getByText("New Workspace")).toBeTruthy();
     expect(screen.getByText("New Worktree")).toBeTruthy();
   });
 });

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -835,7 +835,7 @@ describe("WorkspaceItem", () => {
     expect(sidebarSource).toContain("dragActive");
   });
 
-  it("applies accentColor as border-left when provided", () => {
+  it("applies accentColor as DragGrip railColor when provided", () => {
     const ws = makeWorkspace("ws1", "Accent WS");
     render(WorkspaceItem, {
       props: {
@@ -856,21 +856,19 @@ describe("WorkspaceItem", () => {
     );
     expect(source).toContain("export let accentColor");
     expect(source).toContain("accentColor");
-    // The border-left logic uses accentColor when provided
-    expect(source).toMatch(/border-left:.*accentColor/s);
+    // The DragGrip rail uses accentColor when provided
+    expect(source).toMatch(/railColor=\{accentColor.*\$theme\.accent\}/s);
   });
 
-  it("uses accentColor or theme.accent for border, dimmed when inactive", () => {
+  it("uses accentColor or theme.accent for DragGrip rail, dimmed when inactive", () => {
     const source = readFileSync(
       "src/lib/components/WorkspaceItem.svelte",
       "utf-8",
     );
-    // Active uses accentColor or falls back to theme.accent
-    expect(source).toContain("accentColor || $theme.accent");
-    // Inactive uses color-mix to dim
-    expect(source).toContain(
-      "color-mix(in srgb, ${accentColor || $theme.accent} 35%",
-    );
+    // railColor uses accentColor falling back to theme.accent
+    expect(source).toContain("accentColor ?? $theme.accent");
+    // railOpacity is 1 when active, dimmed otherwise
+    expect(source).toContain("railOpacity={isActive ? 1 : 0.35}");
   });
 
   it("passes accentColor through WorkspaceListView", () => {

--- a/src/__tests__/workspace-grip.test.ts
+++ b/src/__tests__/workspace-grip.test.ts
@@ -79,8 +79,11 @@ describe("WorkspaceItem drag grip", () => {
     await fireEvent.mouseDown(row);
     // Mousedown on body bubbles, but the grip handler should not fire
     expect(onGripMouseDown).not.toHaveBeenCalled();
-    // Click on body still selects
-    await fireEvent.click(row);
+    // Click on the inner content div (not the grip) still selects
+    const contentDiv = container.querySelector(
+      "[data-drag-idx] > div:last-child",
+    ) as HTMLElement;
+    await fireEvent.click(contentDiv);
     expect(onSelect).toHaveBeenCalled();
   });
 });

--- a/src/extensions/project-scope/ProjectSectionContent.svelte
+++ b/src/extensions/project-scope/ProjectSectionContent.svelte
@@ -9,11 +9,15 @@
   import { dashboardProjectId$ } from "./index";
 
   export let projectId: string;
+  export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
+  export let gripActive = false;
+
+  let hovered = false;
 
   const api = getContext<ExtensionAPI>(EXTENSION_API_KEY);
   const theme = api.theme;
   const workspacesStore = api.workspaces;
-  const { WorkspaceListView, SplitButton } = api.getComponents();
+  const { WorkspaceListView, SplitButton, DragGrip } = api.getComponents();
 
   let project: ProjectEntry | undefined;
   let stateVersion = 0;
@@ -75,12 +79,25 @@
 {#if project}
   <div style="padding: 2px 0; font-size: 12px; color: {$theme.fg};">
     <!-- Project header: colored dot + name (clickable → dashboard) + SplitButton -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       style="
+        position: relative;
         padding: 6px 12px; display: flex; align-items: center;
         justify-content: space-between; gap: 8px;
       "
+      on:mouseenter={() => (hovered = true)}
+      on:mouseleave={() => (hovered = false)}
     >
+      {#if onGripMouseDown}
+        <svelte:component
+          this={DragGrip as Component}
+          theme={$theme}
+          visible={hovered || gripActive}
+          onMouseDown={onGripMouseDown}
+          ariaLabel="Drag project to reorder"
+        />
+      {/if}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div

--- a/src/extensions/project-scope/ProjectSectionContent.svelte
+++ b/src/extensions/project-scope/ProjectSectionContent.svelte
@@ -74,21 +74,39 @@
 
 {#if project}
   <div style="padding: 2px 0; font-size: 12px; color: {$theme.fg};">
-    <!-- Project header with SplitButton matching Workspaces section -->
+    <!-- Project header: colored dot + name (clickable → dashboard) + SplitButton -->
     <div
       style="
-        padding: 6px 12px; font-size: 10px; font-weight: 600;
-        letter-spacing: 0.5px; text-transform: uppercase;
-        color: {$theme.fgDim};
-        display: flex; align-items: center; justify-content: space-between;
-        border-left: 3px solid {project.color};
+        padding: 6px 12px; display: flex; align-items: center;
+        justify-content: space-between; gap: 8px;
       "
     >
-      <span>{project.name}</span>
-      {#if coreAction}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        style="
+          display: flex; align-items: center; gap: 8px;
+          min-width: 0; flex: 1; cursor: pointer;
+        "
+        on:click={() => {
+          if (project) dashboardProjectId$.set(project.id);
+        }}
+      >
         <span
-          style="text-transform: none; letter-spacing: normal; font-weight: 400;"
+          style="
+            width: 8px; height: 8px; border-radius: 50%;
+            background: {project.color}; flex-shrink: 0;
+          "
+        ></span>
+        <span
+          style="
+            font-size: 13px; font-weight: 600; color: {$theme.fg};
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+          ">{project.name}</span
         >
+      </div>
+      {#if coreAction}
+        <span style="flex-shrink: 0;">
           <svelte:component
             this={SplitButton as Component}
             label="+ New"
@@ -98,28 +116,6 @@
           />
         </span>
       {/if}
-    </div>
-
-    <!-- Dashboard link -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      style="
-        padding: 3px 12px 4px; font-size: 10px; color: {$theme.fgDim};
-        cursor: pointer; border-left: 3px solid {project.color};
-      "
-      on:click={() => {
-        if (project) dashboardProjectId$.set(project.id);
-      }}
-    >
-      <span
-        style="
-          border: 1px solid {$theme.border}; border-radius: 4px;
-          padding: 2px 8px; display: inline-block;
-        "
-      >
-        Dashboard
-      </span>
     </div>
 
     <!-- Workspace list -->

--- a/src/extensions/project-scope/ProjectSectionContent.svelte
+++ b/src/extensions/project-scope/ProjectSectionContent.svelte
@@ -9,15 +9,11 @@
   import { dashboardProjectId$ } from "./index";
 
   export let projectId: string;
-  export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
-  export let gripActive = false;
-
-  let hovered = false;
 
   const api = getContext<ExtensionAPI>(EXTENSION_API_KEY);
   const theme = api.theme;
   const workspacesStore = api.workspaces;
-  const { WorkspaceListView, SplitButton, DragGrip } = api.getComponents();
+  const { WorkspaceListView, SplitButton } = api.getComponents();
 
   let project: ProjectEntry | undefined;
   let stateVersion = 0;
@@ -79,25 +75,12 @@
 {#if project}
   <div style="padding: 2px 0; font-size: 12px; color: {$theme.fg};">
     <!-- Project header: colored dot + name (clickable → dashboard) + SplitButton -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       style="
-        position: relative;
         padding: 6px 12px; display: flex; align-items: center;
         justify-content: space-between; gap: 8px;
       "
-      on:mouseenter={() => (hovered = true)}
-      on:mouseleave={() => (hovered = false)}
     >
-      {#if onGripMouseDown}
-        <svelte:component
-          this={DragGrip as Component}
-          theme={$theme}
-          visible={hovered || gripActive}
-          onMouseDown={onGripMouseDown}
-          ariaLabel="Drag project to reorder"
-        />
-      {/if}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div

--- a/src/extensions/project-scope/ProjectsContainer.svelte
+++ b/src/extensions/project-scope/ProjectsContainer.svelte
@@ -10,7 +10,7 @@
   const api = getContext<ExtensionAPI>(EXTENSION_API_KEY);
   const theme = api.theme;
   const workspacesStore = api.workspaces;
-  const { SplitButton, DragGrip } = api.getComponents();
+  const { SplitButton } = api.getComponents();
 
   let stateVersion = 0;
   api.on("extension:project:state-changed", () => {
@@ -43,7 +43,6 @@
   let sourceIdx: number | null = null;
   let indicator: { idx: number; edge: "before" | "after" } | null = null;
   let active = false;
-  let hoverIdx: number | null = null;
 
   const reorder = api.createDragReorder({
     dataAttr: "project-drag-idx",
@@ -104,23 +103,17 @@
           style="height: 2px; background: {$theme.accent}; margin: 0 12px; border-radius: 1px;"
         ></div>
       {/if}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         data-project-drag-idx={i}
         style="position: relative; opacity: {active && sourceIdx === i
           ? 0.4
           : 1};"
-        on:mouseenter={() => (hoverIdx = i)}
-        on:mouseleave={() => (hoverIdx = null)}
       >
-        <svelte:component
-          this={DragGrip as Component}
-          theme={$theme}
-          visible={hoverIdx === i || (active && sourceIdx === i)}
-          onMouseDown={(e: MouseEvent) => startDrag(e, i)}
-          ariaLabel="Drag project to reorder"
+        <ProjectSectionContent
+          projectId={project.id}
+          onGripMouseDown={(e) => startDrag(e, i)}
+          gripActive={active && sourceIdx === i}
         />
-        <ProjectSectionContent projectId={project.id} />
       </div>
       {#if indicator?.idx === i && indicator.edge === "after"}
         <div

--- a/src/extensions/project-scope/ProjectsContainer.svelte
+++ b/src/extensions/project-scope/ProjectsContainer.svelte
@@ -10,7 +10,7 @@
   const api = getContext<ExtensionAPI>(EXTENSION_API_KEY);
   const theme = api.theme;
   const workspacesStore = api.workspaces;
-  const { SplitButton } = api.getComponents();
+  const { SplitButton, DragGrip } = api.getComponents();
 
   let stateVersion = 0;
   api.on("extension:project:state-changed", () => {
@@ -40,6 +40,7 @@
     orderedProjects = next;
   }
 
+  let projectHoverIdx: number | null = null;
   let sourceIdx: number | null = null;
   let indicator: { idx: number; edge: "before" | "after" } | null = null;
   let active = false;
@@ -103,17 +104,31 @@
           style="height: 2px; background: {$theme.accent}; margin: 0 12px; border-radius: 1px;"
         ></div>
       {/if}
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         data-project-drag-idx={i}
-        style="position: relative; opacity: {active && sourceIdx === i
-          ? 0.4
-          : 1};"
+        style="
+          display: flex;
+          opacity: {active && sourceIdx === i ? 0.4 : 1};
+        "
       >
-        <ProjectSectionContent
-          projectId={project.id}
-          onGripMouseDown={(e) => startDrag(e, i)}
-          gripActive={active && sourceIdx === i}
-        />
+        <div
+          on:mouseenter={() => (projectHoverIdx = i)}
+          on:mouseleave={() => (projectHoverIdx = null)}
+          style="flex-shrink: 0; align-self: stretch; display: flex;"
+        >
+          <svelte:component
+            this={DragGrip as Component}
+            theme={$theme}
+            visible={projectHoverIdx === i || (active && sourceIdx === i)}
+            onMouseDown={(e: MouseEvent) => startDrag(e, i)}
+            ariaLabel="Drag project to reorder"
+            railColor={project.color}
+          />
+        </div>
+        <div style="flex: 1; min-width: 0;">
+          <ProjectSectionContent projectId={project.id} />
+        </div>
       </div>
       {#if indicator?.idx === i && indicator.edge === "after"}
         <div

--- a/src/extensions/project-scope/ProjectsContainer.svelte
+++ b/src/extensions/project-scope/ProjectsContainer.svelte
@@ -84,16 +84,19 @@
   class="projects-container"
   style="padding: 2px 0; font-size: 12px; color: {$theme.fg};"
 >
-  <div style="padding: 4px 8px;">
+  <div style="padding: 4px 8px; display: flex; align-items: center; gap: 8px;">
+    <span
+      style="font-size: 13px; font-weight: 600; color: {$theme.fg}; flex: 1; min-width: 0;"
+      >Projects</span
+    >
     <svelte:component
       this={SplitButton as Component}
-      label="New Project"
+      label="+ New"
       onMainClick={() => {
         void onCreateProject();
       }}
       dropdownItems={[]}
       {theme}
-      fullWidth={true}
     />
   </div>
 

--- a/src/extensions/project-scope/__tests__/project-scope-extension.test.ts
+++ b/src/extensions/project-scope/__tests__/project-scope-extension.test.ts
@@ -97,6 +97,19 @@ describe("Project Scope included extension", () => {
     expect(sections[0].label).toBe("Projects");
   });
 
+  it("registers the projects sidebar section with showLabel: false", async () => {
+    registerExtension(projectScopeManifest, registerProjectScopeExtension);
+    await activateExtension("project-scope");
+    const sections = get(sidebarSectionStore);
+    const projectsSection = sections.find(
+      (s: { id: string }) => s.id === "project-scope:projects",
+    );
+    expect(projectsSection).toBeDefined();
+    expect(
+      (projectsSection as unknown as { showLabel: boolean }).showLabel,
+    ).toBe(false);
+  });
+
   it("Projects section exposes onCreateProject prop to the container", async () => {
     registerExtension(projectScopeManifest, registerProjectScopeExtension);
     await activateExtension("project-scope");

--- a/src/extensions/project-scope/__tests__/project-section-content.test.ts
+++ b/src/extensions/project-scope/__tests__/project-section-content.test.ts
@@ -13,14 +13,23 @@ const CONTAINER_SOURCE = readFileSync(
 );
 
 describe("ProjectsContainer template", () => {
-  it("no longer renders DragGrip at the outer per-project wrapper", () => {
-    expect(CONTAINER_SOURCE).not.toMatch(/DragGrip/);
+  it("renders a DragGrip in the per-project handle column", () => {
+    expect(CONTAINER_SOURCE).toMatch(/this=\{DragGrip as Component\}/);
   });
 
-  it("forwards onGripMouseDown + gripActive to ProjectSectionContent", () => {
+  it("passes railColor={project.color} to the per-project DragGrip", () => {
     const oneLine = CONTAINER_SOURCE.replace(/\s+/g, " ");
-    expect(oneLine).toMatch(/onGripMouseDown=\{\(e\) => startDrag\(e, i\)\}/);
-    expect(oneLine).toMatch(/gripActive=\{active && sourceIdx === i\}/);
+    expect(oneLine).toMatch(/railColor=\{project\.color\}/);
+  });
+
+  it("scopes mouseenter/mouseleave to the handle column (not the outer wrapper or content)", () => {
+    const oneLine = CONTAINER_SOURCE.replace(/\s+/g, " ");
+    // There must be exactly ONE set of mouseenter/mouseleave handlers in the per-project block, on the handle div.
+    const enterMatches = oneLine.match(
+      /on:mouseenter=\{\(\) => \(projectHoverIdx = i\)\}/g,
+    );
+    expect(enterMatches).not.toBeNull();
+    expect(enterMatches!.length).toBe(1);
   });
 });
 
@@ -69,21 +78,5 @@ describe("ProjectSectionContent template", () => {
     expect(oneLine).toMatch(
       /font-size:\s*13px;\s*font-weight:\s*600;\s*color:\s*\{\$theme\.fg\}/,
     );
-  });
-
-  it("renders DragGrip inside the project header (not wrapping the whole project)", () => {
-    // Search within the template section only (after </script>) so we
-    // don't match the destructure line where WorkspaceListView comes first.
-    const templateSection = SOURCE.slice(SOURCE.indexOf("</script>"));
-    const gripIdx = templateSection.indexOf("DragGrip");
-    const listIdx = templateSection.indexOf("WorkspaceListView");
-    expect(gripIdx).toBeGreaterThan(-1);
-    expect(listIdx).toBeGreaterThan(-1);
-    expect(gripIdx).toBeLessThan(listIdx);
-  });
-
-  it("exposes onGripMouseDown and gripActive props", () => {
-    expect(SOURCE).toMatch(/export let onGripMouseDown:/);
-    expect(SOURCE).toMatch(/export let gripActive/);
   });
 });

--- a/src/extensions/project-scope/__tests__/project-section-content.test.ts
+++ b/src/extensions/project-scope/__tests__/project-section-content.test.ts
@@ -7,6 +7,23 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 
+const CONTAINER_SOURCE = readFileSync(
+  "src/extensions/project-scope/ProjectsContainer.svelte",
+  "utf-8",
+);
+
+describe("ProjectsContainer template", () => {
+  it("no longer renders DragGrip at the outer per-project wrapper", () => {
+    expect(CONTAINER_SOURCE).not.toMatch(/DragGrip/);
+  });
+
+  it("forwards onGripMouseDown + gripActive to ProjectSectionContent", () => {
+    const oneLine = CONTAINER_SOURCE.replace(/\s+/g, " ");
+    expect(oneLine).toMatch(/onGripMouseDown=\{\(e\) => startDrag\(e, i\)\}/);
+    expect(oneLine).toMatch(/gripActive=\{active && sourceIdx === i\}/);
+  });
+});
+
 const SOURCE = readFileSync(
   "src/extensions/project-scope/ProjectSectionContent.svelte",
   "utf-8",
@@ -52,5 +69,21 @@ describe("ProjectSectionContent template", () => {
     expect(oneLine).toMatch(
       /font-size:\s*13px;\s*font-weight:\s*600;\s*color:\s*\{\$theme\.fg\}/,
     );
+  });
+
+  it("renders DragGrip inside the project header (not wrapping the whole project)", () => {
+    // Search within the template section only (after </script>) so we
+    // don't match the destructure line where WorkspaceListView comes first.
+    const templateSection = SOURCE.slice(SOURCE.indexOf("</script>"));
+    const gripIdx = templateSection.indexOf("DragGrip");
+    const listIdx = templateSection.indexOf("WorkspaceListView");
+    expect(gripIdx).toBeGreaterThan(-1);
+    expect(listIdx).toBeGreaterThan(-1);
+    expect(gripIdx).toBeLessThan(listIdx);
+  });
+
+  it("exposes onGripMouseDown and gripActive props", () => {
+    expect(SOURCE).toMatch(/export let onGripMouseDown:/);
+    expect(SOURCE).toMatch(/export let gripActive/);
   });
 });

--- a/src/extensions/project-scope/__tests__/project-section-content.test.ts
+++ b/src/extensions/project-scope/__tests__/project-section-content.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Source-scanning tests for ProjectSectionContent.svelte — verifies
+ * the template contract after the project header polish refactor:
+ * colored dot, clickable title → dashboard, no dashboard link row,
+ * no legacy border/typography.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+const SOURCE = readFileSync(
+  "src/extensions/project-scope/ProjectSectionContent.svelte",
+  "utf-8",
+);
+
+describe("ProjectSectionContent template", () => {
+  it("does not render the legacy border-left accent on the header", () => {
+    expect(SOURCE).not.toMatch(/border-left:\s*3px solid \{project\.color\}/);
+  });
+
+  it("does not use uppercase/letter-spacing/10px typography for the name", () => {
+    expect(SOURCE).not.toMatch(/text-transform:\s*uppercase/);
+    expect(SOURCE).not.toMatch(/letter-spacing:\s*0\.5px/);
+    expect(SOURCE).not.toMatch(/font-size:\s*10px/);
+  });
+
+  it("renders an 8×8 colored dot backed by project.color", () => {
+    // Normalize whitespace for style-attr matching.
+    const oneLine = SOURCE.replace(/\s+/g, " ");
+    expect(oneLine).toMatch(
+      /width:\s*8px;\s*height:\s*8px;\s*border-radius:\s*50%;\s*background:\s*\{project\.color\}/,
+    );
+  });
+
+  it("makes the header name clickable and opens the project dashboard", () => {
+    const oneLine = SOURCE.replace(/\s+/g, " ");
+    // Click handler sets dashboardProjectId$ for the current project.
+    expect(oneLine).toMatch(
+      /on:click=\{\(\) => \{ if \(project\) dashboardProjectId\$\.set\(project\.id\); \}\}/,
+    );
+  });
+
+  it("does not render a separate 'Dashboard' link row", () => {
+    expect(SOURCE).not.toMatch(/<!--\s*Dashboard link\s*-->/);
+    // The old row rendered the literal word "Dashboard" as a boxed span.
+    // Verify no top-level Dashboard label remains in the template body.
+    const withoutImports = SOURCE.replace(/<script[\s\S]*?<\/script>/, "");
+    expect(withoutImports).not.toContain("Dashboard");
+  });
+
+  it("uses 13px / 600 / theme.fg typography for the project name", () => {
+    const oneLine = SOURCE.replace(/\s+/g, " ");
+    expect(oneLine).toMatch(
+      /font-size:\s*13px;\s*font-weight:\s*600;\s*color:\s*\{\$theme\.fg\}/,
+    );
+  });
+});

--- a/src/extensions/project-scope/index.ts
+++ b/src/extensions/project-scope/index.ts
@@ -129,7 +129,7 @@ export function registerProjectScopeExtension(api: ExtensionAPI): void {
     // as sub-items inside it, with inner drag-reorder.
     api.registerPrimarySidebarSection("projects", ProjectsContainer, {
       collapsible: false,
-      showLabel: true,
+      showLabel: false,
       label: "Projects",
       props: { onCreateProject: createProjectFlow },
     });

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -24,7 +24,7 @@
     flex-shrink: 0;
     align-self: stretch;
     position: relative;
-    width: {visible ? '14px' : '3px'};
+    width: {visible ? '14px' : '6px'};
     cursor: {visible ? 'grab' : 'default'};
     transition: width 0.12s ease-out;
     overflow: hidden;
@@ -35,7 +35,7 @@
     style="
       position: absolute;
       left: 0; top: 0; bottom: 0;
-      width: 3px;
+      width: {visible ? '3px' : '6px'};
       background: {effectiveColor};
       opacity: {railOpacity};
     "

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -5,6 +5,12 @@
   export let visible: boolean = false;
   export let onMouseDown: (e: MouseEvent) => void;
   export let ariaLabel: string = "Drag to reorder";
+  /** Color of the rail and dot texture. Defaults to theme.fgDim (grey). */
+  export let railColor: string | undefined = undefined;
+  /** Opacity of the always-on rail when not hovered. 1.0 for active items, 0.35 for inactive. */
+  export let railOpacity: number = 0.5;
+
+  $: effectiveColor = railColor ?? theme.fgDim;
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -15,23 +21,37 @@
   class="drag-grip"
   on:mousedown={onMouseDown}
   style="
-    position: absolute;
-    left: 0; top: 0; bottom: 0;
-    width: 8px;
-    cursor: grab;
-    opacity: {visible ? 1 : 0};
-    transition: opacity 0.12s;
-    display: flex; align-items: center; justify-content: center;
-    background: transparent;
-    z-index: 2;
+    flex-shrink: 0;
+    align-self: stretch;
+    position: relative;
+    width: {visible ? '14px' : '3px'};
+    cursor: {visible ? 'grab' : 'default'};
+    transition: width 0.12s ease-out;
+    overflow: hidden;
   "
 >
-  <span
+  <!-- Always-on rail -->
+  <div
     style="
-      width: 3px; height: 60%;
-      border-radius: 2px;
-      background: {theme.accent};
-      opacity: 0.65;
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 3px;
+      background: {effectiveColor};
+      opacity: {railOpacity};
     "
-  ></span>
+  ></div>
+  <!-- Grippy dots overlay (only when expanded) -->
+  {#if visible}
+    <div
+      style="
+        position: absolute;
+        inset: 0;
+        background-image: radial-gradient({effectiveColor} 1px, transparent 1.5px);
+        background-size: 4px 5px;
+        background-position: 3px 4px;
+        opacity: 0.75;
+        pointer-events: none;
+      "
+    ></div>
+  {/if}
 </div>

--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -10,6 +10,8 @@
   import { dragResize } from "../actions/drag-resize";
   import { createDragReorder } from "../actions/drag-reorder";
   import { workspaces } from "../stores/workspace";
+  import type { Readable } from "svelte/store";
+  import SplitButton from "./SplitButton.svelte";
   import type { SplitButtonItem } from "./SplitButton.svelte";
   import { sidebarSectionStore } from "../services/sidebar-section-registry";
   import { workspaceActionStore } from "../services/workspace-action-registry";
@@ -219,6 +221,25 @@
         </div>
       {/if}
 
+      {#if $isFullscreen && coreAction && orderedBlocks.length > 0 && orderedBlocks[0] && orderedBlocks[0].type === "workspaces"}
+        <div
+          style="
+            height: 38px; flex-shrink: 0; display: flex; align-items: center;
+            padding: 0 8px;
+          "
+        >
+          <div style="flex: 1; min-width: 0;">
+            <SplitButton
+              label="New Workspace"
+              onMainClick={() => coreAction?.handler({})}
+              dropdownItems={splitDropdownItems}
+              theme={theme as unknown as Readable<Record<string, string>>}
+              fullWidth={true}
+            />
+          </div>
+        </div>
+      {/if}
+
       <!-- Scrollable content: blocks rendered in order -->
       <div style="flex: 1; overflow-y: auto; padding: 0;">
         {#each orderedBlocks as block, bIdx (block.id)}
@@ -259,6 +280,7 @@
                 {#if block.type === "workspaces"}
                   <WorkspaceListBlock
                     bind:this={workspaceListBlock}
+                    suppressNewButton={$isFullscreen && bIdx === 0}
                     {unclaimedEntries}
                     {coreAction}
                     {splitDropdownItems}

--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -225,18 +225,19 @@
         <div
           style="
             height: 38px; flex-shrink: 0; display: flex; align-items: center;
-            padding: 0 8px;
+            padding: 0 8px; gap: 8px;
           "
         >
-          <div style="flex: 1; min-width: 0;">
-            <SplitButton
-              label="New Workspace"
-              onMainClick={() => coreAction?.handler({})}
-              dropdownItems={splitDropdownItems}
-              theme={theme as unknown as Readable<Record<string, string>>}
-              fullWidth={true}
-            />
-          </div>
+          <span
+            style="font-size: 13px; font-weight: 600; color: {$theme.fg}; flex: 1; min-width: 0;"
+            >Workspaces</span
+          >
+          <SplitButton
+            label="+ New"
+            onMainClick={() => coreAction?.handler({})}
+            dropdownItems={splitDropdownItems}
+            theme={theme as unknown as Readable<Record<string, string>>}
+          />
         </div>
       {/if}
 

--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -232,52 +232,60 @@
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
               data-block-idx={bIdx}
-              style="position: relative;
+              style="
+                display: flex;
+                position: relative;
                 opacity: {blockDragActive && blockDragSourceIdx === bIdx
                 ? 0.4
                 : 1};
-                {bIdx > 0 ? `margin-top: 4px;` : ''}"
-              on:mouseenter={() => (hoverBlockIdx = bIdx)}
-              on:mouseleave={() => (hoverBlockIdx = null)}
+                {bIdx > 0 ? 'margin-top: 4px;' : ''}
+              "
             >
-              <DragGrip
-                theme={$theme}
-                visible={!$innerReorderActive &&
-                  (hoverBlockIdx === bIdx ||
-                    (blockDragActive && blockDragSourceIdx === bIdx))}
-                onMouseDown={(e) => startBlockDrag(e, bIdx)}
-                ariaLabel="Drag block to reorder"
-              />
-
-              {#if block.type === "workspaces"}
-                <WorkspaceListBlock
-                  bind:this={workspaceListBlock}
-                  {unclaimedEntries}
-                  {coreAction}
-                  {splitDropdownItems}
-                  {insertIndicator}
-                  {dragActive}
-                  {dragSourceIdx}
-                  onStartDrag={startDrag}
-                  {onSwitchWorkspace}
-                  {onCloseWorkspace}
-                  {onRenameWorkspace}
-                  {onNewSurface}
+              <div
+                on:mouseenter={() => (hoverBlockIdx = bIdx)}
+                on:mouseleave={() => (hoverBlockIdx = null)}
+                style="flex-shrink: 0; align-self: stretch; display: flex;"
+              >
+                <DragGrip
+                  theme={$theme}
+                  visible={!$innerReorderActive &&
+                    (hoverBlockIdx === bIdx ||
+                      (blockDragActive && blockDragSourceIdx === bIdx))}
+                  onMouseDown={(e) => startBlockDrag(e, bIdx)}
+                  ariaLabel="Drag block to reorder"
                 />
-              {:else}
-                {@const section = $sidebarSectionStore.find(
-                  (s) => s.id === block.id,
-                )}
-                {#if section}
-                  <SidebarSectionBlock
-                    {section}
-                    collapsed={collapsedSections[section.id] ?? false}
-                    onToggleCollapse={() =>
-                      (collapsedSections[section.id] =
-                        !collapsedSections[section.id])}
+              </div>
+              <div style="flex: 1; min-width: 0;">
+                {#if block.type === "workspaces"}
+                  <WorkspaceListBlock
+                    bind:this={workspaceListBlock}
+                    {unclaimedEntries}
+                    {coreAction}
+                    {splitDropdownItems}
+                    {insertIndicator}
+                    {dragActive}
+                    {dragSourceIdx}
+                    onStartDrag={startDrag}
+                    {onSwitchWorkspace}
+                    {onCloseWorkspace}
+                    {onRenameWorkspace}
+                    {onNewSurface}
                   />
+                {:else}
+                  {@const section = $sidebarSectionStore.find(
+                    (s) => s.id === block.id,
+                  )}
+                  {#if section}
+                    <SidebarSectionBlock
+                      {section}
+                      collapsed={collapsedSections[section.id] ?? false}
+                      onToggleCollapse={() =>
+                        (collapsedSections[section.id] =
+                          !collapsedSections[section.id])}
+                    />
+                  {/if}
                 {/if}
-              {/if}
+              </div>
             </div>
 
             {#if blockInsertIndicator?.idx === bIdx && blockInsertIndicator.edge === "after"}

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -16,8 +16,13 @@
     padding: 0; -webkit-app-region: no-drag;
   `;
 
+  // macOS traffic lights (close/min/max) overlay the top-left of the window
+  // when `titleBarStyle: Overlay` is set. When the primary sidebar is visible,
+  // it sits to the left of the TitleBar and absorbs that space. When it's
+  // hidden (and we're not fullscreen), the TitleBar starts at x=0, so push
+  // its first button well past the traffic-light cluster.
   $: leftPadding =
-    !$primarySidebarVisible && isMac && !$isFullscreen ? "78px" : "8px";
+    !$primarySidebarVisible && isMac && !$isFullscreen ? "84px" : "8px";
 </script>
 
 <div

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -169,20 +169,16 @@
 <div
   data-drag-idx={index}
   style="
-    position: relative;
+    display: flex;
     margin: 2px 8px; border-radius: 6px; overflow: hidden; cursor: pointer;
     background: {isActive
     ? $theme.bgActive
     : hovered
       ? $theme.bgHighlight
       : 'transparent'};
-    border-left: 3px solid {isActive
-    ? accentColor || $theme.accent
-    : `color-mix(in srgb, ${accentColor || $theme.accent} 35%, transparent)`};
     transition: opacity 0.15s;
     opacity: {dragActive ? 0.4 : 1};
   "
-  on:click={onSelect}
   on:contextmenu|preventDefault={(e) => onContextMenu(e.clientX, e.clientY)}
   on:mouseenter={() => (hovered = true)}
   on:mouseleave={() => {
@@ -196,160 +192,168 @@
       visible={hovered}
       onMouseDown={onGripMouseDown}
       ariaLabel="Drag workspace to reorder"
+      railColor={accentColor ?? $theme.accent}
+      railOpacity={isActive ? 1 : 0.35}
     />
   {/if}
-  <div style="padding: 8px 12px; display: flex; align-items: center; gap: 8px;">
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div on:click={onSelect} style="flex: 1; min-width: 0;">
     <div
-      style="flex: 1; overflow: hidden; display: flex; align-items: center; gap: 4px;"
+      style="padding: 8px 12px; display: flex; align-items: center; gap: 8px;"
     >
-      {#if isManaged}
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          style="flex-shrink: 0; color: {$theme.fgDim};"
+      <div
+        style="flex: 1; overflow: hidden; display: flex; align-items: center; gap: 4px;"
+      >
+        {#if isManaged}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            style="flex-shrink: 0; color: {$theme.fgDim};"
+          >
+            <title>Git worktree workspace</title>
+            <circle cx="4" cy="4" r="2" />
+            <circle cx="4" cy="12" r="2" />
+            <circle cx="12" cy="8" r="2" />
+            <path d="M4 6 L4 10" />
+            <path d="M6 4 C8 4 10 6 10 8" />
+          </svg>
+        {/if}
+        <span
+          bind:this={nameEl}
+          style="
+            font-weight: {isActive ? '600' : '400'};
+            color: {isDisco
+            ? discoColorFor(workspace.id)
+            : isActive
+              ? $theme.fg
+              : $theme.fgMuted};
+            font-size: 13px; overflow: hidden;
+            text-overflow: ellipsis; white-space: nowrap;
+            outline: none; padding: 2px 4px; margin-left: -4px; border-radius: 4px;
+          "
+          on:blur={finishRename}
+          on:keydown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              nameEl.blur();
+            }
+            if (e.key === "Escape") {
+              e.preventDefault();
+              nameEl.textContent = workspace.name;
+              nameEl.blur();
+            }
+          }}
+          >{#if isDisco}{discoEmojiFor(workspace.id)}
+          {/if}{workspace.name}</span
         >
-          <title>Git worktree workspace</title>
-          <circle cx="4" cy="4" r="2" />
-          <circle cx="4" cy="12" r="2" />
-          <circle cx="12" cy="8" r="2" />
-          <path d="M4 6 L4 10" />
-          <path d="M6 4 C8 4 10 6 10 8" />
-        </svg>
+      </div>
+
+      {#if agentBadges.length > 0 && agentBadges[0]}
+        {@const topBadge = agentBadges[0]}
+        {@const statusLabel =
+          topBadge.variant === "success"
+            ? "running"
+            : topBadge.variant === "warning"
+              ? "waiting"
+              : topBadge.variant === "muted"
+                ? "idle"
+                : topBadge.variant === "error"
+                  ? "error"
+                  : ""}
+        <span
+          title={agentBadges.map((b) => b.label).join(", ")}
+          style="
+            display: inline-flex; align-items: center; gap: 3px;
+            font-size: 10px; color: {topBadge.color};
+            background: color-mix(in srgb, {topBadge.color} 15%, transparent);
+            padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
+          "
+        >
+          <span
+            style="width: 6px; height: 6px; border-radius: 50%; background: {topBadge.color};"
+          ></span>
+          {#if agentCount > 1}{agentCount}
+          {/if}{statusLabel}
+        </span>
+      {:else if agentDotColor}
+        <span
+          title="Agent: {agentStatus}"
+          style="
+            display: inline-flex; align-items: center; gap: 3px;
+            font-size: 10px; color: {agentDotColor};
+            background: color-mix(in srgb, {agentDotColor} 15%, transparent);
+            padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
+          "
+        >
+          <span
+            style="width: 6px; height: 6px; border-radius: 50%; background: {agentDotColor};"
+          ></span>
+          {agentStatus}
+        </span>
       {/if}
+
+      {#if hasUnread && !agentDotColor && agentBadges.length === 0}
+        <span
+          title="Workspace has new terminal activity"
+          style="
+            display: inline-flex; align-items: center; gap: 3px;
+            font-size: 10px; color: {$theme.notify};
+            background: color-mix(in srgb, {$theme.notify} 15%, transparent);
+            padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
+          "
+        >
+          <span
+            style="width: 6px; height: 6px; border-radius: 50%; background: {$theme.notify};"
+          ></span>
+          new
+        </span>
+      {/if}
+
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
       <span
-        bind:this={nameEl}
+        title="Close Workspace (⇧⌘W)"
         style="
-          font-weight: {isActive ? '600' : '400'};
-          color: {isDisco
-          ? discoColorFor(workspace.id)
-          : isActive
-            ? $theme.fg
-            : $theme.fgMuted};
-          font-size: 13px; overflow: hidden;
-          text-overflow: ellipsis; white-space: nowrap;
-          outline: none; padding: 2px 4px; margin-left: -4px; border-radius: 4px;
+          color: {closeHovered
+          ? $theme.danger
+          : $theme.fgDim}; font-size: 14px; cursor: pointer;
+          opacity: {hovered ? '1' : '0'}; transition: opacity 0.15s;
+          padding: 0 2px; flex-shrink: 0;
         "
-        on:blur={finishRename}
-        on:keydown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            nameEl.blur();
-          }
-          if (e.key === "Escape") {
-            e.preventDefault();
-            nameEl.textContent = workspace.name;
-            nameEl.blur();
-          }
-        }}
-        >{#if isDisco}{discoEmojiFor(workspace.id)}
-        {/if}{workspace.name}</span
+        on:click|stopPropagation={onClose}
+        on:mouseenter={() => (closeHovered = true)}
+        on:mouseleave={() => (closeHovered = false)}>×</span
       >
     </div>
 
-    {#if agentBadges.length > 0 && agentBadges[0]}
-      {@const topBadge = agentBadges[0]}
-      {@const statusLabel =
-        topBadge.variant === "success"
-          ? "running"
-          : topBadge.variant === "warning"
-            ? "waiting"
-            : topBadge.variant === "muted"
-              ? "idle"
-              : topBadge.variant === "error"
-                ? "error"
-                : ""}
-      <span
-        title={agentBadges.map((b) => b.label).join(", ")}
-        style="
-          display: inline-flex; align-items: center; gap: 3px;
-          font-size: 10px; color: {topBadge.color};
-          background: color-mix(in srgb, {topBadge.color} 15%, transparent);
-          padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
-        "
-      >
-        <span
-          style="width: 6px; height: 6px; border-radius: 50%; background: {topBadge.color};"
-        ></span>
-        {#if agentCount > 1}{agentCount}
-        {/if}{statusLabel}
-      </span>
-    {:else if agentDotColor}
-      <span
-        title="Agent: {agentStatus}"
-        style="
-          display: inline-flex; align-items: center; gap: 3px;
-          font-size: 10px; color: {agentDotColor};
-          background: color-mix(in srgb, {agentDotColor} 15%, transparent);
-          padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
-        "
-      >
-        <span
-          style="width: 6px; height: 6px; border-radius: 50%; background: {agentDotColor};"
-        ></span>
-        {agentStatus}
-      </span>
-    {/if}
+    {#each subtitleComponents as sub (sub.id)}
+      {@const subApi = getExtensionApiById(sub.source)}
+      {#if subApi}
+        <ExtensionWrapper
+          api={subApi}
+          component={sub.component}
+          props={{ workspaceId: workspace.id }}
+        />
+      {:else}
+        <svelte:component
+          this={sub.component as Component}
+          workspaceId={workspace.id}
+        />
+      {/if}
+    {/each}
 
-    {#if hasUnread && !agentDotColor && agentBadges.length === 0}
-      <span
-        title="Workspace has new terminal activity"
-        style="
-          display: inline-flex; align-items: center; gap: 3px;
-          font-size: 10px; color: {$theme.notify};
-          background: color-mix(in srgb, {$theme.notify} 15%, transparent);
-          padding: 1px 6px; border-radius: 8px; flex-shrink: 0;
-        "
+    {#if latestNotification}
+      <div
+        style="padding: 2px 12px 6px; font-size: 11px; color: {$theme.notify}; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
       >
-        <span
-          style="width: 6px; height: 6px; border-radius: 50%; background: {$theme.notify};"
-        ></span>
-        new
-      </span>
+        {latestNotification}
+      </div>
     {/if}
-
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <span
-      title="Close Workspace (⇧⌘W)"
-      style="
-        color: {closeHovered
-        ? $theme.danger
-        : $theme.fgDim}; font-size: 14px; cursor: pointer;
-        opacity: {hovered ? '1' : '0'}; transition: opacity 0.15s;
-        padding: 0 2px; flex-shrink: 0;
-      "
-      on:click|stopPropagation={onClose}
-      on:mouseenter={() => (closeHovered = true)}
-      on:mouseleave={() => (closeHovered = false)}>×</span
-    >
   </div>
-
-  {#each subtitleComponents as sub (sub.id)}
-    {@const subApi = getExtensionApiById(sub.source)}
-    {#if subApi}
-      <ExtensionWrapper
-        api={subApi}
-        component={sub.component}
-        props={{ workspaceId: workspace.id }}
-      />
-    {:else}
-      <svelte:component
-        this={sub.component as Component}
-        workspaceId={workspace.id}
-      />
-    {/if}
-  {/each}
-
-  {#if latestNotification}
-    <div
-      style="padding: 2px 12px 6px; font-size: 11px; color: {$theme.notify}; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
-    >
-      {latestNotification}
-    </div>
-  {/if}
 </div>

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -18,6 +18,8 @@
   export let dragActive: boolean;
   export let dragSourceIdx: number | null;
 
+  export let suppressNewButton = false;
+
   export let onStartDrag: (e: MouseEvent, idx: number) => void;
   export let onSwitchWorkspace: (idx: number) => void;
   export let onCloseWorkspace: (idx: number) => void;
@@ -72,7 +74,7 @@
   }
 </script>
 
-{#if coreAction}
+{#if coreAction && !suppressNewButton}
   <div style="padding: 4px 8px;">
     <SplitButton
       label="New Workspace"

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -75,13 +75,16 @@
 </script>
 
 {#if coreAction && !suppressNewButton}
-  <div style="padding: 4px 8px;">
+  <div style="padding: 4px 8px; display: flex; align-items: center; gap: 8px;">
+    <span
+      style="font-size: 13px; font-weight: 600; color: {$theme.fg}; flex: 1; min-width: 0;"
+      >Workspaces</span
+    >
     <SplitButton
-      label="New Workspace"
+      label="+ New"
       onMainClick={() => coreAction?.handler({})}
       dropdownItems={splitDropdownItems}
       theme={theme as unknown as Readable<Record<string, string>>}
-      fullWidth={true}
     />
   </div>
 {/if}

--- a/src/lib/components/WorkspaceListView.svelte
+++ b/src/lib/components/WorkspaceListView.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   /**
    * WorkspaceListView — renders a filtered list of WorkspaceItems
-   * with full interaction support (click, close, rename, context menu).
+   * with full interaction support (click, close, rename, context menu)
+   * and drag-to-reorder via the shared DragGrip.
    *
-   * Used by PrimarySidebar for the main workspace list and by extensions
-   * for scoped workspace lists in their own sidebar sections.
+   * Used by extensions for scoped workspace lists in their own sidebar sections.
+   * Reorder affects the global workspace order (the only source of truth);
+   * within a filtered view, that translates to moving a workspace relative to
+   * its visible peers.
    */
+  import { flip } from "svelte/animate";
   import { workspaces, activeWorkspaceIdx } from "../stores/workspace";
   import { theme } from "../stores/theme";
+  import { innerReorderActive } from "../stores/ui";
+  import { createDragReorder } from "../actions/drag-reorder";
   import {
     switchWorkspace,
     closeWorkspace,
     renameWorkspace,
+    reorderWorkspaces,
   } from "../services/workspace-service";
   import WorkspaceItem from "./WorkspaceItem.svelte";
 
@@ -24,29 +31,77 @@
   $: entries = $workspaces
     .map((ws, idx) => ({ ws, idx }))
     .filter(({ ws }) => (filterIds ? filterIds.has(ws.id) : true));
+
+  let sourceIdx: number | null = null;
+  let indicator: { idx: number; edge: "before" | "after" } | null = null;
+  let active = false;
+
+  const reorder = createDragReorder({
+    dataAttr: "ws-view-drag-idx",
+    containerSelector: ".workspace-list-view",
+    ghostStyle: () => ({
+      background: $theme.bgFloat ?? $theme.bgSurface ?? "#111",
+      border: `1px solid ${accentColor ?? $theme.accent}`,
+    }),
+    onDrop: (from, to) => {
+      // `from` and `to` are global workspace indices (encoded in the data
+      // attribute below). reorderWorkspaces operates on the global list.
+      reorderWorkspaces(from, to);
+    },
+    onStateChange: () => {
+      const s = reorder.getState();
+      sourceIdx = s.sourceIdx;
+      indicator = s.indicator;
+      active = s.active;
+      innerReorderActive.set(s.active);
+    },
+  });
+
+  function startDrag(e: MouseEvent, globalIdx: number) {
+    reorder.start(e, globalIdx);
+  }
 </script>
 
-{#each entries as entry (entry.ws.id)}
-  <WorkspaceItem
-    workspace={entry.ws}
-    index={entry.idx}
-    isActive={entry.idx === $activeWorkspaceIdx}
-    dragActive={false}
-    {accentColor}
-    onSelect={() => switchWorkspace(entry.idx)}
-    onClose={() => closeWorkspace(entry.idx)}
-    onRename={(name) => renameWorkspace(entry.idx, name)}
-    onContextMenu={() => {}}
-  />
-{/each}
+<div class="workspace-list-view">
+  {#each entries as entry (entry.ws.id)}
+    <div animate:flip={{ duration: 200 }} data-ws-view-drag-idx={entry.idx}>
+      {#if indicator?.idx === entry.idx && indicator.edge === "before"}
+        <div
+          style="height: 2px; background: {accentColor ??
+            $theme.accent}; margin: 0 12px; border-radius: 1px;"
+        ></div>
+      {/if}
+      <WorkspaceItem
+        workspace={entry.ws}
+        index={entry.idx}
+        isActive={entry.idx === $activeWorkspaceIdx}
+        dragActive={active && sourceIdx === entry.idx}
+        {accentColor}
+        onSelect={() => {
+          if (!active) switchWorkspace(entry.idx);
+        }}
+        onClose={() => closeWorkspace(entry.idx)}
+        onRename={(name) => renameWorkspace(entry.idx, name)}
+        onContextMenu={() => {}}
+        onGripMouseDown={(e) => startDrag(e, entry.idx)}
+      />
+      {#if indicator?.idx === entry.idx && indicator.edge === "after"}
+        <div
+          style="height: 2px; background: {accentColor ??
+            $theme.accent}; margin: 0 12px; border-radius: 1px;"
+        ></div>
+      {/if}
+    </div>
+  {/each}
 
-{#if entries.length === 0}
-  <div
-    style="
-      padding: 4px 12px; font-size: 10px;
-      color: {$theme.fgDim}; font-style: italic;
-    "
-  >
-    No workspaces
-  </div>
-{/if}
+  {#if entries.length === 0}
+    <div
+      style="
+        padding: 4px 12px; font-size: 10px;
+        color: {$theme.fgDim}; font-style: italic;
+      "
+    >
+      No workspaces
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

Sidebar polish pass — restyles project headers, redesigns the drag-grip system, and fixes fullscreen alignment.

- **Project headers**: colored dot replaces the left border; names are mixed-case 13px `$theme.fg` (no longer uppercase/dim); clicking the dot+name opens the project dashboard. Separate "Dashboard" link row is gone.
- **Projects section label hidden**: `showLabel: false` on the `projects` sidebar section — the New Project button is the section's anchor.
- **DragGrip redesign**: always-on left rail (3px) that expands to a 14px grippy dotted grip on hover. Now inline-flex (pushes content right instead of overlaying). New `railColor` + `railOpacity` props.
- **Consistent rail colors across nesting levels**:
  - Sidebar block rail = grey (`$theme.fgDim`)
  - Project rail = `project.color`
  - Workspace rail = `accentColor` (inherits the project color), dim for inactive
- **Distinct drag zones**: block / project / workspace grips live in sibling DOM subtrees, so hovering an inner item cannot trigger an outer handle. Only one grip is ever visible at a time.
- **Fullscreen**: the Workspaces block's "New Workspace" button is hoisted into a 38px top row that aligns with TitleBar buttons.

## Test plan

- [ ] Launch the app — with ≥1 project and ≥1 workspace.
- [ ] Project header shows an 8px colored dot left of the name (no border-left accent).
- [ ] Project name reads as a normal title (mixed-case, 13px), not an uppercase label.
- [ ] Clicking the dot or the project name opens the project dashboard overlay.
- [ ] Clicking the project's "+ New" split button creates a workspace (does NOT open the dashboard).
- [ ] The old "Dashboard" boxed link row is gone.
- [ ] "PROJECTS" section header is gone.
- [ ] Hover the left edge of a sidebar block → grey grippy grip expands from the rail; content shifts right.
- [ ] Hover a project in the sidebar → colored (project.color) grippy grip expands on the project rail.
- [ ] Hover a workspace row → accent-colored grippy grip expands on the workspace rail.
- [ ] Hovering a workspace row does NOT show a project or block grip simultaneously.
- [ ] Hovering a project does NOT show a block grip simultaneously.
- [ ] Drag-reorder still works for blocks, projects, and workspaces.
- [ ] Active workspace rail is fully opaque; inactive rails are dimmed.
- [ ] Enter fullscreen → "New Workspace" button sits in a 38px top row aligned with TitleBar.
- [ ] Exit fullscreen → "New Workspace" returns to its in-block position; the traffic-light placeholder row reappears.
- [ ] `npm test` passes (1050 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)