### PR TITLE
fix(config): read legacy global gnar-term.json

### DIFF
--- a/src/__tests__/app-render.test.ts
+++ b/src/__tests__/app-render.test.ts
@@ -230,6 +230,16 @@ describe("Config loads per-project files", () => {
     expect(source).toContain('"gnar-term.json"');
     expect(source).toContain('"cmux.json"');
   });
+
+  it("loadConfig reads the legacy global ~/.config/gnar-term/gnar-term.json", async () => {
+    const fs = await import("fs");
+    const source = fs.readFileSync("src/lib/config.ts", "utf-8");
+    // Existing installs created the global settings file as gnar-term.json
+    // before it was renamed to settings.json in the extension-core refactor.
+    // The loader must still probe the old name so those users don't silently
+    // lose their autoload workspace and commands on upgrade.
+    expect(source).toContain("${home}/.config/gnar-term/gnar-term.json");
+  });
 });
 
 describe("Workspace from config definition", () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,9 +3,10 @@
  *
  * Settings file locations (in priority order):
  *   ./settings.json                     (per-project)
- *   ~/.config/gnar-term/settings.json   (global)
  *   ./gnar-term.json                    (legacy per-project)
  *   ./cmux.json                         (per-project, cmux compat)
+ *   ~/.config/gnar-term/settings.json   (global)
+ *   ~/.config/gnar-term/gnar-term.json  (legacy global)
  *   ~/.config/cmux/cmux.json            (global, cmux compat)
  *
  * Runtime state:
@@ -140,10 +141,13 @@ export async function loadConfig(
 
   const home = await getHome();
 
-  // Try per-project config first (higher priority), then global
+  // Try per-project config first (higher priority), then global.
+  // Legacy global `gnar-term.json` is still read so existing installs keep
+  // working after the rename to `settings.json`.
   const paths = [
-    ...CONFIG_FILENAMES, // ./gnar-term.json, ./cmux.json
+    ...CONFIG_FILENAMES, // ./settings.json, ./gnar-term.json, ./cmux.json
     `${home}/.config/gnar-term/settings.json`,
+    `${home}/.config/gnar-term/gnar-term.json`,
     `${home}/.config/cmux/cmux.json`,
   ];
 


### PR DESCRIPTION
## Summary
- PR #53 renamed the global settings file from `~/.config/gnar-term/gnar-term.json` to `~/.config/gnar-term/settings.json`, but dropped the old path from the loader's search list. Installs that predate #53 silently lost their `autoload` workspace and custom `commands` on upgrade because the frontend never finds the config, even though the Rust MCP-setting reader still checks the legacy path.
- Adds `~/.config/gnar-term/gnar-term.json` back to `loadConfig`'s search list (ordered after the canonical `settings.json` so it only takes effect when the new file is absent).
- Adds a structural regression test that fails if the legacy path is ever dropped again.

## Test plan
- [x] `npm test` — all 1074 tests pass
- [x] Rust pre-push tests — all 107 pass
- [x] `npm run build` — Tauri build compiles and bundles `.app` (local DMG bundler flake unrelated to this change)
- [ ] Launch the freshly built `GnarTerm.app` on a machine whose only config is `~/.config/gnar-term/gnar-term.json`; confirm the `autoload` workspace opens and custom commands appear in the command palette
- [ ] Rename the file to `settings.json` and relaunch; confirm it still loads (new canonical path still wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)