### PR TITLE
fix(pane/surface): inherit cwd from target pane, not focused pane

### DIFF
--- a/src/__tests__/core-api-extensions.test.ts
+++ b/src/__tests__/core-api-extensions.test.ts
@@ -28,6 +28,7 @@ vi.mock("../lib/config", () => ({
 vi.mock("../lib/services/service-helpers", () => ({
   safeFocus: vi.fn(),
   getActiveCwd: vi.fn().mockResolvedValue(undefined),
+  getCwdForSurface: vi.fn().mockResolvedValue(undefined),
 }));
 
 // --- Imports ---

--- a/src/__tests__/e2e-workflows.test.ts
+++ b/src/__tests__/e2e-workflows.test.ts
@@ -58,6 +58,7 @@ import { getCwdForSurface } from "../lib/services/service-helpers";
 import {
   openExtensionSurfaceInPane,
   closeSurfaceById,
+  newSurface,
 } from "../lib/services/surface-service";
 import {
   registerSurfaceType,
@@ -298,6 +299,43 @@ describe("Workflow: pane split and navigation", () => {
     await splitPane(paneA.id, "horizontal");
 
     // getCwdForSurface should have been called with A's surface, not B's
+    expect(getCwdForSurface).toHaveBeenCalledTimes(1);
+    const passed = vi.mocked(getCwdForSurface).mock.calls[0][0];
+    expect(passed?.id).toBe(paneA.surfaces[0].id);
+  });
+
+  it("opening a new tab in an inactive pane inherits cwd from that pane, not the focused pane", async () => {
+    // Regression: newSurface read cwd from the globally-active surface.
+    // Clicking "+" on a non-focused pane's tab bar leaked the focused
+    // pane's cwd into the new terminal. Fix routes cwd through the
+    // target pane's active surface.
+    const paneA = makePane([
+      mockTerminalSurface({ cwd: "/src/pane-a", ptyId: 10 }),
+    ]);
+    const paneB = makePane([
+      mockTerminalSurface({ cwd: "/src/pane-b", ptyId: 20 }),
+    ]);
+    const ws: Workspace = {
+      id: uid(),
+      name: "Cwd Source",
+      splitRoot: {
+        type: "split",
+        direction: "horizontal",
+        ratio: 0.5,
+        children: [
+          { type: "pane", pane: paneA },
+          { type: "pane", pane: paneB },
+        ],
+      },
+      activePaneId: paneB.id, // B is focused
+    };
+    workspaces.set([ws]);
+    activeWorkspaceIdx.set(0);
+
+    // Open a new tab in A (the non-focused pane)
+    await newSurface(paneA.id);
+
+    // getCwdForSurface should have been called with A's active surface, not B's
     expect(getCwdForSurface).toHaveBeenCalledTimes(1);
     const passed = vi.mocked(getCwdForSurface).mock.calls[0][0];
     expect(passed?.id).toBe(paneA.surfaces[0].id);

--- a/src/__tests__/e2e-workflows.test.ts
+++ b/src/__tests__/e2e-workflows.test.ts
@@ -28,6 +28,7 @@ vi.mock("../lib/config", () => ({
 vi.mock("../lib/services/service-helpers", () => ({
   safeFocus: vi.fn(),
   getActiveCwd: vi.fn().mockResolvedValue(undefined),
+  getCwdForSurface: vi.fn().mockResolvedValue(undefined),
 }));
 
 // --- Imports ---
@@ -53,6 +54,7 @@ import {
   closeWorkspace,
 } from "../lib/services/workspace-service";
 import { splitPane, focusPane, closePane } from "../lib/services/pane-service";
+import { getCwdForSurface } from "../lib/services/service-helpers";
 import {
   openExtensionSurfaceInPane,
   closeSurfaceById,
@@ -262,6 +264,43 @@ describe("Workflow: pane split and navigation", () => {
       expect(currentWs.splitRoot.direction).toBe("vertical");
       expect(currentWs.splitRoot.ratio).toBe(0.5);
     }
+  });
+
+  it("splitting an inactive pane inherits cwd from the source pane, not the focused pane", async () => {
+    // Regression: splitPane used to read cwd from the globally-active
+    // surface. When MCP or a command targets a non-focused pane, the new
+    // terminal inherited the wrong cwd. Fix routes cwd through the
+    // source pane's active surface.
+    const paneA = makePane([
+      mockTerminalSurface({ cwd: "/src/pane-a", ptyId: 10 }),
+    ]);
+    const paneB = makePane([
+      mockTerminalSurface({ cwd: "/src/pane-b", ptyId: 20 }),
+    ]);
+    const ws: Workspace = {
+      id: uid(),
+      name: "Cwd Source",
+      splitRoot: {
+        type: "split",
+        direction: "horizontal",
+        ratio: 0.5,
+        children: [
+          { type: "pane", pane: paneA },
+          { type: "pane", pane: paneB },
+        ],
+      },
+      activePaneId: paneB.id, // B is focused
+    };
+    workspaces.set([ws]);
+    activeWorkspaceIdx.set(0);
+
+    // Split A (the non-focused pane)
+    await splitPane(paneA.id, "horizontal");
+
+    // getCwdForSurface should have been called with A's surface, not B's
+    expect(getCwdForSurface).toHaveBeenCalledTimes(1);
+    const passed = vi.mocked(getCwdForSurface).mock.calls[0][0];
+    expect(passed?.id).toBe(paneA.surfaces[0].id);
   });
 });
 

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -28,6 +28,7 @@ vi.mock("../lib/config", () => ({
 vi.mock("../lib/services/service-helpers", () => ({
   safeFocus: vi.fn(),
   getActiveCwd: vi.fn().mockResolvedValue(undefined),
+  getCwdForSurface: vi.fn().mockResolvedValue(undefined),
 }));
 
 // --- Imports ---

--- a/src/lib/services/pane-service.ts
+++ b/src/lib/services/pane-service.ts
@@ -20,7 +20,7 @@ import {
   type SplitNode,
 } from "../types";
 import { createWorkspace, schedulePersist } from "./workspace-service";
-import { safeFocus, getActiveCwd } from "./service-helpers";
+import { safeFocus, getCwdForSurface } from "./service-helpers";
 import { eventBus } from "./event-bus";
 
 /**
@@ -75,9 +75,16 @@ export async function splitPane(
   paneId: string,
   direction: "horizontal" | "vertical",
 ) {
+  const ws = get(activeWorkspace);
+  const sourcePane =
+    ws &&
+    (getAllPanes(ws.splitRoot).find((p) => p.id === paneId) ?? get(activePane));
+  const sourceSurface = sourcePane
+    ? sourcePane.surfaces.find((s) => s.id === sourcePane.activeSurfaceId)
+    : null;
   const result = splitPaneEmpty(paneId, direction);
   if (!result) return;
-  const cwd = await getActiveCwd();
+  const cwd = await getCwdForSurface(sourceSurface);
   const surface = await createTerminalSurface(result.newPane, cwd);
   workspaces.update((l) => [...l]);
   void safeFocus(surface);

--- a/src/lib/services/service-helpers.ts
+++ b/src/lib/services/service-helpers.ts
@@ -22,8 +22,9 @@ export async function safeFocus(s: Surface | null | undefined) {
   s.terminal.focus();
 }
 
-export async function getActiveCwd(): Promise<string | undefined> {
-  const surface = get(activeSurface);
+export async function getCwdForSurface(
+  surface: Surface | null | undefined,
+): Promise<string | undefined> {
   if (!surface || !isTerminalSurface(surface)) return undefined;
   if (surface.cwd) return surface.cwd;
   if (surface.ptyId >= 0) {
@@ -37,4 +38,8 @@ export async function getActiveCwd(): Promise<string | undefined> {
     }
   }
   return undefined;
+}
+
+export async function getActiveCwd(): Promise<string | undefined> {
+  return getCwdForSurface(get(activeSurface));
 }

--- a/src/lib/services/surface-service.ts
+++ b/src/lib/services/surface-service.ts
@@ -20,7 +20,7 @@ import {
 } from "../types";
 import { removePane } from "./pane-service";
 import { schedulePersist } from "./workspace-service";
-import { safeFocus, getActiveCwd } from "./service-helpers";
+import { safeFocus, getCwdForSurface } from "./service-helpers";
 import { eventBus } from "./event-bus";
 
 export function selectSurface(paneId: string, surfaceId: string) {
@@ -114,7 +114,10 @@ export async function newSurface(paneId: string) {
   if (!ws) return;
   const pane = getAllPanes(ws.splitRoot).find((p) => p.id === paneId);
   if (!pane) return;
-  const cwd = await getActiveCwd();
+  const sourceSurface = pane.surfaces.find(
+    (s) => s.id === pane.activeSurfaceId,
+  );
+  const cwd = await getCwdForSurface(sourceSurface);
   const surface = await createTerminalSurface(pane, cwd);
   workspaces.update((l) => [...l]);
   eventBus.emit({
@@ -132,7 +135,10 @@ export async function newSurfaceWithCommand(paneId: string, command: string) {
   if (!ws) return;
   const pane = getAllPanes(ws.splitRoot).find((p) => p.id === paneId);
   if (!pane) return;
-  const cwd = await getActiveCwd();
+  const sourceSurface = pane.surfaces.find(
+    (s) => s.id === pane.activeSurfaceId,
+  );
+  const cwd = await getCwdForSurface(sourceSurface);
   const surface = await createTerminalSurface(pane, cwd);
   surface.title = command;
   surface.startupCommand = command;


### PR DESCRIPTION
## Summary

- `splitPane` and `newSurface`/`newSurfaceWithCommand` read cwd via `getActiveCwd()`, which reads from the globally-active surface. When a split or new-tab was triggered against a non-focused pane (MCP tool call, command palette, or clicking "+" on an inactive pane's tab bar), the new terminal inherited the *focused* pane's cwd instead of the target pane's.
- Extracted `getCwdForSurface(surface)` from `getActiveCwd()` in `service-helpers.ts` and updated the three callsites in `pane-service.ts` / `surface-service.ts` to pass the target pane's active surface explicitly.
- Added two regression tests in `e2e-workflows.test.ts` — one per entry point — asserting `getCwdForSurface` is called with the target pane's surface even when a different pane is focused.

## Test plan

- [ ] Open two panes in one workspace, `cd` each to a different directory
- [ ] Focus pane B, then trigger a split on pane A via MCP or the command palette — confirm the new terminal lands in pane A's cwd
- [ ] Focus pane B, then click "+" on pane A's tab bar — confirm the new tab lands in pane A's cwd
- [ ] Normal (focused-pane) split and new-tab flows still inherit cwd correctly
- [ ] `npm test` green (1144 tests)
- [ ] `npm run build` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)