### PR TITLE
chore(deps): bump rustls-webpki 0.103.12 -> 0.103.13

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3638,9 +3638,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Patches **RUSTSEC-2026-0104**: reachable panic in certificate revocation list parsing.
- Transitive dep via `ureq` / `tauri-plugin-updater` — lockfile-only change, no source modifications.
- Unblocks CI on `main` and every open dependabot PR (the "Audit Rust dependencies" step was failing repo-wide).

## Test plan

- [ ] CI passes the "Audit Rust dependencies" step
- [ ] All other CI steps remain green (cargo check, clippy, tests, vite build)
- [ ] Once merged, PR #84 and pending dependabot PRs become mergeable again

🤖 Generated with [Claude Code](https://claude.com/claude-code)