### PR TITLE
feat(tabs): tab rename via ⌘R (or double-click)

### DIFF
--- a/src/__tests__/surface-rename.test.ts
+++ b/src/__tests__/surface-rename.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "fs";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+vi.mock("../lib/terminal-service", () => ({
+  createTerminalSurface: vi.fn(),
+  isMac: false,
+}));
+
+import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
+import { renamingSurfaceId } from "../lib/stores/ui";
+import {
+  renameActiveSurface,
+  renameSurface,
+} from "../lib/services/surface-service";
+import type { Workspace } from "../lib/types";
+
+function makeWorkspace(surfaceId: string, title = "Tab"): Workspace {
+  return {
+    id: "ws-1",
+    name: "Test",
+    activePaneId: "pane-1",
+    splitRoot: {
+      type: "pane",
+      pane: {
+        id: "pane-1",
+        surfaces: [
+          {
+            kind: "extension",
+            id: surfaceId,
+            surfaceTypeId: "test",
+            title,
+            hasUnread: false,
+          },
+        ],
+        activeSurfaceId: surfaceId,
+      },
+    },
+  };
+}
+
+describe("renameActiveSurface()", () => {
+  beforeEach(() => {
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+    renamingSurfaceId.set(null);
+  });
+
+  it("does nothing when no active surface", () => {
+    renameActiveSurface();
+    expect(get(renamingSurfaceId)).toBeNull();
+  });
+
+  it("sets renamingSurfaceId to the active surface id", () => {
+    workspaces.set([makeWorkspace("s-42")]);
+    activeWorkspaceIdx.set(0);
+    renameActiveSurface();
+    expect(get(renamingSurfaceId)).toBe("s-42");
+  });
+});
+
+describe("renameSurface()", () => {
+  beforeEach(() => {
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+  });
+
+  it("updates the surface title", () => {
+    workspaces.set([makeWorkspace("s-42", "Original")]);
+    renameSurface("s-42", "Renamed");
+    const pane =
+      get(workspaces)[0].splitRoot.type === "pane"
+        ? get(workspaces)[0].splitRoot.pane
+        : null;
+    expect(pane?.surfaces[0].title).toBe("Renamed");
+  });
+
+  it("is a no-op for unknown surface id", () => {
+    workspaces.set([makeWorkspace("s-42", "Original")]);
+    renameSurface("unknown", "Changed");
+    const pane =
+      get(workspaces)[0].splitRoot.type === "pane"
+        ? get(workspaces)[0].splitRoot.pane
+        : null;
+    expect(pane?.surfaces[0].title).toBe("Original");
+  });
+});
+
+describe("keyboard-shortcuts: ⌘R wires to renameActiveSurface", () => {
+  it("keyboard-shortcuts.ts imports renameActiveSurface", () => {
+    const src = readFileSync("src/lib/services/keyboard-shortcuts.ts", "utf-8");
+    expect(src).toMatch(/renameActiveSurface/);
+  });
+});
+
+describe("Tab.svelte: rename wiring", () => {
+  it("imports renamingSurfaceId", () => {
+    const src = readFileSync("src/lib/components/Tab.svelte", "utf-8");
+    expect(src).toMatch(/renamingSurfaceId/);
+  });
+
+  it("binds nameEl to the title span", () => {
+    const src = readFileSync("src/lib/components/Tab.svelte", "utf-8");
+    expect(src).toMatch(/bind:this={nameEl}/);
+  });
+});

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { theme } from "../stores/theme";
   import type { Surface } from "../types";
   import { startTabDrag } from "../services/tab-drag";
+  import { renamingSurfaceId } from "../stores/ui";
+  import { renameSurface } from "../services/surface-service";
 
   export let surface: Surface;
   export let index: number;
@@ -20,6 +23,77 @@
 
   let hovered = false;
   let closeHovered = false;
+  let nameEl: HTMLSpanElement | null = null;
+  let _renaming = false;
+
+  $: {
+    if ($renamingSurfaceId === surface.id && !_renaming) {
+      void startRenameMode();
+    } else if ($renamingSurfaceId !== surface.id && _renaming) {
+      cancelRename();
+    }
+  }
+
+  async function startRenameMode() {
+    _renaming = true;
+    await tick();
+    if (!nameEl) return;
+    nameEl.textContent = surface.title;
+    nameEl.contentEditable = "true";
+    nameEl.style.background = $theme.bgSurface;
+    nameEl.style.border = `1px solid ${$theme.borderActive}`;
+    nameEl.style.borderRadius = "3px";
+    nameEl.style.padding = "0 3px";
+    nameEl.style.outline = "none";
+    nameEl.focus();
+    const range = document.createRange();
+    range.selectNodeContents(nameEl);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }
+
+  function finishRename() {
+    if (!nameEl || !_renaming) return;
+    nameEl.contentEditable = "false";
+    nameEl.style.background = "transparent";
+    nameEl.style.border = "none";
+    nameEl.style.borderRadius = "";
+    nameEl.style.padding = "";
+    nameEl.style.outline = "";
+    const newTitle = nameEl.textContent?.trim() ?? "";
+    if (newTitle && newTitle !== surface.title) {
+      renameSurface(surface.id, newTitle);
+    } else {
+      nameEl.textContent = surface.title || `Shell ${index + 1}`;
+    }
+    _renaming = false;
+    renamingSurfaceId.set(null);
+  }
+
+  function cancelRename() {
+    if (!nameEl || !_renaming) return;
+    nameEl.contentEditable = "false";
+    nameEl.style.background = "transparent";
+    nameEl.style.border = "none";
+    nameEl.style.borderRadius = "";
+    nameEl.style.padding = "";
+    nameEl.style.outline = "";
+    nameEl.textContent = surface.title || `Shell ${index + 1}`;
+    _renaming = false;
+    renamingSurfaceId.set(null);
+  }
+
+  function handleNameKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      nameEl?.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      if (nameEl) nameEl.textContent = surface.title;
+      nameEl?.blur();
+    }
+  }
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -43,7 +117,9 @@
   on:click={onSelect}
   on:mouseenter={() => (hovered = true)}
   on:mouseleave={() => (hovered = false)}
-  on:mousedown={(e) => startTabDrag(e, surface.id, paneId, workspaceId)}
+  on:mousedown={(e) => {
+    if (!_renaming) startTabDrag(e, surface.id, paneId, workspaceId);
+  }}
 >
   {#if agentDotColor}
     <svg
@@ -79,13 +155,18 @@
       style="width: 5px; height: 5px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"
     ></span>
   {/if}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <span
+    bind:this={nameEl}
     style="
       overflow: hidden; text-overflow: ellipsis;
       {isWaiting ? `color: ${agentDotColor}; font-weight: 600;` : ''}
     "
+    on:blur={finishRename}
+    on:keydown={handleNameKeydown}
+    on:dblclick|stopPropagation={() => renamingSurfaceId.set(surface.id)}
   >
-    {surface.title || `Shell ${index + 1}`}
+    {#if !_renaming}{surface.title || `Shell ${index + 1}`}{/if}
   </span>
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/services/keyboard-shortcuts.ts
+++ b/src/lib/services/keyboard-shortcuts.ts
@@ -29,6 +29,7 @@ import { executeByShortcut } from "./command-registry";
 import { executeWorkspaceActionByShortcut } from "./workspace-action-registry";
 import { isMac } from "../terminal-service";
 import { zoomIn, zoomOut, resetFontSize } from "../stores/font-size";
+import { renameActiveSurface } from "./surface-service";
 
 /**
  * Context required by shortcuts that have to reach into component
@@ -65,6 +66,7 @@ export function handleAppKeydown(
       },
       p: () => commandPaletteOpen.update((v) => !v),
       f: () => findBarVisible.update((v) => !v),
+      r: () => renameActiveSurface(),
       g: () => {
         findBarVisible.set(true);
         ctx.findNext();

--- a/src/lib/services/surface-service.ts
+++ b/src/lib/services/surface-service.ts
@@ -7,6 +7,7 @@ import {
   activePane,
   activeSurface,
 } from "../stores/workspace";
+import { renamingSurfaceId } from "../stores/ui";
 import { createTerminalSurface } from "../terminal-service";
 import {
   getAllPanes,
@@ -389,4 +390,24 @@ export function openFileAsPreviewSplit(filePath: string): void {
   if (!result) return;
 
   createPreviewSurfaceInPane(result.newPane.id, filePath);
+}
+
+export function renameActiveSurface(): void {
+  const s = get(activeSurface);
+  if (s) renamingSurfaceId.set(s.id);
+}
+
+export function renameSurface(surfaceId: string, title: string): void {
+  workspaces.update((wsList) => {
+    for (const ws of wsList) {
+      for (const pane of getAllPanes(ws.splitRoot)) {
+        const s = pane.surfaces.find((s) => s.id === surfaceId);
+        if (s) {
+          s.title = title;
+          return [...wsList];
+        }
+      }
+    }
+    return wsList;
+  });
 }

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -225,3 +225,5 @@ export function showFormPrompt(
     });
   });
 }
+
+export const renamingSurfaceId = writable<string | null>(null);


### PR DESCRIPTION
## Summary

- Adds inline tab rename: press ⌘R (Mac) / Ctrl+R (Linux) on the active tab to enter edit mode
- Double-clicking any tab title also enters rename mode
- Enter or blur commits the new name; Escape reverts

## Implementation

- `renamingSurfaceId` writable store in `ui.ts` coordinates rename activation across all rendered tabs
- `renameActiveSurface()` reads `activeSurface` and sets the store; `renameSurface()` commits the title to the workspace store
- ⌘R wired in `keyboard-shortcuts.ts` alongside existing ⌘K/⌘F/zoom shortcuts (no context threading needed)
- `Tab.svelte` follows the `WorkspaceItem` contentEditable rename pattern; drag is suppressed during rename mode

## Test plan

- [ ] Open gnar-term with at least one workspace and tab
- [ ] Press ⌘R — active tab title becomes editable (selected text, styled input)
- [ ] Type a new name and press Enter — tab title updates
- [ ] Press ⌘R again, type something, press Escape — original name restored
- [ ] Double-click a tab title — same rename flow triggers
- [ ] Rename a tab, close and reopen the app — renamed title persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)