### PR TITLE
fix(agent-detection): detect agents after late workspace load

### DIFF
--- a/src/__tests__/agent-detection-service.test.ts
+++ b/src/__tests__/agent-detection-service.test.ts
@@ -572,6 +572,63 @@ describe("agent-detection-service — lifecycle hygiene", () => {
   });
 });
 
+describe("agent-detection-service — late workspace load (startup race)", () => {
+  it("attaches agent when workspaces load after surface:created and surface:ptyReady", () => {
+    // Simulates the startup race: Tauri emits surface events before the
+    // workspace store is populated, so allTerminalSurfaces() returned []
+    // and the surface was tracked with no agent. When the workspace loads
+    // later, the agent should now be detected.
+    initAgentDetection();
+
+    eventBus.emit({
+      type: "surface:created",
+      id: "s1",
+      paneId: "p",
+      kind: "terminal",
+    });
+    eventBus.emit({ type: "surface:ptyReady", id: "s1", ptyId: 60 });
+    expect(getAgents()).toHaveLength(0);
+
+    workspaces.set([
+      makeWorkspace("w1", [{ id: "s1", title: "claude", ptyId: 60 }]),
+    ]);
+
+    expect(getAgents()).toHaveLength(1);
+    expect(getAgents()[0]?.workspaceId).toBe("w1");
+    const item = get(statusRegistry.store).find(
+      (i) => i.source === "_agent" && i.metadata?.surfaceId === "s1",
+    );
+    expect(item).toBeDefined();
+    expect(item?.label).toBe("idle");
+  });
+
+  it("publishes waiting status after workspace loads late then OSC fires", () => {
+    // The dot must show when Claude uses AskUserQuestion after workspaces
+    // were loaded post-surface-events — this was the reported "no dot" bug.
+    initAgentDetection();
+    eventBus.emit({
+      type: "surface:created",
+      id: "s1",
+      paneId: "p",
+      kind: "terminal",
+    });
+    eventBus.emit({ type: "surface:ptyReady", id: "s1", ptyId: 61 });
+
+    workspaces.set([
+      makeWorkspace("w1", [{ id: "s1", title: "claude", ptyId: 61 }]),
+    ]);
+    expect(getAgents()).toHaveLength(1);
+
+    notifyOutputObservers(61, "\x1b]9;waiting for response\x07");
+
+    const item = get(statusRegistry.store).find(
+      (i) => i.source === "_agent" && i.metadata?.surfaceId === "s1",
+    );
+    expect(item?.label).toBe("waiting");
+    expect(item?.variant).toBe("warning");
+  });
+});
+
 describe("agent-detection-service — workspace:closed cleanup", () => {
   it("removes agents from a workspace when workspace:closed fires", () => {
     // closeWorkspace() emits workspace:closed but NOT surface:closed for

--- a/src/lib/services/agent-detection-service.ts
+++ b/src/lib/services/agent-detection-service.ts
@@ -255,6 +255,10 @@ interface TrackedSurface {
   tracker: StatusTracker | null;
   unsubscribeOutput: (() => void) | null;
   preAgentTitle?: string;
+  /** Most recent title seen for this surface — used by the workspace
+   *  subscription to derive a pre-agent title when attaching after a
+   *  late workspace load. */
+  lastKnownTitle?: string;
   /** Pending debounced detach timer — cancelled if title re-matches before it fires. */
   detachTimer: ReturnType<typeof setTimeout> | null;
 }
@@ -487,6 +491,7 @@ export function initAgentDetection(): void {
       agentPattern: null,
       tracker: null,
       unsubscribeOutput: null,
+      lastKnownTitle: initialTitle || undefined,
       detachTimer: null,
     };
     trackedSurfaces.set(surfaceId, tracked);
@@ -613,6 +618,7 @@ export function initAgentDetection(): void {
         }, TITLE_DETACH_DEBOUNCE_MS);
       }
     }
+    tracked.lastKnownTitle = event.newTitle;
   };
   const handleClosed = (event: { type: "surface:closed"; id: string }) => {
     detachFromSurface(event.id);
@@ -646,9 +652,12 @@ export function initAgentDetection(): void {
     let tracked = trackedSurfaces.get(event.id);
     if (!tracked) {
       // Missed surface:created (e.g. init raced with a restore) —
-      // attach now with an empty title and fall through to observer
-      // wiring.
-      attachToSurface(event.id, "");
+      // attach now using the current title from the workspace store
+      // (may be empty if workspaces haven't loaded yet) and fall
+      // through to observer wiring.
+      const currentTitleForPty =
+        allTerminalSurfaces().find((s) => s.id === event.id)?.title ?? "";
+      attachToSurface(event.id, currentTitleForPty);
       tracked = trackedSurfaces.get(event.id);
       if (!tracked) return;
     }
@@ -673,6 +682,34 @@ export function initAgentDetection(): void {
   for (const info of allTerminalSurfaces()) {
     attachToSurface(info.id, info.title);
   }
+
+  // Re-detect agents when the workspace store is populated or updated.
+  // Handles the startup race where surface events (surface:created,
+  // surface:ptyReady) arrive before workspaces finish loading — at that
+  // point allTerminalSurfaces() returned [] so surfaces were tracked
+  // without agents. When workspaces load, this subscription re-checks
+  // unattached surfaces against their now-known titles.
+  const unsubWorkspaces = workspaces.subscribe(() => {
+    for (const [, tracked] of trackedSurfaces) {
+      if (tracked.agentId) continue;
+      const currentTitle =
+        allTerminalSurfaces().find((s) => s.id === tracked.surfaceId)?.title ??
+        "";
+      if (!currentTitle) continue;
+      const match = matchesPattern(currentTitle, patterns);
+      if (match) {
+        // If lastKnownTitle predates the agent pattern match, use it as the
+        // pre-agent title so detachAgent can restore it on exit.
+        const preTitle =
+          tracked.lastKnownTitle &&
+          !matchesPattern(tracked.lastKnownTitle, patterns)
+            ? tracked.lastKnownTitle
+            : undefined;
+        attachAgent(tracked, match, idleTimeoutMs, preTitle);
+      }
+    }
+  });
+  cleanups.push(unsubWorkspaces);
 
   _current = {
     destroy() {


### PR DESCRIPTION
## Summary

- Fixes the startup race where surface events (`surface:created`, `surface:ptyReady`) fire before the workspace store is populated, leaving Claude Code sessions with no status dot
- Adds a `workspaces` store subscription inside `initAgentDetection()` that re-checks unattached surfaces whenever the store changes, attaching agents once titles are known
- Tracks `lastKnownTitle` on each surface so the pre-agent title is preserved for title restoration when agents detach
- `handlePtyReady` now looks up the current title from the workspace store instead of passing an empty string when a missed surface is encountered

## Stories completed
- [x] Status dot no longer disappears intermittently when a Claude Code session is restored from a previous run

## Test plan
- [ ] Start gnar-term with an existing Claude Code session from a previous run — verify the status dot appears (gray/green) without needing to interact with the terminal
- [ ] Trigger `AskUserQuestion` in Claude Code — verify the yellow pulsing dot appears in the tab
- [ ] Wait 30s for Claude to go idle — verify a gray dot still shows
- [ ] Close the Claude process — verify the dot disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)