### PR TITLE
feat: active pane indicator + plain-click hyperlinks

### DIFF
--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1959,36 +1959,70 @@ describe("PreviewSurface link interception", () => {
 });
 
 describe("terminal link handling", () => {
-  it("WebLinksAddon is constructed with a custom handler that invokes open_url", async () => {
-    const { WebLinksAddon: WebLinksAddonMock } =
-      await import("@xterm/addon-web-links");
-    // WebLinksAddon constructor: new WebLinksAddon(handler?, options?)
-    const WebLinksAddonCtor = vi.mocked(
-      WebLinksAddonMock as unknown as new (
-        handler: (e: MouseEvent, url: string) => void,
-      ) => object,
-    );
+  it("registerLinkProvider is called and link activate invokes open_url", async () => {
     const { invoke: invokeMock } = await import("@tauri-apps/api/core");
     const invokeMockFn = vi.mocked(invokeMock);
     invokeMockFn.mockClear();
-    WebLinksAddonCtor.mockClear();
+
+    const { Terminal: TerminalMock } = await import("@xterm/xterm");
+    // TerminalMock is the mock constructor; instances track calls on the instance
+    const TerminalCtor = vi.mocked(
+      TerminalMock as unknown as new (...args: unknown[]) => {
+        registerLinkProvider: ReturnType<typeof vi.fn>;
+        loadAddon: ReturnType<typeof vi.fn>;
+        buffer: { active: { getLine: ReturnType<typeof vi.fn> } };
+      },
+    );
 
     const { createTerminalSurface } = await import("../lib/terminal-service");
-    const fakePane = { id: "p-link-test", surfaces: [], activeSurfaceId: null };
+    const fakePane = {
+      id: "p-link-plain-click",
+      surfaces: [],
+      activeSurfaceId: null,
+    };
     await createTerminalSurface(
       fakePane as unknown as Parameters<typeof createTerminalSurface>[0],
     );
 
-    expect(WebLinksAddonCtor).toHaveBeenCalledWith(expect.any(Function));
+    const termInstance = TerminalCtor.mock.instances.at(-1)!;
+    expect(termInstance.registerLinkProvider).toHaveBeenCalledTimes(1);
 
-    // Extract and invoke the handler directly (first positional argument)
-    const handler = WebLinksAddonCtor.mock.calls[
-      WebLinksAddonCtor.mock.calls.length - 1
-    ][0] as (e: MouseEvent, url: string) => void;
-    handler(new MouseEvent("click"), "https://example.com");
+    const provider = termInstance.registerLinkProvider.mock.calls[0][0] as {
+      provideLinks: (
+        line: number,
+        cb: (
+          links:
+            | Array<{ activate: (e: MouseEvent, text: string) => void }>
+            | undefined,
+        ) => void,
+      ) => void;
+    };
 
+    // Wire up the mock terminal's buffer so provideLinks can scan a real line
+    const mockLine = {
+      translateToString: vi
+        .fn()
+        .mockReturnValue("visit https://example.com/path for info"),
+    };
+    termInstance.buffer = {
+      active: { getLine: vi.fn().mockReturnValue(mockLine) },
+    };
+
+    let capturedLinks:
+      | Array<{ activate: (e: MouseEvent, text: string) => void }>
+      | undefined;
+    provider.provideLinks(1, (links) => {
+      capturedLinks = links;
+    });
+
+    expect(capturedLinks).toBeDefined();
+    expect(capturedLinks!.length).toBeGreaterThan(0);
+    capturedLinks![0].activate(
+      new MouseEvent("click"),
+      "https://example.com/path",
+    );
     expect(invokeMockFn).toHaveBeenCalledWith("open_url", {
-      url: "https://example.com",
+      url: "https://example.com/path",
     });
   });
 });

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1985,7 +1985,8 @@ describe("terminal link handling", () => {
     );
 
     const termInstance = TerminalCtor.mock.instances.at(-1)!;
-    expect(termInstance.registerLinkProvider).toHaveBeenCalledTimes(1);
+    // 2 calls: URL provider (index 0, added by Task 5) + file-path provider (index 1, existing)
+    expect(termInstance.registerLinkProvider).toHaveBeenCalledTimes(2);
 
     const provider = termInstance.registerLinkProvider.mock.calls[0][0] as {
       provideLinks: (

--- a/src/__tests__/pane-view-notify.test.ts
+++ b/src/__tests__/pane-view-notify.test.ts
@@ -286,13 +286,11 @@ describe("PaneView notification chrome", () => {
 
     const root = container.firstChild as HTMLElement;
     expect(root.dataset.unread).toBe("true");
-    // notify wins over accent — data-unread present means notify branch taken
     expect(root.style.border).toContain("rgb(88, 166, 255)");
-    // Corner pip is only rendered when paneHasUnread is true — confirms the notify
-    // branch (not the accent branch) determined the border color.
+    // pip + glow are only rendered when paneHasUnread is true — proving the notify
+    // ternary branch was taken, not the isActive accent branch.
     const pip = container.querySelector('[title="New activity in this pane"]');
     expect(pip).not.toBeNull();
-    // Box-shadow glow is also only set when paneHasUnread is true.
     expect(root.style.boxShadow).toBeTruthy();
   });
 });

--- a/src/__tests__/pane-view-notify.test.ts
+++ b/src/__tests__/pane-view-notify.test.ts
@@ -231,6 +231,11 @@ describe("PaneView notification chrome", () => {
     const root = container.firstChild as HTMLElement;
     // github-dark theme accent = #58a6ff = rgb(88, 166, 255)
     expect(root.style.border).toContain("rgb(88, 166, 255)");
+    // No corner pip or glow when only isActive (no unread)
+    expect(
+      container.querySelector('[title="New activity in this pane"]'),
+    ).toBeNull();
+    expect(root.style.boxShadow).toBeFalsy();
   });
 
   it("renders default border when isActive is false and no surface has hasUnread", () => {
@@ -283,5 +288,11 @@ describe("PaneView notification chrome", () => {
     expect(root.dataset.unread).toBe("true");
     // notify wins over accent — data-unread present means notify branch taken
     expect(root.style.border).toContain("rgb(88, 166, 255)");
+    // Corner pip is only rendered when paneHasUnread is true — confirms the notify
+    // branch (not the accent branch) determined the border color.
+    const pip = container.querySelector('[title="New activity in this pane"]');
+    expect(pip).not.toBeNull();
+    // Box-shadow glow is also only set when paneHasUnread is true.
+    expect(root.style.boxShadow).toBeTruthy();
   });
 });

--- a/src/__tests__/pane-view-notify.test.ts
+++ b/src/__tests__/pane-view-notify.test.ts
@@ -206,4 +206,82 @@ describe("PaneView notification chrome", () => {
     expect(onFocusPane).toHaveBeenCalledTimes(1);
     expect(surface.hasUnread).toBe(false);
   });
+
+  it("renders accent border when isActive is true and no surface has hasUnread", () => {
+    const surface = makeTerminalSurface("s1", false);
+    const pane = makePane([surface]);
+    setupWorkspace(pane);
+
+    const { container } = render(PaneView, {
+      props: {
+        pane,
+        workspaceId: "ws1",
+        isActive: true,
+        onSelectSurface: noop,
+        onCloseSurface: noop,
+        onNewSurface: noop,
+        onSelectSurfaceType: noop,
+        onSplitRight: noop,
+        onSplitDown: noop,
+        onClosePane: noop,
+        onFocusPane: noop,
+      },
+    });
+
+    const root = container.firstChild as HTMLElement;
+    // github-dark theme accent = #58a6ff = rgb(88, 166, 255)
+    expect(root.style.border).toContain("rgb(88, 166, 255)");
+  });
+
+  it("renders default border when isActive is false and no surface has hasUnread", () => {
+    const surface = makeTerminalSurface("s1", false);
+    const pane = makePane([surface]);
+    setupWorkspace(pane);
+
+    const { container } = render(PaneView, {
+      props: {
+        pane,
+        workspaceId: "ws1",
+        isActive: false,
+        onSelectSurface: noop,
+        onCloseSurface: noop,
+        onNewSurface: noop,
+        onSelectSurfaceType: noop,
+        onSplitRight: noop,
+        onSplitDown: noop,
+        onClosePane: noop,
+        onFocusPane: noop,
+      },
+    });
+
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.border).not.toContain("rgb(88, 166, 255)");
+  });
+
+  it("renders notify border (unread wins) when isActive is true and a surface has hasUnread", () => {
+    const surface = makeTerminalSurface("s1", true);
+    const pane = makePane([surface]);
+    setupWorkspace(pane);
+
+    const { container } = render(PaneView, {
+      props: {
+        pane,
+        workspaceId: "ws1",
+        isActive: true,
+        onSelectSurface: noop,
+        onCloseSurface: noop,
+        onNewSurface: noop,
+        onSelectSurfaceType: noop,
+        onSplitRight: noop,
+        onSplitDown: noop,
+        onClosePane: noop,
+        onFocusPane: noop,
+      },
+    });
+
+    const root = container.firstChild as HTMLElement;
+    expect(root.dataset.unread).toBe("true");
+    // notify wins over accent — data-unread present means notify branch taken
+    expect(root.style.border).toContain("rgb(88, 166, 255)");
+  });
 });

--- a/src/lib/components/PaneView.svelte
+++ b/src/lib/components/PaneView.svelte
@@ -33,6 +33,7 @@
   export let onSplitDown: () => void;
   export let onClosePane: () => void;
   export let onFocusPane: () => void;
+  export let isActive: boolean = false;
 
   let paneEl: HTMLElement;
   let resizeObserver: ResizeObserver;
@@ -186,7 +187,11 @@
     position: relative;
     --notify: {$theme.notify};
     --notify-glow: {$theme.notifyGlow};
-    border: 1px solid {paneHasUnread ? $theme.notify : $theme.border};
+    border: 1px solid {paneHasUnread
+    ? $theme.notify
+    : isActive
+      ? $theme.accent
+      : $theme.border};
     border-radius: 4px; overflow: hidden;
     {paneHasUnread
     ? `box-shadow: 0 0 0 1px ${$theme.notifyGlow}, 0 0 14px 1px ${$theme.notifyGlow};`

--- a/src/lib/components/SplitNodeView.svelte
+++ b/src/lib/components/SplitNodeView.svelte
@@ -48,6 +48,7 @@
   <PaneView
     pane={node.pane}
     workspaceId={workspace.id}
+    isActive={workspace.activePaneId === node.pane.id}
     onSelectSurface={(sid) => onSelectSurface(node.pane.id, sid)}
     onCloseSurface={(sid) => onCloseSurface(node.pane.id, sid)}
     onNewSurface={() => onNewSurface(node.pane.id)}

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -7,8 +7,8 @@
  */
 
 import { Terminal } from "@xterm/xterm";
+import type { ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
 import { invoke, Channel } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -562,12 +562,39 @@ export async function createTerminalSurface(
   const fitAddon = new FitAddon();
   const searchAddon = new SearchAddon();
   terminal.loadAddon(fitAddon);
-  terminal.loadAddon(
-    new WebLinksAddon((_event: MouseEvent, url: string) => {
-      invoke("open_url", { url }).catch(() => {});
-    }),
-  );
   terminal.loadAddon(searchAddon);
+
+  const urlRegex = /https?:\/\/[^\s"'<>()[\]{}]+/g;
+  terminal.registerLinkProvider({
+    provideLinks(lineNumber, callback) {
+      const line = terminal.buffer.active.getLine(lineNumber);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+      const text = line.translateToString(true);
+      const links: ILink[] = [];
+      urlRegex.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = urlRegex.exec(text)) !== null) {
+        const url = m[0]!;
+        const startX = m.index + 1;
+        const endX = m.index + url.length;
+        links.push({
+          range: {
+            start: { x: startX, y: lineNumber },
+            end: { x: endX, y: lineNumber },
+          },
+          text: url,
+          decorations: { pointerCursor: true, underline: true },
+          activate(_event: MouseEvent, text: string) {
+            invoke("open_url", { url: text }).catch(() => {});
+          },
+        });
+      }
+      callback(links.length > 0 ? links : undefined);
+    },
+  });
 
   const termElement = document.createElement("div");
   termElement.style.cssText =


### PR DESCRIPTION
## Summary

- **Active pane indicator**: accent-colored border (`$theme.accent`) on the focused pane in split workspaces; `$theme.notify` (unread) wins over accent when both apply. Inactive panes fall back to `$theme.border`. Threaded `isActive` prop from `SplitNodeView` → `PaneView` using the existing `workspace.activePaneId`.
- **Plain-click hyperlinks**: replaced `WebLinksAddon` with a custom `registerLinkProvider` that fires `open_url` on plain left-click (no modifier key required). HTTP/HTTPS URLs matched via regex; Rust security boundary unchanged.

## Test plan

- [ ] Open a workspace and split into two panes — active pane shows accent border; inactive pane shows default border
- [ ] Click the inactive pane — it becomes active (accent border moves), previous active pane loses accent border
- [ ] Trigger an unread notification on the inactive pane — `$theme.notify` border + corner pip render; click the pane to clear
- [ ] Print a URL (`echo https://example.com`) in a terminal and plain-click it — browser opens without holding Cmd/Ctrl
- [ ] Verify Cmd/Ctrl+click still works (xterm default behavior preserved via fallthrough)
- [ ] `npm test` — 1398 tests pass
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` — exits 0