### PR TITLE
chore: sync package-lock.json version to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gnar-term",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnar-term",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "dependencies": {
         "@embedpdf/snippet": "^2.12.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",


### PR DESCRIPTION
## Summary
- Syncs `package-lock.json` version field from `0.3.1` to `0.5.0` to match `package.json`

## Test plan
- [x] All 1407 tests pass
- [x] Pre-commit hooks pass (typecheck, svelte-check, rust-check, rust-clippy, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)