### PR TITLE
fix(audit): apply all audit findings + shortcut hint overlay (2026-04-27)

### DIFF
--- a/src-tauri/src/git_info.rs
+++ b/src-tauri/src/git_info.rs
@@ -93,6 +93,27 @@ pub async fn git_remote_url(repo_path: String) -> Result<String, String> {
     }
 }
 
+/// Validate a git ref string against a strict allowlist of characters.
+///
+/// Accepts only alphanumeric characters plus hyphen, underscore, dot,
+/// slash, and `@` — the characters that appear in valid git ref names,
+/// branch names, and commit SHAs. Rejects anything else to prevent
+/// ref-parsing edge cases from reaching git.
+fn validate_git_ref(r: &str) -> Result<(), String> {
+    if r.is_empty() {
+        return Err("git ref must not be empty".to_string());
+    }
+    let invalid: Vec<char> = r
+        .chars()
+        .filter(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '/' | '@' | '{' | '}'))
+        .collect();
+    if invalid.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("git ref contains invalid characters: {invalid:?}"))
+    }
+}
+
 /// Return the raw unified-diff text for a repository. All filter args
 /// are optional and compose:
 ///   - `staged = true`         → `git diff --staged`
@@ -120,6 +141,12 @@ pub async fn git_diff(
         args.push("--staged".to_string());
     }
     args.push("--end-of-options".to_string());
+    if let Some(b) = base.as_deref() {
+        validate_git_ref(b)?;
+    }
+    if let Some(h) = head.as_deref() {
+        validate_git_ref(h)?;
+    }
     match (base.as_deref(), head.as_deref()) {
         (Some(b), Some(h)) => args.push(format!("{b}..{h}")),
         (Some(b), None) => args.push(b.to_string()),
@@ -191,5 +218,36 @@ mod tests {
     fn strip_userinfo_leaves_plain_https_unchanged() {
         let url = "https://github.com/org/repo";
         assert_eq!(strip_userinfo(url), url);
+    }
+
+    // --- validate_git_ref tests (F33) ---
+
+    #[test]
+    fn git_ref_accepts_branch_names() {
+        assert!(validate_git_ref("main").is_ok());
+        assert!(validate_git_ref("feature/my-branch").is_ok());
+        assert!(validate_git_ref("v1.2.3").is_ok());
+        assert!(validate_git_ref("HEAD@{1}").is_ok());
+        assert!(validate_git_ref("abc1234def5678").is_ok());
+    }
+
+    #[test]
+    fn git_ref_rejects_empty_string() {
+        assert!(validate_git_ref("").is_err());
+    }
+
+    #[test]
+    fn git_ref_rejects_shell_special_chars() {
+        assert!(validate_git_ref("main;rm -rf /").is_err());
+        assert!(validate_git_ref("$(evil)").is_err());
+        assert!(validate_git_ref("main\x00evil").is_err());
+        assert!(validate_git_ref("branch name").is_err()); // space
+    }
+
+    #[test]
+    fn git_ref_rejects_tilde_and_caret() {
+        // ~ and ^ have special meaning to git's rev-parse and are not in the allowlist
+        assert!(validate_git_ref("HEAD~1").is_err());
+        assert!(validate_git_ref("HEAD^").is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,22 @@ enum OscAction {
     Ignore,
 }
 
+/// Sanitize a notification text string received from PTY output.
+///
+/// Strips C0/C1 control characters (U+0000–U+001F, U+007F, U+0080–U+009F)
+/// and limits the result to 500 characters to prevent malicious PTY output
+/// from injecting control sequences into system notifications.
+fn sanitize_notification(text: &str) -> String {
+    text.chars()
+        .filter(|&c| {
+            let n = c as u32;
+            // Exclude C0 (0x00–0x1F), DEL (0x7F), and C1 (0x80–0x9F)
+            !(n <= 0x1F || n == 0x7F || (0x80..=0x9F).contains(&n))
+        })
+        .take(500)
+        .collect()
+}
+
 /// Classify a raw OSC payload (the bytes between `ESC]` and `BEL`/`ST`).
 ///
 /// Returns an `OscAction` describing what the sequence means.
@@ -211,10 +227,10 @@ fn classify_osc(raw: &str) -> OscAction {
             (true, false) => body.to_string(),
             (false, false) => format!("{title}: {body}"),
         };
-        return OscAction::Notification(formatted);
+        return OscAction::Notification(sanitize_notification(&formatted));
     }
 
-    OscAction::Notification(text.to_string())
+    OscAction::Notification(sanitize_notification(text))
 }
 
 /// Shared pause state — uses a Condvar so the reader thread blocks efficiently
@@ -3304,6 +3320,53 @@ mod tests {
     fn osc9_number_without_semicolon_is_notification() {
         // A payload like "9;42" — just a number, no sub-command semicolon
         assert_eq!(classify_osc("9;42"), OscAction::Notification("42".into()));
+    }
+
+    // --- sanitize_notification tests (F17) ---
+
+    #[test]
+    fn sanitize_strips_c0_control_characters() {
+        // NUL, BEL, ESC, etc. should be removed
+        let input = "hello\x00world\x07\x1b[31m";
+        assert_eq!(sanitize_notification(input), "helloworld[31m");
+    }
+
+    #[test]
+    fn sanitize_strips_del_and_c1_controls() {
+        let input = "foo\x7fbar\u{0080}\u{009f}baz";
+        assert_eq!(sanitize_notification(input), "foobarbaz");
+    }
+
+    #[test]
+    fn sanitize_truncates_to_500_chars() {
+        let long = "a".repeat(600);
+        let result = sanitize_notification(&long);
+        assert_eq!(result.len(), 500);
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_unicode() {
+        let input = "Build complete \u{2705}";
+        assert_eq!(sanitize_notification(input), input);
+    }
+
+    #[test]
+    fn osc9_notification_strips_control_chars() {
+        // A PTY payload containing an embedded ESC sequence should be sanitized
+        assert_eq!(
+            classify_osc("9;Hello\x1b[1mWorld"),
+            OscAction::Notification("Hello[1mWorld".into())
+        );
+    }
+
+    #[test]
+    fn osc_notification_truncated_at_500_chars() {
+        let long_payload = format!("9;{}", "x".repeat(600));
+        if let OscAction::Notification(text) = classify_osc(&long_payload) {
+            assert_eq!(text.len(), 500);
+        } else {
+            panic!("Expected Notification variant");
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -559,7 +559,7 @@
       id: "core:new-workspace",
       label: "New Workspace",
       icon: "plus",
-      shortcut: isMac ? "Cmd+Shift+N" : "Ctrl+Shift+N",
+      shortcut: `${shiftModLabel}N`,
       source: "core",
       handler: (ctx) => {
         const name = `Workspace ${get(workspaces).length + 1}`;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { listen } from "@tauri-apps/api/event";
   import { getCurrentWindow } from "@tauri-apps/api/window";
   import { ask } from "@tauri-apps/plugin-dialog";
@@ -101,6 +101,7 @@
   import { registerWorkspaceAction } from "./lib/services/workspace-action-registry";
   import { initMcpServer } from "./lib/services/mcp-server";
   import { handleAppKeydown } from "./lib/services/keyboard-shortcuts";
+  import { initShortcutHints } from "./lib/stores/shortcut-hints";
 
   // Components
   import PrimarySidebar from "./lib/components/PrimarySidebar.svelte";
@@ -469,7 +470,11 @@
   }
 
   // ---- Initialization ----
+  let _cleanupShortcutHints: (() => void) | null = null;
+  onDestroy(() => _cleanupShortcutHints?.());
+
   onMount(async () => {
+    _cleanupShortcutHints = initShortcutHints();
     await fontReady;
     void setupListeners();
     startCwdPolling();

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -27,14 +27,15 @@ describe("DragGrip", () => {
     cleanup();
   });
 
-  it("renders with role=button and accessible label", () => {
+  it("is aria-hidden (pointer-only decoration, not keyboard interactive)", () => {
     const onMouseDown = vi.fn();
     const { container } = render(DragGrip, {
       props: { theme: stubTheme, visible: true, onMouseDown },
     });
-    const grip = container.querySelector('[role="button"]');
+    const grip = container.querySelector(".drag-grip");
     expect(grip).not.toBeNull();
-    expect(grip?.getAttribute("aria-label")).toMatch(/drag/i);
+    expect(grip?.getAttribute("aria-hidden")).toBe("true");
+    expect(grip?.getAttribute("role")).toBeNull();
   });
 
   it("calls onMouseDown when pressed", async () => {
@@ -42,7 +43,7 @@ describe("DragGrip", () => {
     const { container } = render(DragGrip, {
       props: { theme: stubTheme, visible: true, onMouseDown },
     });
-    const grip = container.querySelector('[role="button"]') as HTMLElement;
+    const grip = container.querySelector(".drag-grip") as HTMLElement;
     await fireEvent.mouseDown(grip);
     expect(onMouseDown).toHaveBeenCalledTimes(1);
   });

--- a/src/__tests__/service-helpers.test.ts
+++ b/src/__tests__/service-helpers.test.ts
@@ -16,10 +16,12 @@ vi.mock("svelte", () => ({
 
 vi.mock("../lib/stores/workspace", () => ({
   activeSurface: writable(null),
+  workspaces: writable([]),
 }));
 
 vi.mock("../lib/types", () => ({
   isTerminalSurface: vi.fn((s) => s?.kind === "terminal"),
+  getAllPanes: vi.fn(() => []),
 }));
 
 import { invoke } from "@tauri-apps/api/core";

--- a/src/__tests__/shortcut-hint-action.test.ts
+++ b/src/__tests__/shortcut-hint-action.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// vi.hoisted runs before module imports — inline a minimal writable-like store
+// so the vi.mock factory below can reference it without a TDZ error.
+const _hintsActive = vi.hoisted(() => {
+  let _value = false;
+  const _subs = new Set<(v: boolean) => void>();
+  return {
+    subscribe(fn: (v: boolean) => void) {
+      _subs.add(fn);
+      fn(_value);
+      return () => _subs.delete(fn);
+    },
+    set(v: boolean) {
+      _value = v;
+      _subs.forEach((fn) => fn(v));
+    },
+  };
+});
+
+vi.mock("../lib/stores/shortcut-hints", () => ({
+  shortcutHintsActive: { subscribe: _hintsActive.subscribe },
+}));
+
+vi.mock("../lib/stores/theme", () => ({
+  theme: {
+    subscribe: vi.fn((fn: (v: object) => void) => {
+      fn({ accent: "#ff0000", bg: "#000000" });
+      return () => {};
+    }),
+  },
+}));
+
+import { shortcutHint } from "../lib/actions/shortcut-hint";
+
+function makeNode(): HTMLElement {
+  const node = document.createElement("div");
+  vi.spyOn(node, "getBoundingClientRect").mockReturnValue({
+    left: 10,
+    right: 110,
+    top: 20,
+    bottom: 40,
+    width: 100,
+    height: 20,
+    x: 10,
+    y: 20,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return node;
+}
+
+describe("shortcut-hint action", () => {
+  beforeEach(() => {
+    _hintsActive.set(false);
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("appends no badge when hints are inactive", () => {
+    const node = makeNode();
+    shortcutHint(node, "⌘T");
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("appends a badge when hints become active", () => {
+    const node = makeNode();
+    shortcutHint(node, "⌘T");
+
+    _hintsActive.set(true);
+
+    expect(document.body.children.length).toBe(1);
+    expect(document.body.children[0].textContent).toBe("⌘T");
+  });
+
+  it("removes badge when hints deactivate", () => {
+    const node = makeNode();
+    shortcutHint(node, "⌘T");
+
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(1);
+
+    _hintsActive.set(false);
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("badge is aria-hidden and pointer-events:none", () => {
+    const node = makeNode();
+    shortcutHint(node, "⌘T");
+    _hintsActive.set(true);
+
+    const badge = document.body.children[0] as HTMLElement;
+    expect(badge.getAttribute("aria-hidden")).toBe("true");
+    expect(badge.style.pointerEvents).toBe("none");
+  });
+
+  it("appends no badge when label is null", () => {
+    const node = makeNode();
+    shortcutHint(node, null);
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("appends no badge when label is undefined", () => {
+    const node = makeNode();
+    shortcutHint(node, undefined);
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("update() changes badge text while hints are active", () => {
+    const node = makeNode();
+    const action = shortcutHint(node, "⌘T");
+    _hintsActive.set(true);
+
+    action.update("⌘B");
+    expect(document.body.children[0].textContent).toBe("⌘B");
+  });
+
+  it("update() removes badge when new label is null", () => {
+    const node = makeNode();
+    const action = shortcutHint(node, "⌘T");
+    _hintsActive.set(true);
+
+    action.update(null);
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("update() shows badge when label becomes truthy during active hints", () => {
+    const node = makeNode();
+    const action = shortcutHint(node, undefined);
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(0);
+
+    action.update("⌘1");
+    expect(document.body.children.length).toBe(1);
+    expect(document.body.children[0].textContent).toBe("⌘1");
+  });
+
+  it("destroy() removes badge and unsubscribes", () => {
+    const node = makeNode();
+    const action = shortcutHint(node, "⌘T");
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(1);
+
+    action.destroy();
+    expect(document.body.children.length).toBe(0);
+
+    // After destroy, re-activating hints must not bring the badge back
+    _hintsActive.set(false);
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(0);
+  });
+
+  it("does not duplicate badge on repeated active signals", () => {
+    const node = makeNode();
+    shortcutHint(node, "⌘T");
+
+    _hintsActive.set(true);
+    _hintsActive.set(true);
+    expect(document.body.children.length).toBe(1);
+  });
+});

--- a/src/__tests__/shortcut-hints.test.ts
+++ b/src/__tests__/shortcut-hints.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("../lib/terminal-service", () => ({
+  isMac: true,
+  modLabel: "⌘",
+  shiftModLabel: "⇧⌘",
+}));
+
+// Capture window listeners so we can fire them manually
+type Listener = (e: Event) => void;
+const listeners: Record<string, Listener[]> = {};
+
+vi.stubGlobal("window", {
+  addEventListener: vi.fn((type: string, fn: Listener) => {
+    if (!listeners[type]) listeners[type] = [];
+    listeners[type].push(fn);
+  }),
+  removeEventListener: vi.fn((type: string, fn: Listener) => {
+    if (listeners[type]) {
+      listeners[type] = listeners[type].filter((l) => l !== fn);
+    }
+  }),
+});
+
+function fire(type: string, eventInit: Partial<KeyboardEvent> = {}) {
+  const event = Object.assign(
+    { type, key: "", repeat: false, preventDefault: vi.fn() },
+    eventInit,
+  );
+  for (const fn of listeners[type] ?? []) fn(event as unknown as Event);
+}
+
+describe("shortcut-hints store", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Reset listener registry between tests
+    for (const key of Object.keys(listeners)) delete listeners[key];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function load() {
+    const mod = await import("../lib/stores/shortcut-hints");
+    return mod;
+  }
+
+  it("store starts as false", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+    expect(get(shortcutHintsActive)).toBe(false);
+  });
+
+  it("becomes true after holding modifier for 1s", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    expect(get(shortcutHintsActive)).toBe(false);
+
+    vi.advanceTimersByTime(1000);
+    expect(get(shortcutHintsActive)).toBe(true);
+  });
+
+  it("stays false if modifier released before 1s", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(500);
+    fire("keyup", { key: "Meta" });
+    vi.advanceTimersByTime(1000);
+
+    expect(get(shortcutHintsActive)).toBe(false);
+  });
+
+  it("cancels and stays false when any other key is pressed during hold", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(500);
+    fire("keydown", { key: "t" });
+    vi.advanceTimersByTime(1000);
+
+    expect(get(shortcutHintsActive)).toBe(false);
+  });
+
+  it("hides hints on modifier keyup after activation", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(1000);
+    expect(get(shortcutHintsActive)).toBe(true);
+
+    fire("keyup", { key: "Meta" });
+    expect(get(shortcutHintsActive)).toBe(false);
+  });
+
+  it("cancels and hides on window blur", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(1000);
+    expect(get(shortcutHintsActive)).toBe(true);
+
+    fire("blur");
+    expect(get(shortcutHintsActive)).toBe(false);
+  });
+
+  it("ignores repeated keydown events (does not reset timer)", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(500);
+    // Simulated key-repeat should be ignored
+    fire("keydown", { key: "Meta", repeat: true });
+    fire("keydown", { key: "Meta", repeat: true });
+    vi.advanceTimersByTime(500);
+
+    expect(get(shortcutHintsActive)).toBe(true);
+  });
+
+  it("cleanup removes listeners and resets store", async () => {
+    const { shortcutHintsActive, initShortcutHints } = await load();
+    const cleanup = initShortcutHints();
+
+    fire("keydown", { key: "Meta" });
+    vi.advanceTimersByTime(1000);
+    expect(get(shortcutHintsActive)).toBe(true);
+
+    cleanup();
+    expect(get(shortcutHintsActive)).toBe(false);
+    expect(window.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/workspace-grip.test.ts
+++ b/src/__tests__/workspace-grip.test.ts
@@ -26,7 +26,7 @@ const noop = () => {};
 describe("WorkspaceItem drag grip", () => {
   afterEach(() => cleanup());
 
-  it("renders a DragGrip with drag aria-label", () => {
+  it("renders a DragGrip", () => {
     const { container } = render(WorkspaceItem, {
       props: {
         workspace: makeWorkspace(),
@@ -39,9 +39,7 @@ describe("WorkspaceItem drag grip", () => {
         onGripMouseDown: vi.fn(),
       },
     });
-    const grip = container.querySelector(
-      '[role="button"][aria-label*="rag" i]',
-    );
+    const grip = container.querySelector(".drag-grip");
     expect(grip).not.toBeNull();
   });
 
@@ -59,9 +57,7 @@ describe("WorkspaceItem drag grip", () => {
         onGripMouseDown,
       },
     });
-    const grip = container.querySelector(
-      '[role="button"][aria-label*="rag" i]',
-    ) as HTMLElement;
+    const grip = container.querySelector(".drag-grip") as HTMLElement;
     await fireEvent.mouseDown(grip);
     expect(onGripMouseDown).toHaveBeenCalledTimes(1);
   });
@@ -80,9 +76,7 @@ describe("WorkspaceItem drag grip", () => {
       },
     });
     const row = container.querySelector("[data-drag-idx]") as HTMLElement;
-    const grip = container.querySelector(
-      '[role="button"][aria-label*="rag" i]',
-    ) as HTMLElement;
+    const grip = container.querySelector(".drag-grip") as HTMLElement;
     // Baseline: the grip is in its collapsed 10px width until hover.
     expect(grip.style.width).toBe("10px");
     // Hover the row body (not the grip itself) — the grip should expand.

--- a/src/extensions/claude-settings/components/sections/EnvSection.svelte
+++ b/src/extensions/claude-settings/components/sections/EnvSection.svelte
@@ -36,6 +36,7 @@
     <div class="env-row">
       <code class="env-key" style="color: {theme.fg};">{key}</code>
       <input
+        aria-label={`Value for ${key}`}
         value={val}
         style={inputStyle("flex: 1;")}
         on:change={(e) => updateValue(key, e.currentTarget.value)}
@@ -51,12 +52,14 @@
 
   <div class="add-row">
     <input
+      aria-label="New environment variable key"
       bind:value={newKey}
       placeholder="KEY"
       style={inputStyle("width: 140px;")}
       on:keydown={(e) => e.key === "Enter" && addEntry()}
     />
     <input
+      aria-label="New environment variable value"
       bind:value={newVal}
       placeholder="value"
       style={inputStyle("flex: 1;")}

--- a/src/extensions/claude-settings/components/sections/HooksSection.svelte
+++ b/src/extensions/claude-settings/components/sections/HooksSection.svelte
@@ -121,6 +121,7 @@
           >
             <input
               bind:value={newCommands[event]}
+              aria-label={`Command for ${event} hook`}
               placeholder="command to run"
               style={inputStyle("flex: 1;")}
               on:keydown={(e) => {

--- a/src/extensions/claude-settings/components/sections/McpSection.svelte
+++ b/src/extensions/claude-settings/components/sections/McpSection.svelte
@@ -63,12 +63,14 @@
         <button
           class="remove-btn"
           style="color: {theme.fgDim};"
+          aria-label={`Remove ${name} from enabled servers`}
           on:click={() => removeEnabled(name)}>×</button
         >
       </div>
     {/each}
     <div class="add-row">
       <input
+        aria-label="New enabled server name"
         bind:value={newEnabled}
         placeholder="server-name"
         style={inputStyle("flex: 1;")}
@@ -89,12 +91,14 @@
         <button
           class="remove-btn"
           style="color: {theme.fgDim};"
+          aria-label={`Remove ${name} from disabled servers`}
           on:click={() => removeDisabled(name)}>×</button
         >
       </div>
     {/each}
     <div class="add-row">
       <input
+        aria-label="New disabled server name"
         bind:value={newDisabled}
         placeholder="server-name"
         style={inputStyle("flex: 1;")}

--- a/src/extensions/claude-settings/components/sections/ModelSection.svelte
+++ b/src/extensions/claude-settings/components/sections/ModelSection.svelte
@@ -21,6 +21,7 @@
       <div class="field-control">
         {#if field.type === "enum" && field.options}
           <select
+            aria-label={field.label}
             value={String(get(field.key) ?? "")}
             style="background: {theme.bg}; color: {theme.fg}; border: 1px solid {theme.border}; border-radius: 4px; padding: 2px 6px; font-size: 12px;"
             on:change={(e) => onChange(field.key, e.currentTarget.value)}
@@ -32,12 +33,14 @@
         {:else if field.type === "boolean"}
           <input
             type="checkbox"
+            aria-label={field.label}
             checked={Boolean(get(field.key))}
             on:change={(e) => onChange(field.key, e.currentTarget.checked)}
           />
         {:else}
           <input
             type="text"
+            aria-label={field.label}
             value={String(get(field.key) ?? "")}
             style="background: {theme.bg}; color: {theme.fg}; border: 1px solid {theme.border}; border-radius: 4px; padding: 2px 6px; font-size: 12px; width: 180px;"
             on:change={(e) => onChange(field.key, e.currentTarget.value)}

--- a/src/extensions/claude-settings/components/sections/OtherSection.svelte
+++ b/src/extensions/claude-settings/components/sections/OtherSection.svelte
@@ -29,6 +29,7 @@
         <code class="other-key" style="color: {theme.fg};">{key}</code>
         <textarea
           rows={typeof val === "object" && val !== null ? 3 : 1}
+          aria-label={`Value for ${key}`}
           style="background: {theme.bg}; color: {theme.fg}; border: 1px solid {theme.border}; border-radius: 4px; padding: 3px 8px; font-size: 11px; font-family: monospace; flex: 1; resize: vertical;"
           on:change={(e) => updateOther(key, e.currentTarget.value)}
           >{JSON.stringify(val, null, 2)}</textarea

--- a/src/lib/actions/shortcut-hint.ts
+++ b/src/lib/actions/shortcut-hint.ts
@@ -1,0 +1,76 @@
+import { get } from "svelte/store";
+import { shortcutHintsActive } from "../stores/shortcut-hints";
+import { theme } from "../stores/theme";
+
+export function shortcutHint(
+  node: HTMLElement,
+  label: string | null | undefined,
+) {
+  let badge: HTMLDivElement | null = null;
+  let currentLabel = label;
+
+  function showBadge() {
+    if (!currentLabel || badge) return;
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return;
+
+    const t = get(theme);
+    badge = document.createElement("div");
+    badge.textContent = currentLabel;
+    badge.setAttribute("aria-hidden", "true");
+    badge.style.cssText = `
+      position: fixed;
+      z-index: 99999;
+      pointer-events: none;
+      left: ${rect.left + rect.width / 2}px;
+      top: ${rect.bottom + 4}px;
+      transform: translateX(-50%);
+      background: ${t.accent};
+      color: ${t.bg};
+      font-size: 10px;
+      font-family: inherit;
+      font-weight: 700;
+      padding: 2px 6px;
+      border-radius: 4px;
+      white-space: nowrap;
+      line-height: 1.4;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+    `;
+    document.body.appendChild(badge);
+    window.addEventListener("resize", reposition);
+  }
+
+  function hideBadge() {
+    if (badge) {
+      badge.remove();
+      badge = null;
+      window.removeEventListener("resize", reposition);
+    }
+  }
+
+  function reposition() {
+    if (!badge) return;
+    const rect = node.getBoundingClientRect();
+    badge.style.left = `${rect.left + rect.width / 2}px`;
+    badge.style.top = `${rect.bottom + 4}px`;
+  }
+
+  const unsub = shortcutHintsActive.subscribe((active) => {
+    if (active) showBadge();
+    else hideBadge();
+  });
+
+  return {
+    update(newLabel: string | null | undefined) {
+      currentLabel = newLabel;
+      if (badge) {
+        if (newLabel) badge.textContent = newLabel;
+        else hideBadge();
+      }
+    },
+    destroy() {
+      unsub();
+      hideBadge();
+    },
+  };
+}

--- a/src/lib/actions/shortcut-hint.ts
+++ b/src/lib/actions/shortcut-hint.ts
@@ -38,6 +38,7 @@ export function shortcutHint(
     `;
     document.body.appendChild(badge);
     window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
   }
 
   function hideBadge() {
@@ -45,6 +46,7 @@ export function shortcutHint(
       badge.remove();
       badge = null;
       window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
     }
   }
 

--- a/src/lib/actions/shortcut-hint.ts
+++ b/src/lib/actions/shortcut-hint.ts
@@ -66,6 +66,8 @@ export function shortcutHint(
       if (badge) {
         if (newLabel) badge.textContent = newLabel;
         else hideBadge();
+      } else if (newLabel && get(shortcutHintsActive)) {
+        showBadge();
       }
     },
     destroy() {

--- a/src/lib/components/ContainerRow.svelte
+++ b/src/lib/components/ContainerRow.svelte
@@ -36,8 +36,6 @@
    * In nested variant (parentColor set) the grip is not rendered.
    */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
-  export let gripAriaLabel: string = "Drag to reorder";
-
   /** Banner body right-click — ignored if undefined. */
   export let onBannerContextMenu: ((e: MouseEvent) => void) | undefined =
     undefined;
@@ -235,7 +233,6 @@
         <DragGrip
           theme={$theme}
           visible={rowHovered && $reorderContext === null}
-          ariaLabel={gripAriaLabel}
           railColor={color}
           dotColor="#000"
           railOpacity={1}

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -10,7 +10,6 @@
    * stays optional for callers that still want a grip-only binding.
    */
   export let onMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
-  export let ariaLabel: string = "Drag to reorder";
   /** Color of the rail and dot texture. Defaults to theme.fgDim (grey). */
   export let railColor: string | undefined = undefined;
   /** Opacity of the always-on rail when not hovered. 1.0 for active items, 0.35 for inactive. */
@@ -51,11 +50,8 @@
   $: fritBackgroundRepeat = "repeat";
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  role="button"
-  tabindex="-1"
-  aria-label={ariaLabel}
+  aria-hidden="true"
   class="drag-grip"
   on:mousedown={onMouseDown ?? (() => {})}
   style="

--- a/src/lib/components/NewSurfaceButton.svelte
+++ b/src/lib/components/NewSurfaceButton.svelte
@@ -2,7 +2,8 @@
   import { tick } from "svelte";
   import { theme } from "../stores/theme";
   import { surfaceTypeStore } from "../services/surface-type-registry";
-  import { modLabel } from "../terminal-service";
+  import { isMac, modLabel, shiftModLabel } from "../terminal-service";
+  import { shortcutHint } from "../actions/shortcut-hint";
 
   export let onNewSurface: () => void;
   export let onSelectSurfaceType: (typeId: string) => void;
@@ -96,6 +97,7 @@
       border-bottom: 2px solid {plusHovered ? $theme.accent : 'transparent'};
       transition: color 0.1s, border-color 0.1s;
     "
+    use:shortcutHint={isMac ? `${modLabel}T` : `${shiftModLabel}T`}
     on:click={onNewSurface}
     on:mouseenter={() => (plusHovered = true)}
     on:mouseleave={() => (plusHovered = false)}>+</span

--- a/src/lib/components/NewSurfaceButton.svelte
+++ b/src/lib/components/NewSurfaceButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { theme } from "../stores/theme";
   import { surfaceTypeStore } from "../services/surface-type-registry";
   import { modLabel } from "../terminal-service";
@@ -20,9 +21,16 @@
   let plusHovered = false;
   let chevronHovered = false;
 
-  let chevronEl: HTMLSpanElement;
+  let chevronEl: HTMLButtonElement;
   let dropdownX = 0;
   let dropdownY = 0;
+  let itemEls: (HTMLButtonElement | undefined)[] = [];
+
+  $: if (dropdownOpen) void tick().then(() => focusableItems()[0]?.focus());
+
+  function focusableItems(): HTMLButtonElement[] {
+    return itemEls.filter((el): el is HTMLButtonElement => el != null);
+  }
 
   function toggleDropdown() {
     if (!dropdownOpen && chevronEl) {
@@ -49,8 +57,24 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape" && dropdownOpen) {
+    if (!dropdownOpen) return;
+    if (e.key === "Escape") {
       dropdownOpen = false;
+      chevronEl?.focus();
+      return;
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const items = focusableItems();
+      if (items.length === 0) return;
+      const focused = items.indexOf(
+        document.activeElement as HTMLButtonElement,
+      );
+      if (e.key === "ArrowDown") {
+        items[(focused + 1) % items.length]?.focus();
+      } else {
+        items[(focused - 1 + items.length) % items.length]?.focus();
+      }
     }
   }
 </script>
@@ -78,12 +102,13 @@
   >
 
   {#if hasExtra}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span
+    <button
       bind:this={chevronEl}
-      title="New surface type..."
+      aria-label="New surface type..."
+      aria-expanded={dropdownOpen}
+      aria-haspopup="menu"
       style="
+        background: transparent; border: none;
         color: {chevronHovered || dropdownOpen ? $theme.fg : $theme.fgDim};
         cursor: pointer; font-size: 16px;
         padding: 2px 4px 2px 1px; line-height: 1;
@@ -94,11 +119,12 @@
       "
       on:click={toggleDropdown}
       on:mouseenter={() => (chevronHovered = true)}
-      on:mouseleave={() => (chevronHovered = false)}>&#9662;</span
+      on:mouseleave={() => (chevronHovered = false)}>&#9662;</button
     >
 
     {#if dropdownOpen}
       <div
+        role="menu"
         style="
           position: fixed; top: {dropdownY}px; left: {dropdownX}px;
           background: {$theme.bgFloat}; border: 1px solid {$theme.border};
@@ -107,11 +133,15 @@
           z-index: 9999; min-width: 160px;
         "
       >
-        <!-- Terminal -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          style="padding: 5px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; color: {$theme.fg};"
+        <button
+          bind:this={itemEls[0]}
+          role="menuitem"
+          tabindex="-1"
+          style="
+            width: 100%; padding: 5px 10px; border: none; border-radius: 4px;
+            background: transparent; cursor: pointer;
+            font-size: 12px; color: {$theme.fg}; text-align: left;
+          "
           on:click={() => {
             dropdownOpen = false;
             onNewSurface();
@@ -127,17 +157,23 @@
           }}
         >
           Terminal
-        </div>
+        </button>
 
         {#if visibleSurfaceTypes.length > 0}
           <div
+            role="separator"
             style="height: 1px; background: {$theme.border}; margin: 4px 8px;"
           ></div>
-          {#each visibleSurfaceTypes as surfaceType (surfaceType.id)}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
-              style="padding: 5px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; color: {$theme.fg};"
+          {#each visibleSurfaceTypes as surfaceType, i (surfaceType.id)}
+            <button
+              bind:this={itemEls[i + 1]}
+              role="menuitem"
+              tabindex="-1"
+              style="
+                width: 100%; padding: 5px 10px; border: none; border-radius: 4px;
+                background: transparent; cursor: pointer;
+                font-size: 12px; color: {$theme.fg}; text-align: left;
+              "
               on:click={() => handleItemClick(surfaceType.id)}
               on:mouseenter={(e) => {
                 const el = e.currentTarget;
@@ -151,7 +187,7 @@
               }}
             >
               {surfaceType.label}
-            </div>
+            </button>
           {/each}
         {/if}
       </div>

--- a/src/lib/components/NewSurfaceButton.svelte
+++ b/src/lib/components/NewSurfaceButton.svelte
@@ -89,7 +89,7 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <span
-    title="New terminal ({modLabel}T)"
+    title="New terminal ({isMac ? modLabel : shiftModLabel}T)"
     style="
       color: {plusHovered ? $theme.fg : $theme.fgDim};
       cursor: pointer; font-size: 14px;

--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -194,6 +194,9 @@
     </div>
     <div
       class="sidebar-resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar"
       style="
       width: 4px; cursor: col-resize; flex-shrink: 0;
       background: {dragging ? $theme.accent : $theme.sidebarBorder};

--- a/src/lib/components/PseudoWorkspaceRow.svelte
+++ b/src/lib/components/PseudoWorkspaceRow.svelte
@@ -87,7 +87,6 @@
     <DragGrip
       theme={$theme}
       visible={gripVisible}
-      ariaLabel="Drag to reorder"
       railColor={bannerBackground}
       railOpacity={1}
       alwaysShowDots={true}

--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -256,6 +256,7 @@
 
     {#each corePages as page}
       <button
+        aria-current={activePage === page.id ? "page" : undefined}
         style="
           display: block; width: calc(100% - 16px); margin: 0 8px;
           padding: 6px 12px; border: none; border-radius: 6px;
@@ -283,6 +284,7 @@
       </div>
       {#each extensionPages as page}
         <button
+          aria-current={activePage === page.id ? "page" : undefined}
           style="
             display: block; width: calc(100% - 16px); margin: 0 8px;
             padding: 6px 12px; border: none; border-radius: 6px;

--- a/src/lib/components/SplitButton.svelte
+++ b/src/lib/components/SplitButton.svelte
@@ -8,6 +8,7 @@
 </script>
 
 <script lang="ts">
+  import { tick } from "svelte";
   import type { Readable } from "svelte/store";
 
   export let label: string;
@@ -34,6 +35,14 @@
 
   let dropdownOpen = false;
   let containerEl: HTMLDivElement;
+  let caretEl: HTMLButtonElement;
+  let itemEls: (HTMLButtonElement | undefined)[] = [];
+
+  $: if (dropdownOpen) void tick().then(() => focusableItems()[0]?.focus());
+
+  function focusableItems(): HTMLButtonElement[] {
+    return itemEls.filter((el): el is HTMLButtonElement => el != null);
+  }
 
   function toggleDropdown() {
     dropdownOpen = !dropdownOpen;
@@ -55,8 +64,24 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape" && dropdownOpen) {
+    if (!dropdownOpen) return;
+    if (e.key === "Escape") {
       dropdownOpen = false;
+      caretEl?.focus();
+      return;
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const items = focusableItems();
+      if (items.length === 0) return;
+      const focused = items.indexOf(
+        document.activeElement as HTMLButtonElement,
+      );
+      if (e.key === "ArrowDown") {
+        items[(focused + 1) % items.length]?.focus();
+      } else {
+        items[(focused - 1 + items.length) % items.length]?.focus();
+      }
     }
   }
 </script>
@@ -106,7 +131,10 @@
   <!-- Dropdown caret (only if there are items) -->
   {#if dropdownItems.length > 1}
     <button
-      title="More actions"
+      bind:this={caretEl}
+      aria-label="More actions"
+      aria-expanded={dropdownOpen}
+      aria-haspopup="menu"
       on:click={toggleDropdown}
       data-dropdown-open={dropdownOpen ? "" : undefined}
       style="
@@ -145,6 +173,7 @@
     <!-- Dropdown menu -->
     {#if dropdownOpen}
       <div
+        role="menu"
         style="
           position: absolute;
           top: 100%;
@@ -159,24 +188,30 @@
           min-width: 180px;
         "
       >
-        {#each dropdownItems as item (item.id)}
+        {#each dropdownItems as item, i (item.id)}
           {#if item.id === "__separator__"}
             <div
+              role="separator"
               style="height: 1px; background: {$theme.border}; margin: 4px 8px;"
             ></div>
           {:else}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
+            <button
+              bind:this={itemEls[i]}
+              role="menuitem"
+              tabindex="-1"
               style="
+                width: 100%;
                 padding: 5px 10px;
+                border: none;
                 border-radius: 4px;
+                background: transparent;
                 cursor: pointer;
                 display: flex;
                 align-items: center;
                 gap: 8px;
                 font-size: 12px;
                 color: {$theme.fg};
+                text-align: left;
               "
               on:click={() => handleItemClick(item)}
               on:mouseenter={(e) => {
@@ -206,7 +241,7 @@
                 </svg>
               {/if}
               <span>{item.label}</span>
-            </div>
+            </button>
           {/if}
         {/each}
       </div>

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -143,7 +143,8 @@
       <path d="M9 13v2" />
     </svg>
     <span
-      title={agentStatus ?? "agent"}
+      role="img"
+      aria-label={agentStatus ?? "agent"}
       class:pulse={isWaiting}
       style="
         width: {isWaiting ? 8 : 7}px; height: {isWaiting ? 8 : 7}px;
@@ -152,6 +153,7 @@
     ></span>
   {:else if surface.hasUnread && !isActive}
     <span
+      aria-label="Unread activity"
       style="width: 5px; height: 5px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"
     ></span>
   {/if}

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { tick } from "svelte";
   import { theme } from "../stores/theme";
+  import { isMac } from "../terminal-service";
+  import { shortcutHint } from "../actions/shortcut-hint";
   import type { Surface } from "../types";
   import { startTabDrag } from "../services/tab-drag";
   import { renamingSurfaceId } from "../stores/ui";
@@ -102,6 +104,7 @@
   class="tab"
   data-tab-idx={index}
   data-tab-surface-id={surface.id}
+  use:shortcutHint={isMac && index < 9 ? `Ctrl+${index + 1}` : undefined}
   style="
     padding: 2px 10px; font-size: 11px; cursor: pointer;
     color: {isActive ? $theme.fg : $theme.fgMuted};

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -7,7 +7,8 @@
     secondarySidebarVisible,
   } from "../stores/ui";
   import { spawnOrNavigate } from "../services/dashboard-workspace-service";
-  import { isMac, modLabel } from "../terminal-service";
+  import { isMac, modLabel, shiftModLabel } from "../terminal-service";
+  import { shortcutHint } from "../actions/shortcut-hint";
   import { isDebugBuild } from "../services/service-helpers";
   import { titleBarButtonStore } from "../services/titlebar-button-registry";
   import TitleBarContributedButton from "./TitleBarContributedButton.svelte";
@@ -57,6 +58,7 @@
     style="{btnStyle} color: {$primarySidebarVisible ? fgActive : fg};"
     title="Toggle Primary Sidebar ({modLabel}B)"
     aria-label="Toggle Primary Sidebar"
+    use:shortcutHint={isMac ? `${modLabel}B` : `${shiftModLabel}B`}
     on:click={() => primarySidebarVisible.update((v) => !v)}
   >
     <svg
@@ -94,6 +96,7 @@
     style="{btnStyle} color: {fg};"
     title="Settings ({modLabel},)"
     aria-label="Settings"
+    use:shortcutHint={isMac ? "⌘," : "Ctrl+,"}
     on:click={() => void spawnOrNavigate("gnar-term:settings")}
   >
     <svg

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -56,7 +56,7 @@
 >
   <button
     style="{btnStyle} color: {$primarySidebarVisible ? fgActive : fg};"
-    title="Toggle Primary Sidebar ({modLabel}B)"
+    title="Toggle Primary Sidebar ({isMac ? modLabel : shiftModLabel}B)"
     aria-label="Toggle Primary Sidebar"
     use:shortcutHint={isMac ? `${modLabel}B` : `${shiftModLabel}B`}
     on:click={() => primarySidebarVisible.update((v) => !v)}

--- a/src/lib/components/WorkspaceGroupCreateOverlay.svelte
+++ b/src/lib/components/WorkspaceGroupCreateOverlay.svelte
@@ -16,6 +16,8 @@
   // assignable without a cast.
   const themeView = theme as unknown as Readable<Record<string, string>>;
 
+  const colorLabelId = `wg-color-label-${Math.random().toString(36).slice(2)}`;
+
   function randomColor(): string {
     return (
       GROUP_COLOR_SLOTS[Math.floor(Math.random() * GROUP_COLOR_SLOTS.length)] ??
@@ -199,11 +201,11 @@
 
       <div style="display: flex; flex-direction: column; gap: 4px;">
         <span
-          id="color-label"
+          id={colorLabelId}
           style="font-size: 12px; color: {$theme.fgDim}; font-weight: 500;"
           >Color</span
         >
-        <div aria-labelledby="color-label" role="radiogroup">
+        <div aria-labelledby={colorLabelId} role="radiogroup">
           <ColorPicker
             bind:value={color}
             colors={[...GROUP_COLOR_SLOTS]}

--- a/src/lib/components/WorkspaceGroupCreateOverlay.svelte
+++ b/src/lib/components/WorkspaceGroupCreateOverlay.svelte
@@ -198,15 +198,19 @@
       </div>
 
       <div style="display: flex; flex-direction: column; gap: 4px;">
-        <span style="font-size: 12px; color: {$theme.fgDim}; font-weight: 500;"
+        <span
+          id="color-label"
+          style="font-size: 12px; color: {$theme.fgDim}; font-weight: 500;"
           >Color</span
         >
-        <ColorPicker
-          bind:value={color}
-          colors={[...GROUP_COLOR_SLOTS]}
-          resolveColor={(c: string) => resolveGroupColor(c, $theme)}
-          theme={themeView}
-        />
+        <div aria-labelledby="color-label" role="radiogroup">
+          <ColorPicker
+            bind:value={color}
+            colors={[...GROUP_COLOR_SLOTS]}
+            resolveColor={(c: string) => resolveGroupColor(c, $theme)}
+            theme={themeView}
+          />
+        </div>
       </div>
 
       <div

--- a/src/lib/components/WorkspaceGroupSectionContent.svelte
+++ b/src/lib/components/WorkspaceGroupSectionContent.svelte
@@ -370,7 +370,6 @@
     <ContainerRow
       color={groupHex}
       {onGripMouseDown}
-      gripAriaLabel="Drag workspace group to reorder"
       onBannerContextMenu={handleBannerContextMenu}
       onBannerClick={handleBannerClick}
       {filterIds}

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -256,7 +256,6 @@
     <DragGrip
       theme={$theme}
       visible={dragActive || (hovered && !$anyReorderActive)}
-      ariaLabel="Drag workspace to reorder"
       {railColor}
       railOpacity={1}
       alwaysShowDots={true}

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -13,6 +13,7 @@
   $: isDisco = $theme.name === "Molly Disco";
   import { getAllSurfaces, getAllPanes } from "../types";
   import type { Workspace } from "../types";
+  import { workspaceSurfaceMap } from "../services/workspace-service";
 
   const discoEmojis = [
     "✨",
@@ -121,7 +122,8 @@
   let nameEl: HTMLSpanElement;
   let _renaming = false;
 
-  $: allSurfaces = getAllSurfaces(workspace);
+  $: allSurfaces =
+    $workspaceSurfaceMap.get(workspace.id) ?? getAllSurfaces(workspace);
   $: hasUnread = allSurfaces.some((s) => s.hasUnread);
   $: latestNotification = allSurfaces.find((s) => s.notification)?.notification;
   $: isManaged = !!workspace.metadata?.worktreePath;

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -9,6 +9,8 @@
   import { getExtensionApiById } from "../services/extension-loader";
   import ExtensionWrapper from "./ExtensionWrapper.svelte";
   import DragGrip from "./DragGrip.svelte";
+  import { modLabel } from "../terminal-service";
+  import { shortcutHint } from "../actions/shortcut-hint";
 
   $: isDisco = $theme.name === "Molly Disco";
   import { getAllSurfaces, getAllPanes } from "../types";
@@ -227,6 +229,7 @@
   data-drag-idx={index}
   data-workspace-id={workspace.id}
   data-worktree={isManaged ? "true" : undefined}
+  use:shortcutHint={index < 9 ? `${modLabel}${index + 1}` : undefined}
   style="
     display: {dragActive ? 'none' : 'flex'};
     position: relative;

--- a/src/lib/services/agent-detection-service.ts
+++ b/src/lib/services/agent-detection-service.ts
@@ -47,6 +47,10 @@ import { statusRegistry } from "./status-registry";
 import { markSurfaceUnreadById } from "./surface-service";
 import { workspaces } from "../stores/workspace";
 import { getAllPanes, isTerminalSurface } from "../types";
+import {
+  lookupSurfaceWorkspaceId,
+  lookupPtyIdForSurface,
+} from "./service-helpers";
 
 // --- Public types ---
 
@@ -312,29 +316,12 @@ function publishStatus(
 // --- Workspace resolution ---
 
 function resolveWorkspaceIdForSurface(surfaceId: string): string {
-  const all = get(workspaces);
-  for (const ws of all) {
-    for (const pane of getAllPanes(ws.splitRoot)) {
-      for (const surface of pane.surfaces) {
-        if (surface.id === surfaceId) return ws.id;
-      }
-    }
-  }
-  return "";
+  return lookupSurfaceWorkspaceId(surfaceId) ?? "";
 }
 
 function resolvePtyIdForSurface(surfaceId: string): number | null {
-  const all = get(workspaces);
-  for (const ws of all) {
-    for (const pane of getAllPanes(ws.splitRoot)) {
-      for (const surface of pane.surfaces) {
-        if (surface.id === surfaceId && isTerminalSurface(surface)) {
-          return surface.ptyId ?? null;
-        }
-      }
-    }
-  }
-  return null;
+  const ptyId = lookupPtyIdForSurface(surfaceId);
+  return ptyId !== undefined ? ptyId : null;
 }
 
 function allTerminalSurfaces(): Array<{

--- a/src/lib/services/extension-api.ts
+++ b/src/lib/services/extension-api.ts
@@ -83,7 +83,7 @@ import {
   type DragReorderHandle,
 } from "../actions/drag-reorder";
 import { reorderContext, anyReorderActive, contextMenu } from "../stores/ui";
-import { getActiveCwd } from "./service-helpers";
+import { getActiveCwd, lookupSurfaceWorkspaceId } from "./service-helpers";
 import { workspaces } from "../stores/workspace";
 import { getAllSurfaces, isTerminalSurface } from "../types";
 import type { ExtensionManifest, ExtensionAPI } from "../extension-types";
@@ -337,12 +337,7 @@ export function createExtensionAPI(
       focusSurfaceById(surfaceId);
     },
     getWorkspaceIdForSurface(surfaceId: string): string | null {
-      for (const ws of get(workspaces)) {
-        for (const surf of getAllSurfaces(ws)) {
-          if (surf.id === surfaceId) return ws.id;
-        }
-      }
-      return null;
+      return lookupSurfaceWorkspaceId(surfaceId) ?? null;
     },
     reportError(message: string): void {
       reportExtensionError(extId, message);

--- a/src/lib/services/git-status-service.ts
+++ b/src/lib/services/git-status-service.ts
@@ -334,6 +334,7 @@ function startPolling(workspaceId: string, cwd: string): void {
  * files). Failures fall back to the polling timer.
  */
 const indexWatches = new Map<string, number>();
+const indexUnlistens = new Map<string, () => void>();
 const refreshDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 async function attachIndexWatcher(
   workspaceId: string,
@@ -359,19 +360,23 @@ async function attachIndexWatcher(
     // for the pattern. Debounce so a burst of writes (git add .) only
     // fires one refresh.
     const { listen } = await import("@tauri-apps/api/event");
-    await listen<{ watchId: number }>("file_changed", (event) => {
-      if (event.payload?.watchId !== watchId) return;
-      const pending = refreshDebounce.get(workspaceId);
-      if (pending) clearTimeout(pending);
-      refreshDebounce.set(
-        workspaceId,
-        setTimeout(() => {
-          refreshDebounce.delete(workspaceId);
-          const latest = workspaceCwds.get(workspaceId);
-          if (latest) void refreshGitStatus(workspaceId, latest);
-        }, 150),
-      );
-    });
+    const unlisten = await listen<{ watchId: number }>(
+      "file_changed",
+      (event) => {
+        if (event.payload?.watchId !== watchId) return;
+        const pending = refreshDebounce.get(workspaceId);
+        if (pending) clearTimeout(pending);
+        refreshDebounce.set(
+          workspaceId,
+          setTimeout(() => {
+            refreshDebounce.delete(workspaceId);
+            const latest = workspaceCwds.get(workspaceId);
+            if (latest) void refreshGitStatus(workspaceId, latest);
+          }, 150),
+        );
+      },
+    );
+    indexUnlistens.set(workspaceId, unlisten);
   } catch {
     // Best-effort — the polling timer is still in place.
   }
@@ -381,6 +386,11 @@ async function detachIndexWatcher(workspaceId: string): Promise<void> {
   const watchId = indexWatches.get(workspaceId);
   if (watchId === undefined) return;
   indexWatches.delete(workspaceId);
+  const unlisten = indexUnlistens.get(workspaceId);
+  if (unlisten) {
+    unlisten();
+    indexUnlistens.delete(workspaceId);
+  }
   const pending = refreshDebounce.get(workspaceId);
   if (pending) clearTimeout(pending);
   refreshDebounce.delete(workspaceId);

--- a/src/lib/services/keyboard-shortcuts.ts
+++ b/src/lib/services/keyboard-shortcuts.ts
@@ -86,7 +86,7 @@ export function handleAppKeydown(
 
   // Shortcuts that reference component bindings or aren't in the
   // command palette. Use Cmd (mac) or Ctrl+Shift (other).
-  if ((isMac ? e.metaKey : ctrl && shift) && shift && !alt) {
+  if ((isMac ? e.metaKey : ctrl) && shift && !alt) {
     const k = e.key.toLowerCase();
     if (k === "h") {
       e.preventDefault();

--- a/src/lib/services/preview-service.ts
+++ b/src/lib/services/preview-service.ts
@@ -14,6 +14,7 @@ import { get } from "svelte/store";
 import { theme } from "../stores/theme";
 import {
   findPreviewer,
+  getExtension,
   type PreviewContext,
   type PreviewResult,
 } from "./preview-registry";
@@ -41,11 +42,6 @@ const BINARY_EXTS = new Set([
   "m4v",
   "ogv",
 ]);
-
-function getExtension(path: string): string {
-  const parts = path.split(".");
-  return parts.length > 1 ? parts.pop()!.toLowerCase() : "";
-}
 
 function buildPreviewContext(): PreviewContext {
   const themeValue = get(theme);

--- a/src/lib/services/service-helpers.ts
+++ b/src/lib/services/service-helpers.ts
@@ -67,6 +67,49 @@ export function forEachTerminalSurface(fn: (s: TerminalSurface) => void): void {
   }
 }
 
+// --- Surface/PTY lookup index ---
+// Rebuilt on every workspaces store update so hot-path callers get O(1) lookups
+// instead of O(W×S) nested scans. Only valid outside of workspaces.update()
+// callbacks — reads from the index during an update see the pre-update state.
+
+const _ptyIndex = new Map<number, TerminalSurface>(); // ptyId → terminal surface
+const _surfaceWsIndex = new Map<string, string>(); // surfaceId → workspaceId
+const _surfacePtyIndex = new Map<string, number>(); // surfaceId → ptyId
+
+workspaces.subscribe(($ws) => {
+  _ptyIndex.clear();
+  _surfaceWsIndex.clear();
+  _surfacePtyIndex.clear();
+  for (const ws of $ws) {
+    if (!ws?.splitRoot) continue;
+    for (const pane of getAllPanes(ws.splitRoot)) {
+      for (const surface of pane.surfaces) {
+        _surfaceWsIndex.set(surface.id, ws.id);
+        if (isTerminalSurface(surface)) {
+          if (surface.ptyId >= 0) _ptyIndex.set(surface.ptyId, surface);
+          _surfacePtyIndex.set(surface.id, surface.ptyId);
+        }
+      }
+    }
+  }
+});
+
+export function lookupTerminalByPtyId(
+  ptyId: number,
+): TerminalSurface | undefined {
+  return _ptyIndex.get(ptyId);
+}
+
+export function lookupSurfaceWorkspaceId(
+  surfaceId: string,
+): string | undefined {
+  return _surfaceWsIndex.get(surfaceId);
+}
+
+export function lookupPtyIdForSurface(surfaceId: string): number | undefined {
+  return _surfacePtyIndex.get(surfaceId);
+}
+
 export async function safeFocus(s: Surface | null | undefined) {
   if (!s || !isTerminalSurface(s)) return;
   await tick();

--- a/src/lib/services/workspace-service.ts
+++ b/src/lib/services/workspace-service.ts
@@ -1,4 +1,5 @@
-import { get } from "svelte/store";
+import { get, derived } from "svelte/store";
+import type { Readable } from "svelte/store";
 import { invoke } from "@tauri-apps/api/core";
 import {
   workspaces,
@@ -507,3 +508,15 @@ export function createWorkspaceFromSurface(
 // pane after moving a surface across workspaces without duplicating
 // the helper.
 export { collapseEmptyPaneInWorkspace };
+
+// Derived store: one flat Map<workspaceId, Surface[]> rebuilt per workspace
+// update. WorkspaceItem rows subscribe via $workspaceSurfaceMap.get(id) so a
+// PTY title change in workspace A does not trigger O(R) getAllSurfaces calls
+// across all R sidebar rows — each row pays only a Map.get() lookup.
+export const workspaceSurfaceMap: Readable<
+  Map<string, ReturnType<typeof getAllSurfaces>>
+> = derived(workspaces, ($ws) => {
+  const m = new Map<string, ReturnType<typeof getAllSurfaces>>();
+  for (const ws of $ws) m.set(ws.id, getAllSurfaces(ws));
+  return m;
+});

--- a/src/lib/services/workspace-service.ts
+++ b/src/lib/services/workspace-service.ts
@@ -510,9 +510,9 @@ export function createWorkspaceFromSurface(
 export { collapseEmptyPaneInWorkspace };
 
 // Derived store: one flat Map<workspaceId, Surface[]> rebuilt per workspace
-// update. WorkspaceItem rows subscribe via $workspaceSurfaceMap.get(id) so a
-// PTY title change in workspace A does not trigger O(R) getAllSurfaces calls
-// across all R sidebar rows — each row pays only a Map.get() lookup.
+// update. WorkspaceItem rows still re-run their reactive statement on every
+// workspaces emission, but each pays only a Map.get() O(1) lookup instead of
+// calling getAllSurfaces independently — O(W×S) once vs O(R×W×S) before.
 export const workspaceSurfaceMap: Readable<
   Map<string, ReturnType<typeof getAllSurfaces>>
 > = derived(workspaces, ($ws) => {

--- a/src/lib/stores/shortcut-hints.ts
+++ b/src/lib/stores/shortcut-hints.ts
@@ -1,0 +1,60 @@
+import { writable } from "svelte/store";
+import type { Readable } from "svelte/store";
+import { isMac } from "../terminal-service";
+
+const _active = writable(false);
+
+export const shortcutHintsActive: Readable<boolean> = {
+  subscribe: _active.subscribe,
+};
+
+export function initShortcutHints(): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const modKey = isMac ? "Meta" : "Control";
+
+  function clearTimer() {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === modKey) {
+      if (e.repeat) return;
+      if (timer === null) {
+        timer = setTimeout(() => {
+          timer = null;
+          _active.set(true);
+        }, 1000);
+      }
+    } else {
+      clearTimer();
+      _active.set(false);
+    }
+  }
+
+  function handleKeyup(e: KeyboardEvent) {
+    if (e.key === modKey) {
+      clearTimer();
+      _active.set(false);
+    }
+  }
+
+  function handleBlur() {
+    clearTimer();
+    _active.set(false);
+  }
+
+  window.addEventListener("keydown", handleKeydown, true);
+  window.addEventListener("keyup", handleKeyup, true);
+  window.addEventListener("blur", handleBlur);
+
+  return () => {
+    clearTimer();
+    _active.set(false);
+    window.removeEventListener("keydown", handleKeydown, true);
+    window.removeEventListener("keyup", handleKeyup, true);
+    window.removeEventListener("blur", handleBlur);
+  };
+}

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -19,6 +19,7 @@ import {
   readText as clipboardRead,
   writeText as clipboardWrite,
 } from "@tauri-apps/plugin-clipboard-manager";
+import { lookupTerminalByPtyId } from "./services/service-helpers";
 import {
   isPermissionGranted as notifPermissionGranted,
   requestPermission as notifRequestPermission,
@@ -156,13 +157,7 @@ const BUFFER_HIGH_WATER = 128 * 1024; // 128KB
 const BUFFER_LOW_WATER = 32 * 1024; // 32KB
 
 function findSurfaceByPty(ptyId: number): TerminalSurface | null {
-  const wsList = get(workspaces);
-  for (const ws of wsList) {
-    for (const s of getAllSurfaces(ws)) {
-      if (isTerminalSurface(s) && s.ptyId === ptyId) return s;
-    }
-  }
-  return null;
+  return lookupTerminalByPtyId(ptyId) ?? null;
 }
 
 function scheduleFlush(ptyId: number) {


### PR DESCRIPTION
## Summary

Addresses all findings from the [2026-04-27 project audit](docs/implement/audits/2026-04-27-1706-dev.md) and adds a shortcut hint overlay feature.

### Security (F17, F33)
- Sanitize OSC notification text — strip C0/C1 control chars, cap at 500 chars (prevents terminal escape injection into system notifications)
- Validate git ref args in `git_diff` — allowlist `[A-Za-z0-9._/@{}-]` before shell invocation (prevents command injection via crafted ref names)

### Performance (F16, F32)
- Add three module-level Maps in `service-helpers.ts` rebuilt on every `workspaces` store update, replacing O(W×S) nested scans at hot paths (`findSurfaceByPty` called per PTY output line, `resolveWorkspaceIdForSurface` called per agent status transition)
- `WorkspaceItem`: replace per-row `getAllSurfaces(workspace)` reactive call with a shared `derived()` store (`workspaceSurfaceMap`) so all sidebar rows share one surface-map computation per store update

### Accessibility (F20–F27, F36–F38)
- `DragGrip`: replace `role=button` + `aria-label` with `aria-hidden=true` — pointer-only decoration, not keyboard interactive
- `SettingsPanel` nav buttons: add `aria-current=page` on the active page
- `Tab` agent-status dot: `role=img` + `aria-label`; unread dot: `aria-label="Unread activity"`
- `HooksSection` add-command input: `aria-label` per hook event
- `PrimarySidebar` resize handle: `role=separator` + `aria-orientation` + `aria-label`
- `WorkspaceGroupCreateOverlay` ColorPicker: `role=radiogroup` + `aria-labelledby`
- Settings sections (Model, Env, Mcp, Other): `aria-label` on all orphaned form controls
- `SplitButton` dropdown: `role=menu`, items as `button[role=menuitem tabindex=-1]`, arrow-key + Escape keyboard nav, `aria-expanded` + `aria-label` on caret
- `NewSurfaceButton` dropdown: same keyboard/ARIA treatment as SplitButton

### Service fixes (F18, F34)
- `git-status-service`: store `UnlistenFn` in a `Map` and call it on detach — fixes Tauri event listener leak
- `preview-service`: remove duplicate private `getExtension` copy, import from `preview-registry`
- `extension-api`: `getWorkspaceIdForSurface` uses O(1) lookup from service-helpers index

### Shortcut correctness
- `keyboard-shortcuts.ts`: simplify `(isMac ? metaKey : ctrl && shift) && shift` → `(isMac ? metaKey : ctrl) && shift`
- `App.svelte`: replace hardcoded `"Cmd+Shift+N"` / `"Ctrl+Shift+N"` strings with `${shiftModLabel}N`

### Shortcut hint overlay (new feature)
Hold Cmd (Mac) or Ctrl (Linux) for 1 second to reveal keyboard shortcut badges on all shortcut-bearing UI elements. Release to dismiss.

- `src/lib/stores/shortcut-hints.ts`: `Readable<boolean>` store + `initShortcutHints()` with 1s timer, capture-phase listeners; any non-modifier keypress cancels, window blur resets
- `src/lib/actions/shortcut-hint.ts`: `use:shortcutHint={label}` Svelte action — appends a `position:fixed` badge to `document.body` via `getBoundingClientRect()`, themed with `get(theme)`
- Applied to: TitleBar sidebar toggle + settings, NewSurfaceButton `+`, Tab items (Ctrl+1–9, Mac only), WorkspaceItem rows (⌘1–9 / Ctrl+1–9)

## Test plan

- [x] All 1415 unit tests pass (`npm test`)
- [x] Prettier, typecheck, eslint, svelte-check, rust-check, rust-clippy all pass (enforced by pre-commit hook)
- [ ] Hold Cmd (Mac) for >1s → shortcut badges appear on sidebar toggle, settings gear, `+` button, visible tabs, visible workspace rows
- [ ] Release modifier → all badges disappear immediately
- [ ] Press Cmd+T within the first second → no badges (timer cancelled)
- [ ] Open Settings panel — active nav item has `aria-current=page`
- [ ] SplitButton dropdown: arrow keys navigate items, Escape closes and returns focus to caret
- [ ] No regressions in workspace drag-reorder or agent status dot behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)