### PR TITLE
fix(audit): easy fixes F13 F17 F20 — sidebar DRY, pty O(1), tablist ARIA

### DIFF
--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -13,7 +13,6 @@
    */
   import { theme } from "../stores/theme";
   import { primarySidebarVisible, primarySidebarWidth } from "../stores/ui";
-  import { dragResize } from "../actions/drag-resize";
   import type { Readable } from "svelte/store";
   import type { SplitButtonItem } from "./SplitButton.svelte";
   import { sidebarSectionStore } from "../services/sidebar-section-registry";
@@ -25,6 +24,7 @@
   import McpSidebarSection from "./McpSidebarSection.svelte";
   import SplitButton from "./SplitButton.svelte";
   import ArchiveZone from "./ArchiveZone.svelte";
+  import SidebarResizeHandle from "./SidebarResizeHandle.svelte";
 
   const iconSvgMap: Record<string, string> = {
     plus: `<line x1="8" y1="3" x2="8" y2="13" /><line x1="3" y1="8" x2="13" y2="8" />`,
@@ -85,8 +85,6 @@
   export function startRename(idx: number) {
     workspaceListBlock?.startRename(idx);
   }
-
-  let dragging = false;
 </script>
 
 {#if $primarySidebarVisible}
@@ -195,38 +193,18 @@
 
       <ArchiveZone />
     </div>
-    <div
-      class="sidebar-resize-handle"
-      role="separator"
-      aria-orientation="vertical"
-      aria-label="Resize sidebar"
-      style="
-      width: 4px; cursor: col-resize; flex-shrink: 0;
-      background: {dragging ? $theme.accent : $theme.sidebarBorder};
-      transition: background 0.15s;
-    "
-      use:dragResize={{
-        onDrag: (ev) => {
-          const maxWidth = window.innerWidth * 0.33;
-          primarySidebarWidth.set(
-            Math.max(140, Math.min(maxWidth, ev.clientX)),
-          );
-        },
-        onStart: () => {
-          dragging = true;
-        },
-        onEnd: () => {
-          dragging = false;
-        },
+    <SidebarResizeHandle
+      direction="right"
+      theme={$theme}
+      onDrag={(clientX) => {
+        const maxWidth = window.innerWidth * 0.33;
+        primarySidebarWidth.set(Math.max(140, Math.min(maxWidth, clientX)));
       }}
-    ></div>
+    />
   </div>
 {/if}
 
 <style>
-  .sidebar-resize-handle:hover {
-    filter: brightness(1.3);
-  }
   /* Top-row "+ New" chip — suppress SplitButton's own border/color so
      the chip wash defines its look, and tint the hover bg to match
      the rest of the top-row buttons. --section-btn-fg is set inline

--- a/src/lib/components/SecondarySidebar.svelte
+++ b/src/lib/components/SecondarySidebar.svelte
@@ -2,7 +2,6 @@
   import type { Component } from "svelte";
   import { theme } from "../stores/theme";
   import { secondarySidebarVisible, secondarySidebarWidth } from "../stores/ui";
-  import { dragResize } from "../actions/drag-resize";
   import {
     sidebarTabStore,
     sidebarActionStore,
@@ -14,8 +13,8 @@
   import { secondarySections } from "../stores/mcp-sidebar";
   import ExtensionWrapper from "./ExtensionWrapper.svelte";
   import McpSidebarSection from "./McpSidebarSection.svelte";
+  import SidebarResizeHandle from "./SidebarResizeHandle.svelte";
 
-  let dragging = false;
   let activeTabId: string | null = null;
 
   // Auto-select first tab when tabs change
@@ -59,33 +58,22 @@
       flex-shrink: 0;
     "
   >
-    <div
-      class="sidebar-resize-handle"
-      style="
-      width: 4px; cursor: col-resize; flex-shrink: 0;
-      background: {dragging ? $theme.accent : $theme.sidebarBorder};
-      transition: background 0.15s;
-    "
-      use:dragResize={{
-        onDrag: (ev) => {
-          const maxWidth = window.innerWidth * 0.33;
-          secondarySidebarWidth.set(
-            Math.max(140, Math.min(maxWidth, window.innerWidth - ev.clientX)),
-          );
-        },
-        onStart: () => {
-          dragging = true;
-        },
-        onEnd: () => {
-          dragging = false;
-        },
+    <SidebarResizeHandle
+      direction="left"
+      theme={$theme}
+      onDrag={(clientX) => {
+        const maxWidth = window.innerWidth * 0.33;
+        secondarySidebarWidth.set(
+          Math.max(140, Math.min(maxWidth, window.innerWidth - clientX)),
+        );
       }}
-    ></div>
+    />
     <div
       style="flex: 1; display: flex; flex-direction: column; overflow: hidden;"
     >
       <!-- Top row: tab bar -->
       <div
+        role="tablist"
         data-tauri-drag-region=""
         style="
         height: 38px; display: flex; align-items: center;
@@ -97,6 +85,9 @@
       >
         {#each $sidebarTabStore as tab (tab.id)}
           <button
+            role="tab"
+            aria-selected={activeTabId === tab.id}
+            aria-controls="secondary-sidebar-tab-panel-{tab.id}"
             style="
             background: none; border: none; cursor: pointer;
             padding: 4px 10px; border-radius: 4px; font-size: 11px;
@@ -150,6 +141,11 @@
 
       <!-- Content area -->
       <div
+        role="tabpanel"
+        id={activeTab
+          ? `secondary-sidebar-tab-panel-${activeTab.id}`
+          : undefined}
+        aria-labelledby={activeTab ? activeTab.id : undefined}
         style="flex: 1; overflow-y: auto; display: flex; flex-direction: column;"
       >
         {#if activeTab}
@@ -179,9 +175,3 @@
     </div>
   </div>
 {/if}
-
-<style>
-  .sidebar-resize-handle:hover {
-    filter: brightness(1.3);
-  }
-</style>

--- a/src/lib/components/SidebarResizeHandle.svelte
+++ b/src/lib/components/SidebarResizeHandle.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  /**
+   * SidebarResizeHandle — shared resize divider for PrimarySidebar and
+   * SecondarySidebar. Encapsulates dragging state, the dragResize action,
+   * border-color theming, and keyboard resize support (ArrowLeft/ArrowRight
+   * for WCAG 2.1 SC 2.1.1 keyboard operability).
+   *
+   * Props:
+   *   direction — "right" for primary sidebar (handle on the right edge),
+   *               "left" for secondary sidebar (handle on the left edge).
+   *   onDrag    — called on every mousemove / keyboard step with the new
+   *               clientX-equivalent offset so the parent can update its
+   *               width store.
+   *   theme     — reactive theme object (pass as $theme from the parent).
+   */
+  import { dragResize } from "../actions/drag-resize";
+  import type { ThemeDef } from "../theme-data";
+
+  export let direction: "left" | "right";
+  export let onDrag: (clientX: number) => void;
+  export let theme: ThemeDef;
+
+  /** Step size in pixels for keyboard ArrowLeft / ArrowRight resize. */
+  const KEYBOARD_STEP = 8;
+
+  let dragging = false;
+  let handleEl: HTMLElement;
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+
+    // Derive the current handle position from its bounding rect so we can
+    // feed a synthetic "clientX" to the parent's onDrag without knowing the
+    // current width.
+    const rect = handleEl.getBoundingClientRect();
+    const currentX = rect.left + rect.width / 2;
+
+    const delta = e.key === "ArrowRight" ? KEYBOARD_STEP : -KEYBOARD_STEP;
+    onDrag(currentX + delta);
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+  bind:this={handleEl}
+  class="sidebar-resize-handle sidebar-resize-handle--{direction}"
+  role="separator"
+  aria-orientation="vertical"
+  aria-label="Resize sidebar"
+  tabindex="0"
+  style="
+    width: 4px; cursor: col-resize; flex-shrink: 0;
+    background: {dragging ? theme.accent : theme.sidebarBorder};
+    transition: background 0.15s;
+  "
+  use:dragResize={{
+    onDrag: (ev) => onDrag(ev.clientX),
+    onStart: () => {
+      dragging = true;
+    },
+    onEnd: () => {
+      dragging = false;
+    },
+  }}
+  on:keydown={handleKeydown}
+></div>
+
+<style>
+  .sidebar-resize-handle:hover,
+  .sidebar-resize-handle:focus-visible {
+    filter: brightness(1.3);
+    outline: none;
+  }
+</style>


### PR DESCRIPTION
## Summary

- **F13**: Extract `<SidebarResizeHandle>` Svelte component, eliminating duplicated dragging state and `dragResize` wiring in PrimarySidebar and SecondarySidebar. Includes keyboard resize (ArrowLeft/ArrowRight) satisfying WCAG 2.1 SC 2.1.1.
- **F17**: Build `ptyToSurface` Map index in `terminal-service.ts`. Both `pty-exit` and `pty-notification` handlers now resolve in O(1) via `findSurfaceByPty`, which falls back to the O(W×S) tree scan only if the index misses. Previous code re-walked all workspaces/panes on every PTY event.
- **F20**: Add `role="tablist"` to SecondarySidebar header; `role="tab"`, `aria-selected`, `aria-controls` to each tab button; `role="tabpanel"` with matching `id` to content divs.

> F18 and F23 were skipped — the described code patterns do not exist on `dev`.

## Test plan

- [ ] Sidebar resize handle drags correctly in PrimarySidebar and SecondarySidebar
- [ ] Keyboard focus on resize handle + ArrowLeft/ArrowRight adjusts sidebar width
- [ ] PTY events (exit, notification) resolve without scanning workspace tree
- [ ] SecondarySidebar tabs announce correctly via screen reader (tablist/tab/aria-selected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)