### PR TITLE
fix(audit): easy fixes F14 F22 F34 F35 F38 — registry, WorkspaceItem a11y, extract helpers

### DIFF
--- a/src/__tests__/dashboard-workspace-service.test.ts
+++ b/src/__tests__/dashboard-workspace-service.test.ts
@@ -21,7 +21,6 @@ import {
   registerDashboardWorkspaceType,
   unregisterDashboardWorkspaceType,
   spawnOrNavigate,
-  getDashboardEntry,
   dashboardWorkspaceRegistry,
   clearDashboardRegistry,
 } from "../lib/services/dashboard-workspace-service";
@@ -63,16 +62,16 @@ describe("unregisterDashboardWorkspaceType", () => {
   });
 });
 
-describe("getDashboardEntry", () => {
+describe("getDashboardEntry (via dashboardWorkspaceRegistry)", () => {
   beforeEach(() => clearDashboardRegistry());
 
   it("returns undefined for unknown id", () => {
-    expect(getDashboardEntry("ext:unknown")).toBeUndefined();
+    expect(get(dashboardWorkspaceRegistry).get("ext:unknown")).toBeUndefined();
   });
 
   it("returns entry after registration", () => {
     registerDashboardWorkspaceType(makeEntry("ext:foo"));
-    expect(getDashboardEntry("ext:foo")?.label).toBe("Foo");
+    expect(get(dashboardWorkspaceRegistry).get("ext:foo")?.label).toBe("Foo");
   });
 });
 

--- a/src/extensions/claude-settings/components/sections/EnvSection.svelte
+++ b/src/extensions/claude-settings/components/sections/EnvSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { inputStyle } from "../../utils/section-styles";
+
   export let settings: Record<string, unknown>;
   export let onChange: (key: string, value: unknown) => void;
   export let theme: { fg: string; fgDim: string; bg: string; border: string };
@@ -27,8 +29,7 @@
     onChange("env", { ...envMap, [key]: val });
   }
 
-  const inputStyle = (extra = "") =>
-    `background: ${theme.bg}; color: ${theme.fg}; border: 1px solid ${theme.border}; border-radius: 4px; padding: 3px 8px; font-size: 12px; font-family: monospace; ${extra}`;
+  $: getInputStyle = inputStyle(theme);
 </script>
 
 <div class="env-section">
@@ -38,7 +39,7 @@
       <input
         aria-label={`Value for ${key}`}
         value={val}
-        style={inputStyle("flex: 1;")}
+        style={getInputStyle("flex: 1;")}
         on:change={(e) => updateValue(key, e.currentTarget.value)}
       />
       <button
@@ -55,14 +56,14 @@
       aria-label="New environment variable key"
       bind:value={newKey}
       placeholder="KEY"
-      style={inputStyle("width: 140px;")}
+      style={getInputStyle("width: 140px;")}
       on:keydown={(e) => e.key === "Enter" && addEntry()}
     />
     <input
       aria-label="New environment variable value"
       bind:value={newVal}
       placeholder="value"
-      style={inputStyle("flex: 1;")}
+      style={getInputStyle("flex: 1;")}
       on:keydown={(e) => e.key === "Enter" && addEntry()}
     />
     <button

--- a/src/extensions/claude-settings/components/sections/HooksSection.svelte
+++ b/src/extensions/claude-settings/components/sections/HooksSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { inputStyle } from "../../utils/section-styles";
+
   export let settings: Record<string, unknown>;
   export let onChange: (key: string, value: unknown) => void;
   export let theme: { fg: string; fgDim: string; bg: string; border: string };
@@ -63,8 +65,7 @@
 
   let newCommands: Record<string, string> = {};
 
-  const inputStyle = (extra = "") =>
-    `background: ${theme.bg}; color: ${theme.fg}; border: 1px solid ${theme.border}; border-radius: 4px; padding: 3px 8px; font-size: 11px; font-family: monospace; ${extra}`;
+  $: getInputStyle = inputStyle(theme, 11);
 </script>
 
 <div class="hooks-section">
@@ -123,7 +124,7 @@
               bind:value={newCommands[event]}
               aria-label={`Command for ${event} hook`}
               placeholder="command to run"
-              style={inputStyle("flex: 1;")}
+              style={getInputStyle("flex: 1;")}
               on:keydown={(e) => {
                 if (e.key === "Enter") {
                   addHook(event, newCommands[event] ?? "");

--- a/src/extensions/claude-settings/components/sections/McpSection.svelte
+++ b/src/extensions/claude-settings/components/sections/McpSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { inputStyle } from "../../utils/section-styles";
+
   export let settings: Record<string, unknown>;
   export let onChange: (key: string, value: unknown) => void;
   export let theme: { fg: string; fgDim: string; bg: string; border: string };
@@ -40,8 +42,7 @@
     );
   }
 
-  const inputStyle = (extra = "") =>
-    `background: ${theme.bg}; color: ${theme.fg}; border: 1px solid ${theme.border}; border-radius: 4px; padding: 3px 8px; font-size: 12px; font-family: monospace; ${extra}`;
+  $: getInputStyle = inputStyle(theme);
 </script>
 
 <div class="mcp-section">
@@ -73,7 +74,7 @@
         aria-label="New enabled server name"
         bind:value={newEnabled}
         placeholder="server-name"
-        style={inputStyle("flex: 1;")}
+        style={getInputStyle("flex: 1;")}
         on:keydown={(e) => e.key === "Enter" && addEnabled()}
       />
       <button
@@ -101,7 +102,7 @@
         aria-label="New disabled server name"
         bind:value={newDisabled}
         placeholder="server-name"
-        style={inputStyle("flex: 1;")}
+        style={getInputStyle("flex: 1;")}
         on:keydown={(e) => e.key === "Enter" && addDisabled()}
       />
       <button

--- a/src/extensions/claude-settings/components/sections/PermissionsSection.svelte
+++ b/src/extensions/claude-settings/components/sections/PermissionsSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { inputStyle } from "../../utils/section-styles";
+
   export let settings: Record<string, unknown>;
   export let onChange: (key: string, value: unknown) => void;
   export let theme: {
@@ -58,8 +60,7 @@
     updatePerms({ deny: denyList.filter((e) => e !== entry) });
   }
 
-  const inputStyle = (extra = "") =>
-    `background: ${theme.bg}; color: ${theme.fg}; border: 1px solid ${theme.border}; border-radius: 4px; padding: 3px 8px; font-size: 12px; font-family: monospace; ${extra}`;
+  $: getInputStyle = inputStyle(theme);
 </script>
 
 <div class="perms-section">
@@ -73,7 +74,7 @@
     <select
       id="perm-default-mode"
       value={defaultMode}
-      style={inputStyle()}
+      style={getInputStyle()}
       on:change={(e) => updatePerms({ defaultMode: e.currentTarget.value })}
     >
       {#each MODES as m}
@@ -101,7 +102,7 @@
       <input
         bind:value={newAllow}
         placeholder="Bash(npm *) or Read(~/src/**)"
-        style={inputStyle("flex: 1;")}
+        style={getInputStyle("flex: 1;")}
         on:keydown={(e) => e.key === "Enter" && addAllow()}
       />
       <button
@@ -132,7 +133,7 @@
       <input
         bind:value={newDeny}
         placeholder="Bash(curl *) or Read(./.env)"
-        style={inputStyle("flex: 1;")}
+        style={getInputStyle("flex: 1;")}
         on:keydown={(e) => e.key === "Enter" && addDeny()}
       />
       <button

--- a/src/extensions/claude-settings/utils/section-styles.ts
+++ b/src/extensions/claude-settings/utils/section-styles.ts
@@ -1,0 +1,15 @@
+/** Shared style helpers for claude-settings section components. */
+
+type ThemeColors = { fg: string; bg: string; border: string };
+
+/**
+ * Inline style string for text inputs in settings sections.
+ *
+ * @param theme - Subset of the active theme used for colors.
+ * @param extra - Additional CSS declarations to append (e.g. `"width: 140px;"`).
+ * @param fontSize - Font size in px (default `12`). HooksSection uses `11`.
+ */
+export const inputStyle =
+  (theme: ThemeColors, fontSize = 12) =>
+  (extra = ""): string =>
+    `background: ${theme.bg}; color: ${theme.fg}; border: 1px solid ${theme.border}; border-radius: 4px; padding: 3px 8px; font-size: ${fontSize}px; font-family: monospace; ${extra}`;

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -13,86 +13,12 @@
   import { shortcutHint } from "../actions/shortcut-hint";
   import { shortcutHintsActive } from "../stores/shortcut-hints";
   import { tooltip } from "../actions/tooltip";
+  import { discoEmojiFor, discoColorFor } from "../utils/disco-decoration";
 
   $: isDisco = $theme.name === "Molly Disco";
   import { getAllSurfaces, getAllPanes } from "../types";
   import type { Workspace } from "../types";
   import { workspaceSurfaceMap } from "../services/workspace-service";
-
-  const discoEmojis = [
-    "✨",
-    "🦄",
-    "🌈",
-    "💜",
-    "🪩",
-    "⚡",
-    "💫",
-    "🔮",
-    "🎀",
-    "💎",
-    "🌸",
-    "🍭",
-    "🫧",
-    "💗",
-    "🦋",
-    "🎠",
-    "🧚",
-    "💖",
-    "🌺",
-    "🎵",
-    "🩵",
-    "🪻",
-    "🎪",
-    "🧸",
-    "🌟",
-    "💐",
-    "🩷",
-    "🏄",
-    "🐬",
-    "🌊",
-    "🎨",
-    "🧜",
-    "🫶",
-    "💕",
-    "🌙",
-    "🐾",
-    "🍬",
-    "🎶",
-    "🌻",
-    "🐱",
-    "💝",
-    "🎈",
-    "🪼",
-    "🦩",
-    "🫀",
-    "🧁",
-    "🍩",
-    "🎯",
-  ];
-  const discoColors = [
-    "#e91e63",
-    "#c026d3",
-    "#2979ff",
-    "#00bfa5",
-    "#ff4081",
-    "#e040fb",
-    "#448aff",
-    "#1de9b6",
-    "#ff9100",
-    "#18ffff",
-  ];
-
-  // Stable emoji per workspace based on id hash
-  function discoEmojiFor(id: string): string {
-    let h = 0;
-    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
-    return discoEmojis[Math.abs(h) % discoEmojis.length] ?? "";
-  }
-  function discoColorFor(id: string): string {
-    let h = 0;
-    for (let i = 0; i < id.length; i++) h = (h * 37 + id.charCodeAt(i)) | 0;
-    return discoColors[Math.abs(h) % discoColors.length] ?? "";
-  }
 
   export let workspace: Workspace;
   export let index: number;
@@ -311,9 +237,19 @@
       "
     ></div>
   {/if}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div on:click={onSelect} style="flex: 1; min-width: 0;">
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    role="button"
+    tabindex="0"
+    on:click={onSelect}
+    on:keydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSelect();
+      }
+    }}
+    style="flex: 1; min-width: 0;"
+  >
     <div
       style="padding: 4px 6px; display: flex; align-items: center; gap: 8px;"
     >
@@ -379,17 +315,16 @@
           </span>
         {/if}
         {#if dashboardHint}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <span
+          <button
             data-workspace-dashboard-icon
             data-dashboard-id={dashboardHint.id}
-            title="Open owning dashboard"
+            aria-label="Open owning dashboard"
             on:click|stopPropagation={() => dashboardHint?.onClick()}
             style="
               flex-shrink: 0; display: inline-flex; align-items: center;
               justify-content: center; width: 14px; height: 14px;
               color: {dashboardHint.color ?? $theme.fgDim}; cursor: pointer;
+              background: none; border: none; padding: 0;
             "
           >
             <svg
@@ -409,7 +344,7 @@
               <rect x="14" y="12" width="7" height="9" />
               <rect x="3" y="16" width="7" height="5" />
             </svg>
-          </span>
+          </button>
         {/if}
         {#if dashboardWorkspaceIcon}
           <span
@@ -459,12 +394,15 @@
 
       {#if !hideStatusBadges}
         {#if agentBadges.length > 0 && agentBadges[0]}
+          {@const chipTitle = [latestNotification].filter(Boolean).join(" — ")}
           <span
             data-agent-presence-chip
-            title={[latestNotification].filter(Boolean).join(" — ")}
+            title={chipTitle}
+            aria-label={chipTitle || "Agent active"}
             style="display: inline-flex; align-items: center; padding: 0 3px; flex-shrink: 0;"
           >
             <span
+              aria-hidden="true"
               style="width: 7px; height: 7px; border-radius: 50%; background: {agentChipColor}; box-shadow: 0 0 0 1px color-mix(in srgb, {agentChipColor} 35%, transparent);"
             ></span>
           </span>
@@ -547,9 +485,9 @@
        notification rows stack below the title. The content column
        reserves 24px on the right to keep text from crashing into it. -->
   {#if !isDashboardWs || isDashboardWorkspaceRow}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <span
+    <button
       use:tooltip={"Close Workspace (⇧⌘W)"}
+      aria-label="Close workspace"
       style="
         position: absolute;
         top: 50%; right: 6px;
@@ -570,7 +508,7 @@
       "
       on:click|stopPropagation={onClose}
       on:mouseenter={() => (closeHovered = true)}
-      on:mouseleave={() => (closeHovered = false)}>×</span
+      on:mouseleave={() => (closeHovered = false)}>×</button
     >
   {/if}
 </div>

--- a/src/lib/services/dashboard-workspace-service.ts
+++ b/src/lib/services/dashboard-workspace-service.ts
@@ -1,50 +1,48 @@
-import { writable, get } from "svelte/store";
+import { derived, get, type Readable } from "svelte/store";
 import type { Component } from "svelte";
 import { workspaces } from "../stores/workspace";
 import { createWorkspaceFromDef, switchWorkspace } from "./workspace-service";
+import { createRegistry } from "./create-registry";
 
-export interface DashboardWorkspaceEntry {
+interface DashboardWorkspaceEntry {
   id: string;
   label: string;
   icon: Component;
   component: Component;
   /** Extension ID that registered this entry — used to provide API context when rendering. */
-  source?: string;
+  source: string;
   /** Overrides the workspace row rail/icon color. When absent, falls back to theme accent. */
   accentColor?: string;
 }
 
-export const dashboardWorkspaceRegistry = writable<
+const registry = createRegistry<DashboardWorkspaceEntry>();
+
+/** Readable Map store — consumers can use `$dashboardWorkspaceRegistry.get(id)`. */
+export const dashboardWorkspaceRegistry: Readable<
   Map<string, DashboardWorkspaceEntry>
->(new Map());
+> = derived(registry.store, ($entries) => {
+  const m = new Map<string, DashboardWorkspaceEntry>();
+  for (const e of $entries) m.set(e.id, e);
+  return m;
+});
 
 export function registerDashboardWorkspaceType(
-  entry: DashboardWorkspaceEntry,
+  entry: Omit<DashboardWorkspaceEntry, "source"> & { source?: string },
 ): void {
-  dashboardWorkspaceRegistry.update((m) => {
-    const next = new Map(m);
-    next.set(entry.id, entry);
-    return next;
-  });
+  registry.register({ source: "", ...entry });
 }
 
 export function unregisterDashboardWorkspaceType(id: string): void {
-  dashboardWorkspaceRegistry.update((m) => {
-    const next = new Map(m);
-    next.delete(id);
-    return next;
-  });
+  registry.unregister(id);
 }
 
-export function getDashboardEntry(
-  id: string,
-): DashboardWorkspaceEntry | undefined {
-  return get(dashboardWorkspaceRegistry).get(id);
+function getDashboardEntry(id: string): DashboardWorkspaceEntry | undefined {
+  return registry.get(id);
 }
 
 // Exported for tests only — resets the registry to empty.
 export function clearDashboardRegistry(): void {
-  dashboardWorkspaceRegistry.set(new Map());
+  registry.reset();
 }
 
 export async function spawnOrNavigate(id: string): Promise<void> {

--- a/src/lib/utils/disco-decoration.ts
+++ b/src/lib/utils/disco-decoration.ts
@@ -1,0 +1,82 @@
+/**
+ * Disco decoration data and hash helpers for the "Molly Disco" theme.
+ * These are pure data/utilities with no component-lifecycle dependency.
+ */
+
+export const discoEmojis: readonly string[] = [
+  "✨",
+  "🦄",
+  "🌈",
+  "💜",
+  "🪩",
+  "⚡",
+  "💫",
+  "🔮",
+  "🎀",
+  "💎",
+  "🌸",
+  "🍭",
+  "🫧",
+  "💗",
+  "🦋",
+  "🎠",
+  "🧚",
+  "💖",
+  "🌺",
+  "🎵",
+  "🩵",
+  "🪻",
+  "🎪",
+  "🧸",
+  "🌟",
+  "💐",
+  "🩷",
+  "🏄",
+  "🐬",
+  "🌊",
+  "🎨",
+  "🧜",
+  "🫶",
+  "💕",
+  "🌙",
+  "🐾",
+  "🍬",
+  "🎶",
+  "🌻",
+  "🐱",
+  "💝",
+  "🎈",
+  "🪼",
+  "🦩",
+  "🫀",
+  "🧁",
+  "🍩",
+  "🎯",
+];
+
+export const discoColors: readonly string[] = [
+  "#e91e63",
+  "#c026d3",
+  "#2979ff",
+  "#00bfa5",
+  "#ff4081",
+  "#e040fb",
+  "#448aff",
+  "#1de9b6",
+  "#ff9100",
+  "#18ffff",
+];
+
+/** Returns a stable emoji for the given workspace id based on a hash. */
+export function discoEmojiFor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0;
+  return discoEmojis[Math.abs(h) % discoEmojis.length] ?? "";
+}
+
+/** Returns a stable color for the given workspace id based on a hash. */
+export function discoColorFor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 37 + id.charCodeAt(i)) | 0;
+  return discoColors[Math.abs(h) % discoColors.length] ?? "";
+}


### PR DESCRIPTION
## Summary

- **F14**: Migrate `dashboard-workspace-service.ts` to use `createRegistry<DashboardWorkspaceEntry>()` factory, matching all other service-layer registries. Removes hand-rolled `writable<Map>` + update/get methods. `getDashboardEntry` and `DashboardWorkspaceEntry` unexported (no external callers).
- **F22**: `WorkspaceItem.svelte` — close span → `<button aria-label="Close workspace">`, dashboardHint span → `<button>`, select div → `role="button"` + `tabindex="0"` + Enter/Space keydown.
- **F34**: Extract verbatim-identical `inputStyle` helper from EnvSection, McpSection, HooksSection, PermissionsSection into `src/extensions/claude-settings/utils/section-styles.ts`. HooksSection used `fontSize: 11` vs 12 in others — extracted utility accepts optional `fontSize` parameter.
- **F35**: Move 60-line emoji array, color palette, `discoEmojiFor`/`discoColorFor` from `WorkspaceItem.svelte` to `src/lib/utils/disco-decoration.ts`.
- **F38**: Add `aria-label` to `span[data-agent-presence-chip]` in `WorkspaceItem.svelte`.

## Test plan

- [ ] Dashboard workspace registry behaves identically before/after (CRUD operations on dashboards)
- [ ] WorkspaceItem close button is reachable via keyboard and announces "Close workspace"
- [ ] WorkspaceItem row selectable via Enter/Space
- [ ] claude-settings section inputs retain correct styling in all 4 sections
- [ ] Disco emoji/color decoration renders correctly on workspace items

🤖 Generated with [Claude Code](https://claude.ai/claude-code)