### PR TITLE
fix(audit): a11y easy fixes F19 F21 F24-F28 F37 — dialog roles, button semantics, aria attrs

### DIFF
--- a/src/extensions/agentic-orchestrator/components/AgentStatusRow.svelte
+++ b/src/extensions/agentic-orchestrator/components/AgentStatusRow.svelte
@@ -44,12 +44,18 @@
 </script>
 
 {#if resolved}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
+    role="button"
+    tabindex="0"
     data-agent-status-row
     data-agent-id={resolved.agentId}
     on:click={handleClick}
+    on:keydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleClick();
+      }
+    }}
     style="
       display: flex; align-items: center; gap: 8px;
       padding: 6px 10px; cursor: pointer;

--- a/src/extensions/diff-viewer/DiffSurface.svelte
+++ b/src/extensions/diff-viewer/DiffSurface.svelte
@@ -219,6 +219,7 @@
             class="diff-file-header"
             style:background="{$theme.border}44"
             style:color={$theme.fg}
+            aria-expanded={!collapsedFiles.has(fileIdx)}
             on:click={() => toggleFile(fileIdx)}
           >
             <span class="collapse-indicator"

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -111,10 +111,12 @@
     />
     <button
       title="Previous match (⇧⌘G)"
+      aria-label="Previous match (⇧⌘G)"
       on:click={() => doSearch("prev")}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
       <svg
+        aria-hidden="true"
         width="14"
         height="14"
         viewBox="0 0 16 16"
@@ -125,10 +127,12 @@
     </button>
     <button
       title="Next match (⌘G)"
+      aria-label="Next match (⌘G)"
       on:click={() => doSearch("next")}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
       <svg
+        aria-hidden="true"
         width="14"
         height="14"
         viewBox="0 0 16 16"
@@ -139,6 +143,8 @@
     </button>
     <button
       title="Use regular expression"
+      aria-label="Use regular expression"
+      aria-pressed={regexEnabled}
       on:click={toggleRegex}
       style="background: {regexEnabled
         ? $theme.bg
@@ -151,6 +157,8 @@
     >
     <button
       title="Match case"
+      aria-label="Match case"
+      aria-pressed={caseSensitive}
       on:click={toggleCase}
       style="background: {caseSensitive
         ? $theme.bg
@@ -163,6 +171,8 @@
     >
     <button
       title="Match whole word"
+      aria-label="Match whole word"
+      aria-pressed={wholeWord}
       on:click={toggleWord}
       style="background: {wholeWord ? $theme.bg : 'none'}; border: {wholeWord
         ? `1px solid ${$theme.border}`
@@ -173,10 +183,12 @@
     >
     <button
       title="Close (Esc)"
+      aria-label="Close (Esc)"
       on:click={close}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
       <svg
+        aria-hidden="true"
         width="14"
         height="14"
         viewBox="0 0 16 16"

--- a/src/lib/components/FormPrompt.svelte
+++ b/src/lib/components/FormPrompt.svelte
@@ -111,8 +111,11 @@
     "
     on:mousedown|self={cancel}
   >
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="form-prompt-title"
+      tabindex="-1"
       style="
         width: 460px; height: fit-content; background: {$theme.bgFloat};
         border: 1px solid {$theme.border}; border-radius: 12px;
@@ -121,7 +124,10 @@
       "
       on:keydown={handleKeydown}
     >
-      <div style="font-size: 14px; font-weight: 600; color: {$theme.fg};">
+      <div
+        id="form-prompt-title"
+        style="font-size: 14px; font-weight: 600; color: {$theme.fg};"
+      >
         {$formPrompt.title}
       </div>
 

--- a/src/lib/components/GitStatusLine.svelte
+++ b/src/lib/components/GitStatusLine.svelte
@@ -92,16 +92,15 @@
       {/if}
       {#if dirtyItem && isActiveWorkspace}
         {#if dirtyItem.action && isActiveWorkspace}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <span
+          <button
             style="font-size: 10px; color: {variantColor(
               dirtyItem.variant,
               fgMuted,
-            )}; text-decoration: underline; cursor: pointer; white-space: nowrap;"
+            )}; text-decoration: underline; cursor: pointer; white-space: nowrap; background: none; border: none; padding: 0; font-family: inherit;"
             title={dirtyItem.tooltip || dirtyItem.label}
+            aria-label={dirtyItem.tooltip || dirtyItem.label}
             on:click|stopPropagation={() => handleAction(dirtyItem.action)}
-            >{dirtyItem.label}</span
+            >{dirtyItem.label}</button
           >
         {:else}
           <span
@@ -168,14 +167,13 @@
             ? prCiVariant(prItem)
             : (prItem.variant ?? "muted")}
           {#if prItem.action && isActiveWorkspace}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <span
+            <button
               style="font-size: 10px; color: {variantColor(
                 variant,
                 fgMuted,
-              )}; text-decoration: underline; cursor: pointer; white-space: nowrap; display: inline-flex; gap: 4px; align-items: center;"
+              )}; text-decoration: underline; cursor: pointer; white-space: nowrap; display: inline-flex; gap: 4px; align-items: center; background: none; border: none; padding: 0; font-family: inherit;"
               title={prItem.tooltip || prItem.label}
+              aria-label={prItem.tooltip || prItem.label}
               on:click|stopPropagation={() => handleAction(prItem.action)}
             >
               {prItem.metadata?.prNumber
@@ -186,7 +184,7 @@
                   >[{prItem.metadata.reviewState}]</span
                 >
               {/if}
-            </span>
+            </button>
           {:else}
             <span
               style="font-size: 10px; color: {variantColor(
@@ -215,16 +213,15 @@
         {/if}
         {#if dirtyItem}
           {#if dirtyItem.action && isActiveWorkspace}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <span
+            <button
               style="font-size: 10px; color: {variantColor(
                 dirtyItem.variant,
                 fgMuted,
-              )}; text-decoration: underline; cursor: pointer; white-space: nowrap;"
+              )}; text-decoration: underline; cursor: pointer; white-space: nowrap; background: none; border: none; padding: 0; font-family: inherit;"
               title={dirtyItem.tooltip || dirtyItem.label}
+              aria-label={dirtyItem.tooltip || dirtyItem.label}
               on:click|stopPropagation={() => handleAction(dirtyItem.action)}
-              >{dirtyItem.label}</span
+              >{dirtyItem.label}</button
             >
           {:else}
             <span

--- a/src/lib/components/NewSurfaceButton.svelte
+++ b/src/lib/components/NewSurfaceButton.svelte
@@ -86,11 +86,11 @@
   bind:this={containerEl}
   style="display: inline-flex; align-items: center; position: relative;"
 >
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <span
+  <button
+    aria-label="New terminal ({isMac ? modLabel : shiftModLabel}T)"
     title="New terminal ({isMac ? modLabel : shiftModLabel}T)"
     style="
+      background: none; border: none;
       color: {plusHovered ? $theme.fg : $theme.fgDim};
       cursor: pointer; font-size: 14px;
       padding: 2px {hasExtra ? '3px' : '6px'};
@@ -103,7 +103,7 @@
     }}
     on:click={onNewSurface}
     on:mouseenter={() => (plusHovered = true)}
-    on:mouseleave={() => (plusHovered = false)}>+</span
+    on:mouseleave={() => (plusHovered = false)}>+</button
   >
 
   {#if hasExtra}

--- a/src/lib/components/SidebarSectionBlock.svelte
+++ b/src/lib/components/SidebarSectionBlock.svelte
@@ -62,31 +62,44 @@
     ></div>
     <!-- Title row: 8px left padding creates the same gap other rows use
          between the rail's right edge and their leading content. -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      style="
-        font-size: 10px; font-weight: 600;
-        letter-spacing: 0.5px; text-transform: uppercase;
-        color: {$theme.fg};
-        cursor: {section.collapsible !== false ? 'pointer' : 'default'};
-        display: flex; align-items: center; gap: 4px;
-        padding-left: 8px;
-        pointer-events: auto;
-      "
-      on:click={() => {
-        if (section.collapsible !== false) onToggleCollapse();
-      }}
-    >
-      {#if section.collapsible !== false}
+    {#if section.collapsible !== false}
+      <button
+        style="
+          font-size: 10px; font-weight: 600;
+          letter-spacing: 0.5px; text-transform: uppercase;
+          color: {$theme.fg};
+          cursor: pointer;
+          display: flex; align-items: center; gap: 4px;
+          padding-left: 8px;
+          pointer-events: auto;
+          background: none; border: none; font-family: inherit; width: 100%; text-align: left;
+        "
+        aria-expanded={!collapsed}
+        on:click={onToggleCollapse}
+      >
         <span
+          aria-hidden="true"
           style="font-size: 8px; transform: rotate({collapsed
             ? '-90deg'
             : '0'}); transition: transform 0.15s;">&#9660;</span
         >
-      {/if}
-      {section.label}
-    </div>
+        {section.label}
+      </button>
+    {:else}
+      <div
+        style="
+          font-size: 10px; font-weight: 600;
+          letter-spacing: 0.5px; text-transform: uppercase;
+          color: {$theme.fg};
+          cursor: default;
+          display: flex; align-items: center; gap: 4px;
+          padding-left: 8px;
+          pointer-events: auto;
+        "
+      >
+        {section.label}
+      </div>
+    {/if}
   </div>
 {/if}
 {#if section.collapsible === false || !collapsed}

--- a/src/lib/widgets/Worktrees.svelte
+++ b/src/lib/widgets/Worktrees.svelte
@@ -93,12 +93,18 @@
     <div style="display: flex; flex-direction: column; gap: 4px;">
       {#each entries as entry (entry.worktreePath)}
         {@const hasWorkspace = !!entry.workspaceId}
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
           data-worktree-row
           data-branch={entry.branch}
+          role={hasWorkspace ? "button" : undefined}
+          tabindex={hasWorkspace ? 0 : undefined}
           on:click={() => jumpToWorktree(entry.workspaceId)}
+          on:keydown={(e) => {
+            if (hasWorkspace && (e.key === "Enter" || e.key === " ")) {
+              e.preventDefault();
+              jumpToWorktree(entry.workspaceId);
+            }
+          }}
           style="
             display: flex; align-items: center; gap: 10px;
             padding: 6px 8px; border-radius: 4px;


### PR DESCRIPTION
## Summary

Applies 8 accessibility fixes across separate components. All are ARIA attribute additions or span→button conversions — no behavioral changes.

- **F19**: `FormPrompt.svelte` — add `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
- **F21**: `NewSurfaceButton.svelte` — `+` span → `<button aria-label="New terminal">`
- **F24**: `AgentStatusRow.svelte` — add `role="button"`, `tabindex="0"`, Enter/Space keydown
- **F25**: `Worktrees.svelte` — add `role="button"`, `tabindex="0"`, keydown when `hasWorkspace`
- **F26**: `GitStatusLine.svelte` — interactive status spans → `<button>` elements
- **F27**: `FindBar.svelte` — add `aria-label` to icon-only buttons; inner SVGs `aria-hidden="true"`; add `aria-pressed` to toggle buttons
- **F28**: `SidebarSectionBlock.svelte` — collapsible header div → `<button aria-expanded={\!collapsed}>`
- **F37**: `DiffSurface.svelte` — add `aria-expanded={\!collapsedFiles.has(fileIdx)}` to file-header buttons

## Test plan

- [ ] FormPrompt announced as dialog by screen reader
- [ ] New terminal button reachable and labeled via keyboard
- [ ] AgentStatusRow activatable via Enter/Space
- [ ] Worktree rows with workspace activatable via keyboard
- [ ] GitStatusLine status spans clickable and keyboard-accessible
- [ ] FindBar Previous/Next/Close buttons have accessible names; toggles show pressed state
- [ ] SidebarSectionBlock collapse/expand works via keyboard; aria-expanded reflects state
- [ ] DiffSurface file collapse buttons announce expanded/collapsed state

🤖 Generated with [Claude Code](https://claude.ai/claude-code)