### PR TITLE
fix(security): F01 — replace internal run_script callers with typed git commands

### DIFF
--- a/src-tauri/src/git_status_ops.rs
+++ b/src-tauri/src/git_status_ops.rs
@@ -56,36 +56,6 @@ pub async fn git_status_short(cwd: String) -> Result<ScriptOutput, String> {
     run_argv(&cwd, "git", &["status", "--porcelain=v1", "-b"])
 }
 
-/// `git rev-parse --abbrev-ref HEAD` — resolve the current branch name.
-///
-/// Returns "HEAD" when in detached-HEAD state.
-#[tauri::command]
-pub async fn git_rev_parse_head(cwd: String) -> Result<ScriptOutput, String> {
-    validate_cwd(&cwd)?;
-    run_argv(&cwd, "git", &["rev-parse", "--abbrev-ref", "HEAD"])
-}
-
-/// `gh pr view --json ... -- <branch>` — fetch PR metadata for a branch.
-///
-/// The branch name is passed as a separate argv element so it is never
-/// interpreted by a shell.  Returns non-zero `exit_code` when no PR exists.
-#[tauri::command]
-pub async fn gh_pr_view(repo_path: String, branch: String) -> Result<ScriptOutput, String> {
-    validate_cwd(&repo_path)?;
-    run_argv(
-        &repo_path,
-        "gh",
-        &[
-            "pr",
-            "view",
-            "--json",
-            "number,url,reviewDecision,statusCheckRollup",
-            "--",
-            &branch,
-        ],
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,28 +163,5 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.contains("dirty.txt"));
         cleanup(&repo);
-    }
-
-    #[tokio::test]
-    async fn git_rev_parse_head_returns_branch() {
-        let repo = setup_test_repo();
-        let result = git_rev_parse_head(repo.to_str().unwrap().to_string())
-            .await
-            .unwrap();
-        assert_eq!(result.exit_code, 0);
-        let branch = result.stdout.trim();
-        // Should be a branch name (not empty, not a raw SHA)
-        assert!(!branch.is_empty());
-        cleanup(&repo);
-    }
-
-    #[tokio::test]
-    async fn gh_pr_view_nonexistent_cwd() {
-        let result = gh_pr_view(
-            "/tmp/no-such-repo-gnarterm-gso".to_string(),
-            "main".to_string(),
-        )
-        .await;
-        assert!(result.is_err());
     }
 }

--- a/src-tauri/src/git_status_ops.rs
+++ b/src-tauri/src/git_status_ops.rs
@@ -1,0 +1,220 @@
+/// Typed git commands used by the git-status-service frontend.
+///
+/// These replace the `run_script` shell-injection surface that was
+/// previously used to run `git rev-parse`, `git status`, and `gh pr view`
+/// via `sh -c` with unsanitised path arguments.
+///
+/// Each command builds an argv array directly — no shell interpreter involved.
+use std::path::Path;
+use std::process::Command;
+
+use crate::file_utils::ScriptOutput;
+
+fn validate_cwd(cwd: &str) -> Result<(), String> {
+    let path = Path::new(cwd);
+    if !path.exists() {
+        return Err(format!("Working directory does not exist: {cwd}"));
+    }
+    if !path.is_dir() {
+        return Err(format!("Working directory is not a directory: {cwd}"));
+    }
+    Ok(())
+}
+
+fn run_argv(cwd: &str, program: &str, args: &[&str]) -> Result<ScriptOutput, String> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| format!("Failed to spawn {program}: {e}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_code = output.status.code().unwrap_or(-1);
+    Ok(ScriptOutput {
+        stdout,
+        stderr,
+        exit_code,
+    })
+}
+
+/// `git rev-parse --show-toplevel` — resolve the repo root from a given cwd.
+///
+/// Returns non-zero `exit_code` when cwd is not inside a git repo.
+#[tauri::command]
+pub async fn git_rev_parse_toplevel(cwd: String) -> Result<ScriptOutput, String> {
+    validate_cwd(&cwd)?;
+    run_argv(&cwd, "git", &["rev-parse", "--show-toplevel"])
+}
+
+/// `git status --porcelain=v1 -b` — branch + dirty-file listing.
+///
+/// The output is identical to what `parseGitStatus()` on the frontend expects.
+#[tauri::command]
+pub async fn git_status_short(cwd: String) -> Result<ScriptOutput, String> {
+    validate_cwd(&cwd)?;
+    run_argv(&cwd, "git", &["status", "--porcelain=v1", "-b"])
+}
+
+/// `git rev-parse --abbrev-ref HEAD` — resolve the current branch name.
+///
+/// Returns "HEAD" when in detached-HEAD state.
+#[tauri::command]
+pub async fn git_rev_parse_head(cwd: String) -> Result<ScriptOutput, String> {
+    validate_cwd(&cwd)?;
+    run_argv(&cwd, "git", &["rev-parse", "--abbrev-ref", "HEAD"])
+}
+
+/// `gh pr view --json ... -- <branch>` — fetch PR metadata for a branch.
+///
+/// The branch name is passed as a separate argv element so it is never
+/// interpreted by a shell.  Returns non-zero `exit_code` when no PR exists.
+#[tauri::command]
+pub async fn gh_pr_view(repo_path: String, branch: String) -> Result<ScriptOutput, String> {
+    validate_cwd(&repo_path)?;
+    run_argv(
+        &repo_path,
+        "gh",
+        &[
+            "pr",
+            "view",
+            "--json",
+            "number,url,reviewDecision,statusCheckRollup",
+            "--",
+            &branch,
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn setup_test_repo() -> std::path::PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("gnar-term-gso-{}-{}", std::process::id(), id));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("Failed to create temp dir");
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&dir)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&dir)
+            .output()
+            .expect("git config email");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&dir)
+            .output()
+            .expect("git config name");
+
+        fs::write(dir.join("README.md"), "test").expect("write file");
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&dir)
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&dir)
+            .output()
+            .expect("git commit");
+
+        dir
+    }
+
+    fn cleanup(dir: &std::path::Path) {
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validate_cwd_nonexistent() {
+        assert!(validate_cwd("/tmp/definitely-no-such-dir-gnarterm-gso").is_err());
+    }
+
+    #[test]
+    fn validate_cwd_file_not_dir() {
+        let f = std::env::temp_dir().join("gnar-term-gso-validate-file");
+        fs::write(&f, "x").unwrap();
+        assert!(validate_cwd(f.to_str().unwrap()).is_err());
+        let _ = fs::remove_file(&f);
+    }
+
+    #[tokio::test]
+    async fn git_rev_parse_toplevel_returns_repo_root() {
+        let repo = setup_test_repo();
+        let result = git_rev_parse_toplevel(repo.to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result
+                .stdout
+                .trim()
+                .ends_with(repo.file_name().unwrap().to_str().unwrap())
+                || result.stdout.contains(repo.to_str().unwrap())
+        );
+        cleanup(&repo);
+    }
+
+    #[tokio::test]
+    async fn git_rev_parse_toplevel_nonexistent_cwd() {
+        let result = git_rev_parse_toplevel("/tmp/no-such-repo-gnarterm-gso".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn git_status_short_clean_repo() {
+        let repo = setup_test_repo();
+        let result = git_status_short(repo.to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        // Output starts with "## " branch header
+        assert!(result.stdout.starts_with("## "));
+        cleanup(&repo);
+    }
+
+    #[tokio::test]
+    async fn git_status_short_dirty_repo() {
+        let repo = setup_test_repo();
+        fs::write(repo.join("dirty.txt"), "change").unwrap();
+        let result = git_status_short(repo.to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("dirty.txt"));
+        cleanup(&repo);
+    }
+
+    #[tokio::test]
+    async fn git_rev_parse_head_returns_branch() {
+        let repo = setup_test_repo();
+        let result = git_rev_parse_head(repo.to_str().unwrap().to_string())
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        let branch = result.stdout.trim();
+        // Should be a branch name (not empty, not a raw SHA)
+        assert!(!branch.is_empty());
+        cleanup(&repo);
+    }
+
+    #[tokio::test]
+    async fn gh_pr_view_nonexistent_cwd() {
+        let result = gh_pr_view(
+            "/tmp/no-such-repo-gnarterm-gso".to_string(),
+            "main".to_string(),
+        )
+        .await;
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod gh_commands;
 pub mod git_helpers;
 mod git_info;
 mod git_ops;
+mod git_status_ops;
 mod git_worktree;
 pub mod mcp_bridge;
 pub mod mcp_register;
@@ -1884,7 +1885,11 @@ pub fn run() {
             git_info::git_diff,
             gh_commands::gh_list_prs,
             gh_commands::gh_list_issues,
-            gh_commands::gh_available
+            gh_commands::gh_available,
+            git_status_ops::git_rev_parse_toplevel,
+            git_status_ops::git_status_short,
+            git_status_ops::git_rev_parse_head,
+            git_status_ops::gh_pr_view
         ])
         .setup(|app| {
             // Set window title from CLI --title flag

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1887,9 +1887,7 @@ pub fn run() {
             gh_commands::gh_list_issues,
             gh_commands::gh_available,
             git_status_ops::git_rev_parse_toplevel,
-            git_status_ops::git_status_short,
-            git_status_ops::git_rev_parse_head,
-            git_status_ops::gh_pr_view
+            git_status_ops::git_status_short
         ])
         .setup(|app| {
             // Set window title from CLI --title flag

--- a/src/__tests__/git-status-service.test.ts
+++ b/src/__tests__/git-status-service.test.ts
@@ -238,24 +238,17 @@ describe("initGitStatus()", () => {
 
     const tauri = await import("@tauri-apps/api/core");
     const invokeMock = vi.mocked(tauri.invoke);
-    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
+    invokeMock.mockImplementation(async (cmd: string, _args?: unknown) => {
       if (cmd === "get_pty_cwd") return "/repos/project-A";
-      if (cmd === "run_script") {
-        const a = args as { command?: string };
-        if (a?.command?.includes("echo $HOME"))
-          return { stdout: "/Users/x\n", stderr: "", exit_code: 0 };
-        if (a?.command?.includes("rev-parse --show-toplevel"))
-          return { stdout: "/repos/project-A\n", stderr: "", exit_code: 0 };
-        if (a?.command?.includes("status --porcelain=v1 -b"))
-          return {
-            stdout: "## branch-A...origin/main\n M file.ts\n",
-            stderr: "",
-            exit_code: 0,
-          };
-        if (a?.command?.includes("rev-parse --abbrev-ref HEAD"))
-          return { stdout: "branch-A\n", stderr: "", exit_code: 0 };
-        return { stdout: "", stderr: "", exit_code: 1 };
-      }
+      if (cmd === "get_home") return "/Users/x";
+      if (cmd === "git_rev_parse_toplevel")
+        return { stdout: "/repos/project-A\n", stderr: "", exit_code: 0 };
+      if (cmd === "git_status_short")
+        return {
+          stdout: "## branch-A...origin/main\n M file.ts\n",
+          stderr: "",
+          exit_code: 0,
+        };
       return undefined;
     });
 
@@ -305,25 +298,18 @@ describe("git status service: ensurePolling CWD-race resilience", () => {
         const a = args as { ptyId?: number };
         return a.ptyId === 1 ? "/repos/project-A" : "/repos/project-B";
       }
-      if (cmd === "run_script") {
-        const a = args as { cwd?: string; command?: string };
-        if (a.command?.includes("echo $HOME"))
-          return { stdout: "/Users/x\n", stderr: "", exit_code: 0 };
-        if (a.command?.includes("rev-parse --show-toplevel"))
-          return { stdout: `${a.cwd}\n`, stderr: "", exit_code: 0 };
-        if (a.command?.includes("status --porcelain=v1 -b")) {
-          const branch = a.cwd?.includes("project-A") ? "branch-A" : "branch-B";
-          return {
-            stdout: `## ${branch}...origin/main\n`,
-            stderr: "",
-            exit_code: 0,
-          };
-        }
-        if (a.command?.includes("rev-parse --abbrev-ref HEAD")) {
-          const branch = a.cwd?.includes("project-A") ? "branch-A" : "branch-B";
-          return { stdout: `${branch}\n`, stderr: "", exit_code: 0 };
-        }
-        return { stdout: "", stderr: "", exit_code: 1 };
+      if (cmd === "git_rev_parse_toplevel") {
+        const a = args as { cwd?: string };
+        return { stdout: `${a.cwd}\n`, stderr: "", exit_code: 0 };
+      }
+      if (cmd === "git_status_short") {
+        const a = args as { cwd?: string };
+        const branch = a.cwd?.includes("project-A") ? "branch-A" : "branch-B";
+        return {
+          stdout: `## ${branch}...origin/main\n`,
+          stderr: "",
+          exit_code: 0,
+        };
       }
       return undefined;
     });
@@ -381,36 +367,29 @@ describe("git status service: refreshes when the active workspace's cwd changes"
     activeWorkspaceIdx.set(0);
 
     let ptyCwd = "/repos/project-A";
-    const runScriptCalls: Array<{ cwd?: string; command?: string }> = [];
+    const statusShortCalls: Array<{ cwd?: string }> = [];
     const tauri = await import("@tauri-apps/api/core");
     const invokeMock = vi.mocked(tauri.invoke);
     invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
       if (cmd === "get_home") return "/Users/x";
       if (cmd === "get_pty_cwd") return ptyCwd;
-      if (cmd === "run_script") {
-        const a = args as { cwd?: string; command?: string };
-        runScriptCalls.push({ cwd: a.cwd, command: a.command });
-        if (a.command?.includes("echo $HOME"))
-          return { stdout: "/Users/x\n", stderr: "", exit_code: 0 };
-        if (a.command?.includes("rev-parse --show-toplevel"))
-          return { stdout: `${a.cwd}\n`, stderr: "", exit_code: 0 };
-        if (a.command?.includes("status --porcelain=v1 -b")) {
-          const branch = a.cwd?.includes("project-A")
-            ? "branch-A"
-            : a.cwd?.includes("project-B")
-              ? "branch-B"
-              : "branch-unknown";
-          return {
-            stdout: `## ${branch}...origin/main\n`,
-            stderr: "",
-            exit_code: 0,
-          };
-        }
-        if (a.command?.includes("rev-parse --abbrev-ref HEAD")) {
-          const branch = a.cwd?.includes("project-A") ? "branch-A" : "branch-B";
-          return { stdout: `${branch}\n`, stderr: "", exit_code: 0 };
-        }
-        return { stdout: "", stderr: "", exit_code: 1 };
+      if (cmd === "git_rev_parse_toplevel") {
+        const a = args as { cwd?: string };
+        return { stdout: `${a.cwd}\n`, stderr: "", exit_code: 0 };
+      }
+      if (cmd === "git_status_short") {
+        const a = args as { cwd?: string };
+        statusShortCalls.push({ cwd: a.cwd });
+        const branch = a.cwd?.includes("project-A")
+          ? "branch-A"
+          : a.cwd?.includes("project-B")
+            ? "branch-B"
+            : "branch-unknown";
+        return {
+          stdout: `## ${branch}...origin/main\n`,
+          stderr: "",
+          exit_code: 0,
+        };
       }
       return undefined;
     });
@@ -420,8 +399,8 @@ describe("git status service: refreshes when the active workspace's cwd changes"
     eventBus.emit({ type: "workspace:activated", id: "A", previousId: null });
     await drain(100);
 
-    const initialStatus = runScriptCalls.find((c) =>
-      c.command?.includes("status --porcelain=v1 -b"),
+    const initialStatus = statusShortCalls.find((c) =>
+      c.cwd?.includes("project-A"),
     );
     expect(initialStatus?.cwd).toContain("project-A");
     const initialItems = get(statusRegistry.store);
@@ -439,10 +418,8 @@ describe("git status service: refreshes when the active workspace's cwd changes"
     await vi.advanceTimersByTimeAsync(600);
     await drain(100);
 
-    const statusRunsAgainstB = runScriptCalls.filter(
-      (c) =>
-        c.command?.includes("status --porcelain=v1 -b") &&
-        c.cwd?.includes("project-B"),
+    const statusRunsAgainstB = statusShortCalls.filter((c) =>
+      c.cwd?.includes("project-B"),
     );
     expect(statusRunsAgainstB.length).toBeGreaterThan(0);
 
@@ -498,43 +475,18 @@ describe("git status service: stale-data clear (H4)", () => {
       ] as unknown as Workspace[]);
       activeWorkspaceIdx.set(0);
 
-      const okResponses: Record<
-        string,
-        { stdout: string; stderr: string; exit_code: number } | null
-      > = {
-        "echo $HOME": { stdout: "/Users/x\n", stderr: "", exit_code: 0 },
-        "rev-parse --show-toplevel": {
-          stdout: "/tmp/repo\n",
-          stderr: "",
-          exit_code: 0,
-        },
-        "status --porcelain=v1 -b": {
-          stdout: "## main...origin/main\n M file.ts\n",
-          stderr: "",
-          exit_code: 0,
-        },
-        "rev-parse --abbrev-ref HEAD": {
-          stdout: "main\n",
-          stderr: "",
-          exit_code: 0,
-        },
-        "gh pr view": { stdout: "{}", stderr: "", exit_code: 1 },
-      };
-
       const tauri = await import("@tauri-apps/api/core");
       const invokeMock = vi.mocked(tauri.invoke);
-      invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
+      invokeMock.mockImplementation(async (cmd: string, _args?: unknown) => {
         if (cmd === "get_home") return "/Users/x";
-        if (cmd === "run_script") {
-          const a = args as { command?: string };
-          const key = Object.keys(okResponses).find((k) =>
-            a?.command?.includes(k),
-          );
-          if (!key) return null;
-          const val = okResponses[key];
-          if (val === null) throw new Error("failure");
-          return val;
-        }
+        if (cmd === "git_rev_parse_toplevel")
+          return { stdout: "/tmp/repo\n", stderr: "", exit_code: 0 };
+        if (cmd === "git_status_short")
+          return {
+            stdout: "## main...origin/main\n M file.ts\n",
+            stderr: "",
+            exit_code: 0,
+          };
         return undefined;
       });
 
@@ -566,19 +518,13 @@ describe("git status service: stale-data clear (H4)", () => {
         ),
       ).toBe(true);
 
-      invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
+      // Second pass: git_rev_parse_toplevel still succeeds (same root) but
+      // git_status_short now fails — branch+dirty items should be cleared.
+      invokeMock.mockImplementation(async (cmd: string, _args?: unknown) => {
         if (cmd === "get_home") return "/Users/x";
-        if (cmd === "run_script") {
-          const a = args as { command?: string };
-          if (a?.command?.includes("rev-parse --show-toplevel")) {
-            return {
-              stdout: "/tmp/repo\n",
-              stderr: "",
-              exit_code: 0,
-            };
-          }
-          return null;
-        }
+        if (cmd === "git_rev_parse_toplevel")
+          return { stdout: "/tmp/repo\n", stderr: "", exit_code: 0 };
+        // git_status_short intentionally absent — returns undefined → null in runWithTimeout
         return undefined;
       });
 

--- a/src/lib/services/git-status-service.ts
+++ b/src/lib/services/git-status-service.ts
@@ -51,13 +51,12 @@ interface ScriptResult {
 }
 
 async function runWithTimeout(
-  cwd: string,
-  command: string,
+  invocation: Promise<ScriptResult>,
   timeoutMs: number = 10000,
 ): Promise<string | null> {
   try {
     const result = await Promise.race([
-      invoke<ScriptResult>("run_script", { cwd, command }),
+      invocation,
       new Promise<null>((_, reject) =>
         setTimeout(() => reject(new Error("timeout")), timeoutMs),
       ),
@@ -175,15 +174,18 @@ let cwdChangeTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function getHomeDir(): Promise<string | null> {
   if (homeDir) return homeDir;
-  const result = await runWithTimeout("/tmp", "echo $HOME", 2000);
-  homeDir = result?.trim() || null;
+  try {
+    const result = await invoke<string>("get_home");
+    homeDir = result?.trim() || null;
+  } catch {
+    homeDir = null;
+  }
   return homeDir;
 }
 
 async function detectGitRoot(cwd: string): Promise<string | null> {
   const result = await runWithTimeout(
-    cwd,
-    "git rev-parse --show-toplevel",
+    invoke<ScriptResult>("git_rev_parse_toplevel", { cwd }),
     5000,
   );
   const root = result?.trim() || null;
@@ -219,8 +221,7 @@ async function refreshGitStatus(
   }
 
   const raw = await runWithTimeout(
-    gitRoot,
-    "git status --porcelain=v1 -b",
+    invoke<ScriptResult>("git_status_short", { cwd: gitRoot }),
     5000,
   );
   if (!raw) {


### PR DESCRIPTION
## Summary

`run_script` passes a free-form `command: String` verbatim to `sh -c`. Three internal services were constructing shell strings with user-controlled values (repo paths, workspace names), creating a live injection surface.

- Add `src-tauri/src/git_status_ops.rs` with typed Tauri commands `git_rev_parse_toplevel` and `git_status_short` — fixed argv arrays, no shell expansion.
- Update `git-status-service.ts` to invoke the new typed commands instead of `run_script`.
- Remove unused `git_rev_parse_head` and `gh_pr_view` commands added proactively (no frontend callers).
- Update mocks in `git-status-service.test.ts` accordingly.
- `run_script` is **kept intact** — it is intentionally exposed as an extension API gated behind the `"shell"` capability.

## Test plan

- [ ] `npm test` passes
- [ ] `cargo check` passes
- [ ] Git status sidebar continues to show dirty/clean state correctly
- [ ] Extensions with `"shell"` capability can still invoke `run_script`
- [ ] No shell injection possible via workspace path in git status calls

🤖 Generated with [Claude Code](https://claude.ai/claude-code)