### PR TITLE
fix(a11y): high-severity fixes F05 F06 F07 F08 F11 — TabBar, Tab, CommandPalette, InputPrompt, ContextMenu

### DIFF
--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -537,6 +537,83 @@ describe("Tab", () => {
     const spans = container.querySelectorAll(".tab span");
     expect(spans.length).toBe(1);
   });
+
+  // ---- a11y regression tests (F06) ----------------------------------------
+
+  it("tab div has role=tab and aria-selected", () => {
+    const surface = makeSurface("t1");
+    const { container } = render(Tab, {
+      props: {
+        surface,
+        index: 0,
+        isActive: true,
+        onSelect: noop,
+        onClose: noop,
+      },
+    });
+    const tab = container.querySelector(".tab") as HTMLElement;
+    expect(tab.getAttribute("role")).toBe("tab");
+    expect(tab.getAttribute("aria-selected")).toBe("true");
+    expect(tab.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("Enter key on the tab div calls onSelect", async () => {
+    const surface = makeSurface("t1");
+    const onSelect = vi.fn();
+    const { container } = render(Tab, {
+      props: { surface, index: 0, isActive: false, onSelect, onClose: noop },
+    });
+    const tab = container.querySelector(".tab") as HTMLElement;
+    fireEvent.keyDown(tab, { key: "Enter", target: tab, currentTarget: tab });
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("Space key on the tab div calls onSelect", async () => {
+    const surface = makeSurface("t1");
+    const onSelect = vi.fn();
+    const { container } = render(Tab, {
+      props: { surface, index: 0, isActive: false, onSelect, onClose: noop },
+    });
+    const tab = container.querySelector(".tab") as HTMLElement;
+    fireEvent.keyDown(tab, { key: " ", target: tab, currentTarget: tab });
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("Enter on close button does not call onSelect (bubbling guard)", async () => {
+    const surface = makeSurface("t1");
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(Tab, {
+      props: { surface, index: 0, isActive: true, onSelect, onClose },
+    });
+    const closeBtn = container.querySelector(
+      "button[aria-label='Close tab']",
+    ) as HTMLElement;
+    // Dispatch keydown directly on the close button — it bubbles to the tab
+    // div, but handleTabKeydown should ignore it (target !== currentTarget).
+    closeBtn.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("close button has aria-label and is a button element", () => {
+    const surface = makeSurface("t1");
+    const { container } = render(Tab, {
+      props: {
+        surface,
+        index: 0,
+        isActive: true,
+        onSelect: noop,
+        onClose: noop,
+      },
+    });
+    const closeBtn = container.querySelector(
+      "button[aria-label='Close tab']",
+    ) as HTMLButtonElement;
+    expect(closeBtn).toBeTruthy();
+    expect(closeBtn.tagName).toBe("BUTTON");
+  });
 });
 
 // ===========================================================================
@@ -734,6 +811,96 @@ describe("ContextMenu", () => {
     expect(row).toBeTruthy();
     expect(row.style.opacity).toBe("0.5");
   });
+
+  // ---- a11y regression tests (F11) ----------------------------------------
+
+  it("menu container has role=menu", () => {
+    contextMenu.set({ x: 0, y: 0, items: [{ label: "Item", action: noop }] });
+    const { container } = render(ContextMenu);
+    const menu = container.querySelector("#context-menu") as HTMLElement;
+    expect(menu.getAttribute("role")).toBe("menu");
+  });
+
+  it("menu items have role=menuitem and tabindex=-1", () => {
+    contextMenu.set({
+      x: 0,
+      y: 0,
+      items: [
+        { label: "Copy", action: noop },
+        { label: "Paste", action: noop },
+      ],
+    });
+    const { container } = render(ContextMenu);
+    const items = container.querySelectorAll('[role="menuitem"]');
+    expect(items.length).toBe(2);
+    items.forEach((item) => {
+      expect((item as HTMLElement).getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  it("separator element has role=separator", () => {
+    contextMenu.set({
+      x: 0,
+      y: 0,
+      items: [
+        { label: "Copy", action: noop },
+        { label: "", action: noop, separator: true },
+        { label: "Paste", action: noop },
+      ],
+    });
+    const { container } = render(ContextMenu);
+    const sep = container.querySelector('[role="separator"]');
+    expect(sep).toBeTruthy();
+  });
+
+  it("ArrowDown/ArrowUp keyboard navigation is wired on the menu container", () => {
+    contextMenu.set({
+      x: 0,
+      y: 0,
+      items: [
+        { label: "First", action: noop },
+        { label: "Second", action: noop },
+        { label: "Third", action: noop },
+      ],
+    });
+    const { container } = render(ContextMenu);
+    const menu = container.querySelector("#context-menu") as HTMLElement;
+    const items = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    );
+
+    // Spy on focus for each item and track calls.
+    // Use a mutable "current active" so the handler's document.activeElement
+    // lookup reflects which item was last focused.
+    let activeItem: HTMLElement | null = null;
+    const activeElementSpy = vi
+      .spyOn(document, "activeElement", "get")
+      .mockImplementation(() => activeItem);
+
+    const focusCalls: HTMLElement[] = [];
+    items.forEach((item) => {
+      vi.spyOn(item, "focus").mockImplementation(() => {
+        activeItem = item;
+        focusCalls.push(item);
+      });
+    });
+
+    // ArrowDown from first item should focus second
+    activeItem = items[0]!;
+    menu.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect(focusCalls.at(-1)).toBe(items[1]);
+
+    // ArrowUp from second item should focus first
+    activeItem = items[1]!;
+    menu.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+    );
+    expect(focusCalls.at(-1)).toBe(items[0]);
+
+    activeElementSpy.mockRestore();
+  });
 });
 
 // ===========================================================================
@@ -802,6 +969,56 @@ describe("CommandPalette", () => {
     commandPaletteOpen.set(true);
     const { container } = render(CommandPalette);
     expect(container.querySelector("#cmd-palette-overlay")).toBeTruthy();
+  });
+
+  // ---- a11y regression tests (F07) ----------------------------------------
+
+  it("overlay has role=dialog and aria-modal", () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    const overlay = container.querySelector(
+      "#cmd-palette-overlay",
+    ) as HTMLElement;
+    expect(overlay.getAttribute("role")).toBe("dialog");
+    expect(overlay.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("input has aria-label", () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.getAttribute("aria-label")).toBe("Command search");
+  });
+
+  it("results container has role=listbox", () => {
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).toBeTruthy();
+  });
+
+  it("each command row has role=option and aria-selected", () => {
+    registerCommands([
+      { id: "test.cmd-a", title: "Cmd A", action: noop, source: "test" },
+      { id: "test.cmd-b", title: "Cmd B", action: noop, source: "test" },
+    ]);
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    const options = container.querySelectorAll('[role="option"]');
+    expect(options.length).toBe(2);
+    // First option is selected by default (selectedIdx = 0)
+    expect(options[0]!.getAttribute("aria-selected")).toBe("true");
+    expect(options[1]!.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("input aria-activedescendant points to selected option", () => {
+    registerCommands([
+      { id: "test.cmd-a", title: "Cmd A", action: noop, source: "test" },
+    ]);
+    commandPaletteOpen.set(true);
+    const { container } = render(CommandPalette);
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.getAttribute("aria-activedescendant")).toBe("cmd-option-0");
   });
 });
 

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -468,9 +468,9 @@ describe("Tab", () => {
         onClose: noop,
       },
     });
-    // When hasUnread && !isActive, the tab renders 3 spans: dot, title, close
+    // When hasUnread && !isActive, the tab renders 2 spans (dot + title) and 1 close button
     const spans = container.querySelectorAll(".tab span");
-    expect(spans.length).toBe(3);
+    expect(spans.length).toBe(2);
     // The first span is the unread dot (empty text content)
     expect(spans[0].textContent).toBe("");
   });
@@ -486,9 +486,9 @@ describe("Tab", () => {
         onClose: noop,
       },
     });
-    // When isActive, the unread dot is not rendered — only title and close spans
+    // When isActive, the unread dot is not rendered — only title span + close button
     const spans = container.querySelectorAll(".tab span");
-    expect(spans.length).toBe(2);
+    expect(spans.length).toBe(1);
   });
 
   it("renders close button (x symbol)", () => {
@@ -533,9 +533,9 @@ describe("Tab", () => {
         onClose: noop,
       },
     });
-    // Without unread, only 2 spans: title and close
+    // Without unread, only 1 span (title) + close button (not a span)
     const spans = container.querySelectorAll(".tab span");
-    expect(spans.length).toBe(2);
+    expect(spans.length).toBe(1);
   });
 });
 

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -70,6 +70,10 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     id="cmd-palette-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Command palette"
+    tabindex="-1"
     style="
       position: fixed; inset: 0; z-index: 9998;
       background: rgba(0,0,0,0.5); display: flex;
@@ -90,6 +94,12 @@
         bind:this={inputEl}
         type="text"
         placeholder="Type a command..."
+        aria-label="Command search"
+        aria-autocomplete="list"
+        aria-controls="cmd-palette-listbox"
+        aria-activedescendant={filtered.length
+          ? `cmd-option-${selectedIdx}`
+          : undefined}
         bind:value={query}
         on:input={() => {
           selectedIdx = 0;
@@ -100,11 +110,19 @@
           font-size: 15px; outline: none; font-family: inherit;
         "
       />
-      <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
+      <div
+        id="cmd-palette-listbox"
+        role="listbox"
+        aria-label="Commands"
+        style="flex: 1; overflow-y: auto; padding: 4px 0;"
+      >
         {#each filtered as cmd, i}
           <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
+            id="cmd-option-{i}"
+            role="option"
+            tabindex="-1"
+            aria-selected={i === selectedIdx}
             style="
               padding: 8px 18px; cursor: pointer; display: flex;
               align-items: center; justify-content: space-between;

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { contextMenu } from "../stores/ui";
   import { theme } from "../stores/theme";
+
+  let menuEl: HTMLElement | null = null;
 
   function close() {
     contextMenu.set(null);
@@ -29,6 +32,47 @@
       clampPosition($contextMenu.x, $contextMenu.y, el);
     }
   }
+
+  function getMenuItems(): HTMLElement[] {
+    if (!menuEl) return [];
+    return Array.from(
+      menuEl.querySelectorAll<HTMLElement>(
+        '[role="menuitem"]:not([aria-disabled="true"])',
+      ),
+    );
+  }
+
+  function focusItem(el: HTMLElement) {
+    el.focus();
+  }
+
+  function handleMenuKeydown(e: KeyboardEvent) {
+    const items = getMenuItems();
+    if (!items.length) return;
+    const focused = document.activeElement as HTMLElement;
+    const idx = items.indexOf(focused);
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = idx < items.length - 1 ? idx + 1 : 0;
+      focusItem(items[next]!);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = idx > 0 ? idx - 1 : items.length - 1;
+      focusItem(items[prev]!);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (focused && items.includes(focused)) focused.click();
+    }
+  }
+
+  // Focus first item when menu opens
+  $: if ($contextMenu) {
+    void tick().then(() => {
+      const items = getMenuItems();
+      if (items[0]) focusItem(items[0]);
+    });
+  }
 </script>
 
 <svelte:window on:mousedown={handleMousedown} on:keydown={handleKeydown} />
@@ -36,7 +80,11 @@
 {#if $contextMenu}
   <div
     id="context-menu"
+    role="menu"
+    tabindex="-1"
+    bind:this={menuEl}
     use:positionMenu
+    on:keydown={handleMenuKeydown}
     style="
       position: fixed; z-index: 9999;
       background: {$theme.bgFloat}; border: 1px solid {$theme.border};
@@ -48,12 +96,15 @@
     {#each $contextMenu.items as item}
       {#if item.separator}
         <div
+          role="separator"
           style="height: 1px; background: {$theme.border}; margin: 4px 8px;"
         ></div>
       {:else}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
+          role="menuitem"
+          tabindex="-1"
+          aria-disabled={item.disabled ? "true" : undefined}
           class="menu-row"
           class:disabled={item.disabled}
           class:danger={item.danger}

--- a/src/lib/components/InputPrompt.svelte
+++ b/src/lib/components/InputPrompt.svelte
@@ -4,6 +4,8 @@
   import { inputPrompt } from "../stores/ui";
 
   let inputEl: HTMLInputElement;
+  let cancelBtn: HTMLButtonElement;
+  let okBtn: HTMLButtonElement;
 
   function submit() {
     if (!$inputPrompt) return;
@@ -23,10 +25,27 @@
     if (e.key === "Enter") {
       e.preventDefault();
       submit();
+      return;
     }
     if (e.key === "Escape") {
       e.preventDefault();
       cancel();
+      return;
+    }
+    // Focus trap: cycle Tab/Shift+Tab among input, cancel, ok
+    if (e.key === "Tab") {
+      const focusables = [inputEl, cancelBtn, okBtn].filter(Boolean);
+      const current = document.activeElement;
+      const idx = focusables.indexOf(current as HTMLInputElement);
+      if (e.shiftKey) {
+        e.preventDefault();
+        const prev = idx <= 0 ? focusables.length - 1 : idx - 1;
+        focusables[prev]?.focus();
+      } else {
+        e.preventDefault();
+        const next = idx >= focusables.length - 1 ? 0 : idx + 1;
+        focusables[next]?.focus();
+      }
     }
   }
 
@@ -49,8 +68,10 @@
     "
     on:mousedown|self={cancel}
   >
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={$inputPrompt.placeholder}
       style="
         width: 460px; height: fit-content; background: {$theme.bgFloat};
         border: 1px solid {$theme.border}; border-radius: 12px;
@@ -63,6 +84,7 @@
         bind:this={inputEl}
         type="text"
         placeholder={$inputPrompt.placeholder}
+        aria-label={$inputPrompt.placeholder}
         value={$inputPrompt.defaultValue || ""}
         style="
           padding: 10px 14px; background: {$theme.bg}; border: 1px solid {$theme.borderActive};
@@ -72,6 +94,7 @@
       />
       <div style="display: flex; justify-content: flex-end; gap: 8px;">
         <button
+          bind:this={cancelBtn}
           on:click={cancel}
           style="
             padding: 6px 16px; border-radius: 6px; border: 1px solid {$theme.border};
@@ -79,6 +102,7 @@
           ">Cancel</button
         >
         <button
+          bind:this={okBtn}
           on:click={submit}
           style="
             padding: 6px 16px; border-radius: 6px; border: none;

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -99,7 +99,9 @@
   }
 
   function handleTabKeydown(e: KeyboardEvent) {
-    // Don't intercept keys while the inline rename input is active
+    // Only handle when the tab div itself is the event target — not child
+    // buttons (close button) or the contenteditable rename span.
+    if (e.target !== e.currentTarget) return;
     if (_renaming) return;
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -97,12 +97,22 @@
       nameEl?.blur();
     }
   }
+
+  function handleTabKeydown(e: KeyboardEvent) {
+    // Don't intercept keys while the inline rename input is active
+    if (_renaming) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect();
+    }
+  }
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="tab"
+  role="tab"
+  tabindex="0"
+  aria-selected={isActive}
   data-tab-idx={index}
   data-tab-surface-id={surface.id}
   use:shortcutHint={isMac && index < 9 ? `Ctrl+${index + 1}` : undefined}
@@ -119,6 +129,7 @@
     display: flex; align-items: center; gap: 4px;
   "
   on:click={onSelect}
+  on:keydown={handleTabKeydown}
   on:mouseenter={() => (hovered = true)}
   on:mouseleave={() => (hovered = false)}
   on:mousedown={(e) => {
@@ -176,23 +187,24 @@
         ? `${surface.title || "Preview"} (MD Preview)`
         : surface.title || `Shell ${index + 1}`}{/if}
   </span>
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <span
+  <button
+    aria-label="Close tab"
     style="
+      background: none; border: none; padding: {$shortcutHintsActive
+      ? '0 3px'
+      : '0'};
+      font: inherit; cursor: pointer; margin-left: 4px;
       color: {closeHovered ? $theme.danger : $theme.fgDim};
       font-size: {$shortcutHintsActive ? '16px' : '13px'};
-      cursor: pointer;
-      margin-left: 4px;
-      padding: {$shortcutHintsActive ? '0 3px' : '0'};
       visibility: {isActive || hovered || $shortcutHintsActive
       ? 'visible'
       : 'hidden'};
       transition: font-size 0.1s, padding 0.1s;
+      line-height: 1;
     "
     on:click|stopPropagation={onClose}
     on:mouseenter={() => (closeHovered = true)}
-    on:mouseleave={() => (closeHovered = false)}>×</span
+    on:mouseleave={() => (closeHovered = false)}>×</button
   >
 </div>
 

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -53,6 +53,7 @@
 </script>
 
 <div
+  role="tablist"
   data-pane-id={pane.id}
   style="
     display: flex; align-items: center; gap: 1px; position: relative;
@@ -104,12 +105,11 @@
     style="display: flex; align-items: center; gap: 2px; padding-right: 2px;"
   >
     {#if showJumpToBottom && onJumpToBottom}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <span
+      <button
         data-jump-to-bottom
+        aria-label="Jump to bottom"
         title="Jump to bottom"
-        style="color: {$theme.fgDim}; cursor: pointer; height: 20px; border-radius: 4px; display: flex; align-items: center; gap: 4px; padding: 0 6px; font-size: 11px; border: 1px solid {$theme.border};"
+        style="background: none; border: 1px solid {$theme.border}; padding: 0 6px; font: inherit; color: {$theme.fgDim}; cursor: pointer; height: 20px; border-radius: 4px; display: flex; align-items: center; gap: 4px; font-size: 11px;"
         on:click|stopPropagation={onJumpToBottom}
       >
         <svg
@@ -121,19 +121,19 @@
           stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <line x1="5" y1="1" x2="5" y2="9" />
           <polyline points="2,6 5,9 8,6" />
         </svg>
         Jump to bottom
-      </span>
+      </button>
     {/if}
     {#if activeIsPreview && onRefreshPreview}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <span
+      <button
+        aria-label="Refresh Preview"
         title="Refresh Preview"
-        style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
+        style="background: none; border: none; padding: 0; font: inherit; color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
         on:click|stopPropagation={onRefreshPreview}
       >
         <svg
@@ -145,17 +145,17 @@
           stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
           ><path d="M2 7a5 5 0 1 1 1.5 3.5" /><polyline
             points="2 11 2 7 6 7"
           /></svg
         >
-      </span>
+      </button>
     {/if}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span
+    <button
+      aria-label="Split Right (⌘D)"
       title="Split Right (⌘D)"
-      style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
+      style="background: none; border: none; padding: 0; font: inherit; color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onSplitRight}
     >
       <svg
@@ -165,6 +165,7 @@
         fill="none"
         stroke="currentColor"
         stroke-width="1.5"
+        aria-hidden="true"
         ><rect x="1" y="1" width="12" height="12" rx="1" /><line
           x1="7"
           y1="1"
@@ -172,12 +173,11 @@
           y2="13"
         /></svg
       >
-    </span>
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span
+    </button>
+    <button
+      aria-label="Split Down (⇧⌘D)"
       title="Split Down (⇧⌘D)"
-      style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
+      style="background: none; border: none; padding: 0; font: inherit; color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onSplitDown}
     >
       <svg
@@ -187,6 +187,7 @@
         fill="none"
         stroke="currentColor"
         stroke-width="1.5"
+        aria-hidden="true"
         ><rect x="1" y="1" width="12" height="12" rx="1" /><line
           x1="1"
           y1="7"
@@ -194,12 +195,11 @@
           y2="7"
         /></svg
       >
-    </span>
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <span
+    </button>
+    <button
+      aria-label="Close Pane"
       title="Close Pane"
-      style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
+      style="background: none; border: none; padding: 0; font: inherit; color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onClosePane}
     >
       <svg
@@ -210,6 +210,7 @@
         stroke="currentColor"
         stroke-width="1.5"
         stroke-linecap="round"
+        aria-hidden="true"
         ><line x1="2" y1="2" x2="10" y2="10" /><line
           x1="10"
           y1="2"
@@ -217,6 +218,6 @@
           y2="10"
         /></svg
       >
-    </span>
+    </button>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Five high-severity a11y fixes. All components were previously keyboard-inaccessible or invisible to screen readers.

- **F05**: `TabBar.svelte` — five control spans (jump-to-bottom, refresh-preview, split-right, split-down, close-pane) converted to `<button>` with `aria-label`. `role="tablist"` added to tab bar container.
- **F06**: `Tab.svelte` — outer div gets `role="tab"`, `tabindex="0"`, Enter/Space keydown. Close span → `<button aria-label="Close tab">`. Bubbling guard prevents close-button Enter from also triggering tab select.
- **F07**: `CommandPalette.svelte` — `role="dialog"` + `aria-modal="true"` on overlay; `aria-label="Command search"` on input; `role="listbox"` on results, `role="option"` + `tabindex="-1"` on rows; `aria-activedescendant` wired.
- **F08**: `InputPrompt.svelte` — `role="dialog"` + `aria-modal="true"`; `aria-label` on input; Tab focus trap within dialog.
- **F11**: `ContextMenu.svelte` — `role="menu"` on container; `role="menuitem"` + `tabindex="-1"` on rows; `role="separator"` on dividers; ArrowUp/ArrowDown navigation; focus first item on open.

14 new a11y regression tests added.

## Test plan

- [ ] `npm test` passes (1560 tests)
- [ ] TabBar control buttons reachable and labeled via keyboard/screen reader
- [ ] Tab activatable via Enter/Space; close button does not also activate tab
- [ ] Command palette announced as dialog; options navigable via arrow keys
- [ ] Input prompt announced as dialog; Tab cycles within dialog only
- [ ] Context menu navigable via ArrowUp/ArrowDown; first item focused on open

🤖 Generated with [Claude Code](https://claude.ai/claude-code)