### PR TITLE
feat(sidebar): compact diff + PR statusline on workspace and group rows

### DIFF
--- a/src-tauri/src/gh_commands.rs
+++ b/src-tauri/src/gh_commands.rs
@@ -142,10 +142,67 @@ pub struct GhPrView {
     pub url: String,
     pub head_ref_name: String,
     pub is_draft: bool,
+    /// Derived from statusCheckRollup: "SUCCESS" | "FAILURE" | "PENDING" | "NONE"
+    pub ci_status: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckStatus {
+    conclusion: Option<String>,
+    status: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawPrView {
+    number: u32,
+    title: String,
+    state: String,
+    url: String,
+    head_ref_name: String,
+    is_draft: bool,
+    #[serde(default)]
+    status_check_rollup: Vec<CheckStatus>,
+}
+
+fn derive_ci_status(checks: &[CheckStatus]) -> String {
+    if checks.is_empty() {
+        return "NONE".to_string();
+    }
+    let has_failure = checks.iter().any(|c| {
+        matches!(
+            c.conclusion.as_deref(),
+            Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE")
+        )
+    });
+    if has_failure {
+        return "FAILURE".to_string();
+    }
+    let has_pending = checks.iter().any(|c| {
+        matches!(
+            c.status.as_deref(),
+            Some("IN_PROGRESS" | "QUEUED" | "WAITING" | "PENDING")
+        ) || c.conclusion.is_none()
+    });
+    if has_pending {
+        return "PENDING".to_string();
+    }
+    "SUCCESS".to_string()
 }
 
 fn parse_pr_view(json: &str) -> Result<GhPrView, String> {
-    serde_json::from_str(json).map_err(|e| format!("Failed to parse PR JSON: {e}"))
+    let raw: RawPrView =
+        serde_json::from_str(json).map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
+    Ok(GhPrView {
+        number: raw.number,
+        title: raw.title,
+        state: raw.state,
+        url: raw.url,
+        head_ref_name: raw.head_ref_name,
+        is_draft: raw.is_draft,
+        ci_status: derive_ci_status(&raw.status_check_rollup),
+    })
 }
 
 /// Return the open PR for the current branch in `repo_path`, or `None`
@@ -160,7 +217,7 @@ pub async fn gh_view_pr(repo_path: String) -> Result<Option<GhPrView>, String> {
             "pr",
             "view",
             "--json",
-            "number,title,state,url,isDraft,headRefName",
+            "number,title,state,url,isDraft,headRefName,statusCheckRollup",
         ])
         .env("PATH", shell_path())
         .current_dir(&repo_path)
@@ -287,6 +344,7 @@ mod tests {
         assert_eq!(pr.state, "OPEN");
         assert!(!pr.is_draft);
         assert_eq!(pr.head_ref_name, "feat/diff-statusline");
+        assert_eq!(pr.ci_status, "NONE");
     }
 
     #[test]
@@ -301,6 +359,59 @@ mod tests {
         }"#;
         let pr = parse_pr_view(json).unwrap();
         assert!(pr.is_draft);
+    }
+
+    #[test]
+    fn parse_pr_view_ci_status_passing() {
+        let json = r#"{
+            "number": 10,
+            "title": "ci test",
+            "state": "OPEN",
+            "url": "https://github.com/org/repo/pull/10",
+            "headRefName": "ci-branch",
+            "isDraft": false,
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+                {"conclusion": "SKIPPED", "status": "COMPLETED"}
+            ]
+        }"#;
+        let pr = parse_pr_view(json).unwrap();
+        assert_eq!(pr.ci_status, "SUCCESS");
+    }
+
+    #[test]
+    fn parse_pr_view_ci_status_failing() {
+        let json = r#"{
+            "number": 11,
+            "title": "broken",
+            "state": "OPEN",
+            "url": "https://github.com/org/repo/pull/11",
+            "headRefName": "broken",
+            "isDraft": false,
+            "statusCheckRollup": [
+                {"conclusion": "SUCCESS", "status": "COMPLETED"},
+                {"conclusion": "FAILURE", "status": "COMPLETED"}
+            ]
+        }"#;
+        let pr = parse_pr_view(json).unwrap();
+        assert_eq!(pr.ci_status, "FAILURE");
+    }
+
+    #[test]
+    fn parse_pr_view_ci_status_pending() {
+        let json = r#"{
+            "number": 12,
+            "title": "pending",
+            "state": "OPEN",
+            "url": "https://github.com/org/repo/pull/12",
+            "headRefName": "pending",
+            "isDraft": false,
+            "statusCheckRollup": [
+                {"conclusion": null, "status": "IN_PROGRESS"}
+            ]
+        }"#;
+        let pr = parse_pr_view(json).unwrap();
+        assert_eq!(pr.ci_status, "PENDING");
     }
 
     #[test]

--- a/src-tauri/src/gh_commands.rs
+++ b/src-tauri/src/gh_commands.rs
@@ -131,6 +131,51 @@ fn build_list_args<'a>(
     Ok(args)
 }
 
+/// Minimal PR data returned by `gh_view_pr` — fields needed for a
+/// compact statusline. Does not include author/labels/timestamps.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhPrView {
+    pub number: u32,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+    pub head_ref_name: String,
+    pub is_draft: bool,
+}
+
+fn parse_pr_view(json: &str) -> Result<GhPrView, String> {
+    serde_json::from_str(json).map_err(|e| format!("Failed to parse PR JSON: {e}"))
+}
+
+/// Return the open PR for the current branch in `repo_path`, or `None`
+/// when there is no PR. Non-zero exit from `gh` is treated as "no PR"
+/// rather than an error — this is the normal case for branches that
+/// haven't been pushed as a PR yet.
+#[tauri::command]
+pub async fn gh_view_pr(repo_path: String) -> Result<Option<GhPrView>, String> {
+    validate_repo(&repo_path)?;
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            "--json",
+            "number,title,state,url,isDraft,headRefName",
+        ])
+        .env("PATH", shell_path())
+        .current_dir(&repo_path)
+        .output()
+        .map_err(|e| format!("Failed to execute gh command: {e}"))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let json = String::from_utf8(output.stdout)
+        .map_err(|e| format!("Failed to parse gh output as UTF-8: {e}"))?;
+    Ok(Some(parse_pr_view(&json)?))
+}
+
 /// Probe whether the `gh` binary is available on PATH. Used by
 /// `gh-availability.ts` on the frontend to skip doomed invokes and render
 /// an actionable empty state instead of a terse error line.
@@ -224,5 +269,48 @@ mod tests {
     #[test]
     fn build_list_args_rejects_invalid_state() {
         assert!(build_list_args("issue", "number", Some("merged")).is_err());
+    }
+
+    #[test]
+    fn parse_pr_view_valid_json() {
+        let json = r#"{
+            "number": 42,
+            "title": "feat: add diff statusline",
+            "state": "OPEN",
+            "url": "https://github.com/org/repo/pull/42",
+            "headRefName": "feat/diff-statusline",
+            "isDraft": false
+        }"#;
+        let pr = parse_pr_view(json).unwrap();
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.title, "feat: add diff statusline");
+        assert_eq!(pr.state, "OPEN");
+        assert!(!pr.is_draft);
+        assert_eq!(pr.head_ref_name, "feat/diff-statusline");
+    }
+
+    #[test]
+    fn parse_pr_view_draft() {
+        let json = r#"{
+            "number": 7,
+            "title": "WIP",
+            "state": "OPEN",
+            "url": "https://github.com/org/repo/pull/7",
+            "headRefName": "wip/branch",
+            "isDraft": true
+        }"#;
+        let pr = parse_pr_view(json).unwrap();
+        assert!(pr.is_draft);
+    }
+
+    #[test]
+    fn parse_pr_view_malformed_json_returns_error() {
+        assert!(parse_pr_view("not json").is_err());
+    }
+
+    #[test]
+    fn parse_pr_view_missing_field_returns_error() {
+        let json = r#"{"number": 1, "title": "test"}"#;
+        assert!(parse_pr_view(json).is_err());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1939,6 +1939,7 @@ pub fn run() {
             gh_commands::gh_list_prs,
             gh_commands::gh_list_issues,
             gh_commands::gh_available,
+            gh_commands::gh_view_pr,
             git_status_ops::git_rev_parse_toplevel,
             git_status_ops::git_status_short
         ])

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -33,6 +33,7 @@
     setupListeners,
     fontReady,
     startCwdPolling,
+    registerCwdChangeHook,
     isMac,
     modLabel,
     shiftModLabel,
@@ -79,6 +80,7 @@
     renameWorkspace,
     saveCurrentWorkspace,
     persistWorkspaces,
+    schedulePersist,
   } from "./lib/services/workspace-service";
   import {
     splitPane,
@@ -512,6 +514,7 @@
     await fontReady;
     void setupListeners();
     startCwdPolling();
+    registerCwdChangeHook(schedulePersist);
     initMcpServer().catch((err) => {
       // Surface frontend-side init failures through the extension error
       // toast rather than a silent console.warn.

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1051,14 +1051,24 @@ describe("WorkspaceItem", () => {
     expect(screen.getByText("My Workspace")).toBeTruthy();
   });
 
-  it("renders close button", () => {
-    renderWorkspaceItem();
-    expect(screen.getByText("×")).toBeTruthy();
-  });
-
-  it("renders close button with x symbol", () => {
-    renderWorkspaceItem();
-    // The close button renders the multiplication sign
+  it("renders close button in DragGrip when grip is expanded", async () => {
+    const ws = makeWorkspace("ws1", "My Workspace");
+    const { container } = render(WorkspaceItem, {
+      props: {
+        workspace: ws,
+        index: 0,
+        isActive: true,
+        onSelect: noop,
+        onClose: noop,
+        onRename: noop,
+        onContextMenu: noop,
+        onGripMouseDown: noop,
+      },
+    });
+    // Hover the row — this makes the grip visible, which shows the × chip
+    const row = container.firstElementChild as HTMLElement;
+    await fireEvent.mouseEnter(row);
+    await tick();
     expect(screen.getByText("×")).toBeTruthy();
   });
 
@@ -1941,8 +1951,9 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    expect(container.querySelector("[data-harness-title-row]")).not.toBeNull();
-    expect(screen.getByText("claude > fixing bug")).toBeTruthy();
+    const harnessEl = container.querySelector("[data-harness-title-row]");
+    expect(harnessEl).not.toBeNull();
+    expect(harnessEl?.getAttribute("title")).toBe("claude > fixing bug");
     clearAllStatusForWorkspace(ws.id);
   });
 

--- a/src/__tests__/cwd-polling-notify.test.ts
+++ b/src/__tests__/cwd-polling-notify.test.ts
@@ -22,7 +22,11 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 
 import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
 import type { Workspace } from "../lib/types";
-import { startCwdPolling } from "../lib/terminal-service";
+import {
+  startCwdPolling,
+  registerCwdChangeHook,
+  _stopCwdPolling,
+} from "../lib/terminal-service";
 
 function makeWs(id: string, surfaceId: string, cwd: string): Workspace {
   return {
@@ -57,6 +61,7 @@ describe("startCwdPolling notifies the workspaces store on cwd change", () => {
   });
 
   afterEach(() => {
+    _stopCwdPolling();
     vi.useRealTimers();
     workspaces.set([]);
     activeWorkspaceIdx.set(-1);
@@ -104,5 +109,28 @@ describe("startCwdPolling notifies the workspaces store on cwd change", () => {
     expect(surface.title).toBe("custom-title");
 
     unsub();
+  });
+
+  it("fires the registered cwd change hook when cwd changes", async () => {
+    const ws = makeWs("A", "surf-A", "/repos/project-A");
+    workspaces.set([ws]);
+
+    let ptyCwd = "/repos/project-A";
+    const tauri = await import("@tauri-apps/api/core");
+    vi.mocked(tauri.invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_all_pty_cwds") return { "1": ptyCwd };
+      return undefined;
+    });
+
+    const hookCalls: string[] = [];
+    registerCwdChangeHook(() => hookCalls.push("fired"));
+
+    startCwdPolling();
+    ptyCwd = "/repos/project-B";
+
+    await vi.advanceTimersByTimeAsync(5100);
+    for (let i = 0; i < 50; i++) await Promise.resolve();
+
+    expect(hookCalls.length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/git-status-line.test.ts
+++ b/src/__tests__/git-status-line.test.ts
@@ -105,7 +105,7 @@ describe("GitStatusLine nested rules", () => {
     expect(container.textContent).not.toMatch(/modified/);
   });
 
-  it("still renders full top/bottom rows for a root (non-nested) workspace when active", () => {
+  it("does not render dirty label for a root workspace — WorkspaceDiffPrSubtitle owns that row", () => {
     const ws = makeWorkspace("ws-root", {});
     workspaces.set([ws]);
     activate(ws.id);
@@ -113,16 +113,7 @@ describe("GitStatusLine nested rules", () => {
     const { container } = render(GitStatusLine, {
       props: { workspaceId: ws.id },
     });
-    expect(container.textContent).toMatch(/modified/);
-  });
-
-  it("hides the dirty bottom row on a root workspace when inactive", () => {
-    const ws = makeWorkspace("ws-root", {});
-    workspaces.set([ws]);
-    setDirty(ws.id);
-    const { container } = render(GitStatusLine, {
-      props: { workspaceId: ws.id },
-    });
+    // Dirty display moved to WorkspaceDiffPrSubtitle; GitStatusLine only shows cwd/branch.
     expect(container.textContent).not.toMatch(/modified/);
   });
 });

--- a/src/__tests__/git-status-service.test.ts
+++ b/src/__tests__/git-status-service.test.ts
@@ -222,13 +222,22 @@ describe("initGitStatus()", () => {
     statusRegistry.reset();
   });
 
-  it("registers the workspace subtitle component", () => {
+  it("registers the GitStatusLine subtitle at priority 10", () => {
     initGitStatus();
     const subtitle = get(workspaceSubtitleStore).find(
-      (s) => s.source === GIT_STATUS_SOURCE,
+      (s) => s.id === `${GIT_STATUS_SOURCE}:subtitle`,
     );
     expect(subtitle).toBeTruthy();
     expect(subtitle!.priority).toBe(10);
+  });
+
+  it("registers the WorkspaceDiffPrSubtitle at priority 20", () => {
+    initGitStatus();
+    const subtitle = get(workspaceSubtitleStore).find(
+      (s) => s.id === `${GIT_STATUS_SOURCE}:diff-pr-subtitle`,
+    );
+    expect(subtitle).toBeTruthy();
+    expect(subtitle!.priority).toBe(20);
   });
 
   it("clears workspace status on workspace:closed", async () => {

--- a/src/__tests__/workspace-diff-pr-subtitle.test.ts
+++ b/src/__tests__/workspace-diff-pr-subtitle.test.ts
@@ -1,0 +1,84 @@
+/**
+ * WorkspaceDiffPrSubtitle regression tests: verify the compact diff + PR
+ * statusline renders dirty shorthand from the status registry and that
+ * it hides when there is nothing to show.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+  convertFileSrc: (p: string) => p,
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+import WorkspaceDiffPrSubtitle from "../lib/components/WorkspaceDiffPrSubtitle.svelte";
+import {
+  setStatusItem,
+  clearAllStatusForWorkspace,
+  statusRegistry,
+} from "../lib/services/status-registry";
+import { GIT_STATUS_SOURCE } from "../lib/services/git-status-service";
+
+function setDirty(workspaceId: string, label = "M3 A1") {
+  setStatusItem(GIT_STATUS_SOURCE, workspaceId, "dirty", {
+    category: "git",
+    priority: 30,
+    label,
+    variant: "warning",
+  });
+}
+
+function setBranch(workspaceId: string, repoRoot = "/repos/project") {
+  setStatusItem(GIT_STATUS_SOURCE, workspaceId, "branch", {
+    category: "git",
+    priority: 10,
+    label: "main",
+    metadata: { repoRoot },
+  });
+}
+
+describe("WorkspaceDiffPrSubtitle", () => {
+  beforeEach(() => {
+    cleanup();
+    statusRegistry.reset();
+    clearAllStatusForWorkspace("ws-1");
+  });
+
+  it("renders dirty shorthand when the status registry has a dirty item", () => {
+    setDirty("ws-1", "M3 A1");
+    const { container } = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+    expect(container.textContent).toMatch(/M3 A1/);
+  });
+
+  it("renders nothing when there is no dirty item and no PR", () => {
+    const { container } = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+    expect(container.textContent?.trim()).toBe("");
+  });
+
+  it("starts PR polling when a branch item with repoRoot is set", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const invokeMock = vi.mocked(invoke);
+
+    setBranch("ws-1", "/repos/project");
+
+    render(WorkspaceDiffPrSubtitle, { props: { workspaceId: "ws-1" } });
+
+    // Drain microtask queue so the reactive $: if (repoRoot) block fires.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const called = invokeMock.mock.calls.some(
+      ([cmd, args]) =>
+        cmd === "gh_view_pr" &&
+        (args as Record<string, unknown>).repoPath === "/repos/project",
+    );
+    expect(called).toBe(true);
+  });
+});

--- a/src/lib/bootstrap/init-git-status.ts
+++ b/src/lib/bootstrap/init-git-status.ts
@@ -13,6 +13,7 @@ import {
   handleWorkspaceClosed,
 } from "../services/git-status-service";
 import GitStatusLine from "../components/GitStatusLine.svelte";
+import WorkspaceDiffPrSubtitle from "../components/WorkspaceDiffPrSubtitle.svelte";
 
 export function initGitStatus(): void {
   registerWorkspaceSubtitle({
@@ -20,6 +21,13 @@ export function initGitStatus(): void {
     source: GIT_STATUS_SOURCE,
     component: GitStatusLine,
     priority: 10,
+  });
+
+  registerWorkspaceSubtitle({
+    id: `${GIT_STATUS_SOURCE}:diff-pr-subtitle`,
+    source: GIT_STATUS_SOURCE,
+    component: WorkspaceDiffPrSubtitle,
+    priority: 20,
   });
 
   startGitStatusService();

--- a/src/lib/components/ContainerRow.svelte
+++ b/src/lib/components/ContainerRow.svelte
@@ -23,7 +23,6 @@
   import DragGrip from "./DragGrip.svelte";
   import DefaultWorkspaceListView from "./WorkspaceListView.svelte";
   import type { Workspace } from "../types";
-  import { tooltip } from "../actions/tooltip";
   import { wsMeta } from "../services/service-helpers";
 
   /** Banner + rail color. Required. */
@@ -89,7 +88,6 @@
     undefined;
 
   let bannerHovered = false;
-  let closeHovered = false;
   let mouseOverContainer = false;
   let containerLeaveTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -245,6 +243,8 @@
           railOpacity={1}
           alwaysShowDots={true}
           fadeRight={!rowHovered}
+          {onClose}
+          closeTooltip="Delete Workspace Group"
         />
         {#if hasActiveChild && collapsed}
           <div
@@ -331,34 +331,6 @@
             </div>
           {/if}
         </div>
-        {#if onClose}
-          <!-- svelte-ignore a11y_click_events_have_key_events -->
-          <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <span
-            use:tooltip={"Delete Workspace Group"}
-            style="
-              position: absolute;
-              top: 50%; right: 6px;
-              transform: translateY(-50%);
-              color: {closeHovered ? $theme.danger : $theme.fgDim};
-              background: {closeHovered
-              ? ($theme.bgHighlight ?? 'rgba(255,255,255,0.06)')
-              : 'transparent'};
-              border: 1px solid {$theme.border ?? 'transparent'};
-              border-radius: 4px;
-              font-size: 11px;
-              cursor: pointer;
-              padding: 2px 5px;
-              line-height: 1;
-              opacity: {bannerHovered ? '1' : '0'};
-              -webkit-app-region: no-drag;
-              transition: opacity 0.15s, background 0.1s, color 0.1s;
-            "
-            on:click|stopPropagation={onClose}
-            on:mouseenter={() => (closeHovered = true)}
-            on:mouseleave={() => (closeHovered = false)}>×</span
-          >
-        {/if}
       </div>
       {#if !collapsed && nonDashboardCount > 0}
         <div

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -196,8 +196,12 @@
     {/if}
 
     {#if showPr && pr}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden; cursor: pointer;"
+        title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+        on:click={() => pr && invoke("open_url", { url: pr.url })}
       >
         <!-- Pull request icon -->
         <svg
@@ -209,17 +213,15 @@
           aria-hidden="true"
         >
           <path
-            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
+            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.628a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
           />
         </svg>
         <span
           style="font-size: 10px; color: {isDraft
             ? fgMuted
-            : '#4ec957'}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;"
-          title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+            : '#4ec957'}; white-space: nowrap; flex-shrink: 0;"
         >
           #{pr.number}{isDraft ? " draft" : ""}
-          <span style="opacity: 0.75;">{pr.title}</span>
         </span>
       </div>
     {/if}

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -12,10 +12,8 @@
    */
   import { onDestroy, getContext } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
-  import {
-    parseGitStatus,
-    formatDirtyShorthand,
-  } from "../services/git-status-service";
+  import { parseGitStatus } from "../services/git-status-service";
+  import type { GitInfo } from "../services/git-status-service";
   import { EXTENSION_API_KEY, type ExtensionAPI } from "../../extensions/api";
 
   export let id: string;
@@ -44,7 +42,7 @@
     isDraft: boolean;
   }
 
-  let diffLabel = "";
+  let gitInfo: GitInfo | null = null;
   let pr: GhPrView | null = null;
   let lastId: string | null = null;
   let diffTimer: ReturnType<typeof setInterval> | null = null;
@@ -71,7 +69,7 @@
       gitRoot = await detectRoot();
     }
     if (!gitRoot) {
-      diffLabel = "";
+      gitInfo = null;
       return;
     }
     try {
@@ -79,13 +77,12 @@
         cwd: gitRoot,
       });
       if (!result || result.exit_code !== 0) {
-        diffLabel = "";
+        gitInfo = null;
         return;
       }
-      const info = parseGitStatus(result.stdout);
-      diffLabel = info ? formatDirtyShorthand(info) : "";
+      gitInfo = parseGitStatus(result.stdout) ?? null;
     } catch {
-      diffLabel = "";
+      gitInfo = null;
     }
   }
 
@@ -131,14 +128,40 @@
   $: if (isGit && id !== lastId) start(id);
   $: if (!isGit) {
     stop();
-    diffLabel = "";
+    gitInfo = null;
     pr = null;
     lastId = null;
   }
 
   onDestroy(() => stop());
 
-  $: showDiff = diffLabel.length > 0;
+  $: modifiedOnly = gitInfo
+    ? Math.max(
+        0,
+        gitInfo.modified +
+          gitInfo.staged -
+          gitInfo.added -
+          gitInfo.deleted -
+          gitInfo.renamed,
+      )
+    : 0;
+  $: diffSegments = gitInfo
+    ? [
+        modifiedOnly > 0
+          ? { label: `~${modifiedOnly}`, color: "#e8b73a" }
+          : null,
+        gitInfo.added > 0
+          ? { label: `+${gitInfo.added}`, color: "#4ec957" }
+          : null,
+        gitInfo.deleted > 0
+          ? { label: `-${gitInfo.deleted}`, color: "#e85454" }
+          : null,
+        gitInfo.untracked > 0
+          ? { label: `?${gitInfo.untracked}`, color: fgMuted }
+          : null,
+      ].filter(Boolean)
+    : [];
+  $: showDiff = diffSegments.length > 0;
   $: showPr = pr !== null && (pr.state === "OPEN" || pr.state === "open");
   $: isDraft = pr?.isDraft ?? false;
 </script>
@@ -149,27 +172,14 @@
   >
     {#if showDiff}
       <div
-        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+        style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden;"
       >
-        <!-- Diff icon: two stacked horizontal bars with +/- markers -->
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 16 16"
-          fill={iconFg}
-          style="flex-shrink: 0; opacity: 0.7;"
-          aria-hidden="true"
-        >
-          <path
-            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
-          />
-        </svg>
-        <span
-          style="font-size: 10px; color: #e8b73a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
-          title={diffLabel}
-        >
-          {diffLabel}
-        </span>
+        {#each diffSegments as seg}
+          <span
+            style="font-size: 10px; color: {seg?.color}; white-space: nowrap; flex-shrink: 0;"
+            >{seg?.label}</span
+          >
+        {/each}
       </div>
     {/if}
 

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -178,8 +178,8 @@
           width="10"
           height="10"
           viewBox="0 0 16 16"
-          fill={fgMuted}
-          style="flex-shrink: 0; opacity: 0.6;"
+          fill={iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
           <path

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  /**
+   * DiffPrStatusLine — compact diff + PR statusline for container row
+   * banners (workspace groups). Renders two optional rows beneath
+   * PathStatusLine:
+   *
+   *   1. Diff row — [diff icon] M3 A1 D1   (only when working tree is dirty)
+   *   2. PR row   — [PR icon] #42 my title  (only when a PR exists for HEAD)
+   *
+   * Self-contained polling: diff at 30s, PR at 60s. Keyed on `id` so
+   * switching projects reseeds both loops immediately.
+   */
+  import { onDestroy, getContext } from "svelte";
+  import { invoke } from "@tauri-apps/api/core";
+  import {
+    parseGitStatus,
+    formatDirtyShorthand,
+  } from "../services/git-status-service";
+  import { EXTENSION_API_KEY, type ExtensionAPI } from "../../extensions/api";
+
+  export let id: string;
+  export let path: string;
+  export let isGit: boolean;
+  export let fgColor: string | undefined = undefined;
+  export let iconColor: string | undefined = undefined;
+
+  const api = getContext<ExtensionAPI>(EXTENSION_API_KEY);
+  const theme = api.theme;
+  $: fgMuted = fgColor ?? (($theme["fgMuted"] ?? $theme.fgDim) as string);
+  $: iconFg = iconColor ?? fgMuted;
+
+  interface ScriptResult {
+    stdout: string;
+    stderr: string;
+    exit_code: number;
+  }
+
+  interface GhPrView {
+    number: number;
+    title: string;
+    state: string;
+    url: string;
+    headRefName: string;
+    isDraft: boolean;
+  }
+
+  let diffLabel = "";
+  let pr: GhPrView | null = null;
+  let lastId: string | null = null;
+  let diffTimer: ReturnType<typeof setInterval> | null = null;
+  let prTimer: ReturnType<typeof setInterval> | null = null;
+  let gitRoot: string | null = null;
+
+  const DIFF_REFRESH_MS = 30_000;
+  const PR_REFRESH_MS = 60_000;
+
+  async function detectRoot(): Promise<string | null> {
+    try {
+      const result = await invoke<ScriptResult>("git_rev_parse_toplevel", {
+        cwd: path,
+      });
+      if (!result || result.exit_code !== 0) return null;
+      return result.stdout.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function refreshDiff(): Promise<void> {
+    if (!gitRoot) {
+      gitRoot = await detectRoot();
+    }
+    if (!gitRoot) {
+      diffLabel = "";
+      return;
+    }
+    try {
+      const result = await invoke<ScriptResult>("git_status_short", {
+        cwd: gitRoot,
+      });
+      if (!result || result.exit_code !== 0) {
+        diffLabel = "";
+        return;
+      }
+      const info = parseGitStatus(result.stdout);
+      diffLabel = info ? formatDirtyShorthand(info) : "";
+    } catch {
+      diffLabel = "";
+    }
+  }
+
+  async function refreshPr(): Promise<void> {
+    if (!gitRoot) {
+      gitRoot = await detectRoot();
+    }
+    if (!gitRoot) {
+      pr = null;
+      return;
+    }
+    try {
+      const result = await invoke<GhPrView | null>("gh_view_pr", {
+        repoPath: gitRoot,
+      });
+      pr = result ?? null;
+    } catch {
+      pr = null;
+    }
+  }
+
+  function start(targetId: string): void {
+    stop();
+    lastId = targetId;
+    gitRoot = null;
+    void refreshDiff();
+    void refreshPr();
+    diffTimer = setInterval(() => void refreshDiff(), DIFF_REFRESH_MS);
+    prTimer = setInterval(() => void refreshPr(), PR_REFRESH_MS);
+  }
+
+  function stop(): void {
+    if (diffTimer) {
+      clearInterval(diffTimer);
+      diffTimer = null;
+    }
+    if (prTimer) {
+      clearInterval(prTimer);
+      prTimer = null;
+    }
+  }
+
+  $: if (isGit && id !== lastId) start(id);
+  $: if (!isGit) {
+    stop();
+    diffLabel = "";
+    pr = null;
+    lastId = null;
+  }
+
+  onDestroy(() => stop());
+
+  $: showDiff = diffLabel.length > 0;
+  $: showPr = pr !== null && (pr.state === "OPEN" || pr.state === "open");
+  $: isDraft = pr?.isDraft ?? false;
+</script>
+
+{#if showDiff || showPr}
+  <div
+    style="display: flex; flex-direction: column; gap: 1px; padding: 1px 12px 2px 0; overflow: hidden;"
+  >
+    {#if showDiff}
+      <div
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+      >
+        <!-- Diff icon: two stacked horizontal bars with +/- markers -->
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
+          />
+        </svg>
+        <span
+          style="font-size: 10px; color: #e8b73a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+          title={diffLabel}
+        >
+          {diffLabel}
+        </span>
+      </div>
+    {/if}
+
+    {#if showPr && pr}
+      <div
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+      >
+        <!-- Pull request icon -->
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={isDraft ? fgMuted : iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
+          aria-hidden="true"
+        >
+          <path
+            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
+          />
+        </svg>
+        <span
+          style="font-size: 10px; color: {isDraft
+            ? fgMuted
+            : '#4ec957'}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;"
+          title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+        >
+          #{pr.number}{isDraft ? " draft" : ""}
+          <span style="opacity: 0.75;">{pr.title}</span>
+        </span>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -190,14 +190,18 @@
         <svg
           width="10"
           height="10"
-          viewBox="0 0 16 16"
-          fill={iconFg}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={iconFg}
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
           style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
-          <path
-            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
-          />
+          <path d="M12 3v14" />
+          <path d="M5 10h14" />
+          <path d="M5 21h14" />
         </svg>
         {#each diffSegments as seg}
           <span
@@ -216,18 +220,22 @@
         title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
         on:click={() => pr && invoke("open_url", { url: pr.url })}
       >
-        <!-- Pull request icon -->
         <svg
           width="10"
           height="10"
-          viewBox="0 0 16 16"
-          fill={isDraft ? fgMuted : iconFg}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={iconFg}
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
           style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
-          <path
-            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.628a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
-          />
+          <circle cx="18" cy="18" r="3" />
+          <circle cx="6" cy="6" r="3" />
+          <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+          <line x1="6" x2="6" y1="9" y2="21" />
         </svg>
         <span
           style="font-size: 10px; color: {prColor}; white-space: nowrap; flex-shrink: 0; text-decoration: underline;"

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -40,6 +40,14 @@
     url: string;
     headRefName: string;
     isDraft: boolean;
+    ciStatus: string;
+  }
+
+  function ciColor(status: string, fallback: string): string {
+    if (status === "SUCCESS") return "#4ec957";
+    if (status === "FAILURE") return "#e85454";
+    if (status === "PENDING") return "#e8b73a";
+    return fallback;
   }
 
   let gitInfo: GitInfo | null = null;
@@ -50,7 +58,7 @@
   let gitRoot: string | null = null;
 
   const DIFF_REFRESH_MS = 30_000;
-  const PR_REFRESH_MS = 60_000;
+  const PR_REFRESH_MS = 5_000;
 
   async function detectRoot(): Promise<string | null> {
     try {
@@ -164,6 +172,11 @@
   $: showDiff = diffSegments.length > 0;
   $: showPr = pr !== null && (pr.state === "OPEN" || pr.state === "open");
   $: isDraft = pr?.isDraft ?? false;
+  $: prColor = pr
+    ? isDraft
+      ? fgMuted
+      : ciColor(pr.ciStatus, "#4ec957")
+    : fgMuted;
 </script>
 
 {#if showDiff || showPr}
@@ -217,9 +230,7 @@
           />
         </svg>
         <span
-          style="font-size: 10px; color: {isDraft
-            ? fgMuted
-            : '#4ec957'}; white-space: nowrap; flex-shrink: 0;"
+          style="font-size: 10px; color: {prColor}; white-space: nowrap; flex-shrink: 0; text-decoration: underline;"
         >
           #{pr.number}{isDraft ? " draft" : ""}
         </span>

--- a/src/lib/components/DiffPrStatusLine.svelte
+++ b/src/lib/components/DiffPrStatusLine.svelte
@@ -174,6 +174,18 @@
       <div
         style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden;"
       >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={fgMuted}
+          style="flex-shrink: 0; opacity: 0.6;"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
+          />
+        </svg>
         {#each diffSegments as seg}
           <span
             style="font-size: 10px; color: {seg?.color}; white-space: nowrap; flex-shrink: 0;"

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -32,6 +32,13 @@
    * unfaded so the pattern runs the full rail height cleanly.
    */
   export let fadeRight: boolean = false;
+  /** When provided, renders a × chip at the top of the grip whenever the grip is expanded. */
+  export let onClose: (() => void) | undefined = undefined;
+  /** Tooltip text for the close button. */
+  export let closeTooltip: string | undefined = undefined;
+
+  let closeButtonHovered = false;
+  $: showClose = onClose != null && visible;
 
   $: effectiveColor = railColor ?? theme.fgDim;
   $: effectiveDotColor = dotColor ?? effectiveColor;
@@ -99,5 +106,34 @@
         mask-image: {fadeRight ? fadeMask : 'none'};
       "
     ></div>
+  {/if}
+  {#if showClose}
+    <button
+      title={closeTooltip}
+      aria-label={closeTooltip ?? "Close"}
+      style="
+        position: absolute;
+        top: 4px; left: 1px; right: 1px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: {closeButtonHovered ? theme.danger : effectiveColor};
+        background: {closeButtonHovered
+        ? (theme.bgHighlight ?? 'rgba(255,255,255,0.08)')
+        : (theme.bgSurface ?? theme.bg)};
+        border: 1px solid {closeButtonHovered ? theme.danger : effectiveColor};
+        border-radius: 4px;
+        font-size: 11px;
+        cursor: pointer;
+        padding: 2px 0;
+        line-height: 1;
+        -webkit-app-region: no-drag;
+        transition: background 0.1s, color 0.1s, border-color 0.1s;
+      "
+      on:mousedown|stopPropagation
+      on:click|stopPropagation={onClose}
+      on:mouseenter={() => (closeButtonHovered = true)}
+      on:mouseleave={() => (closeButtonHovered = false)}>×</button
+    >
   {/if}
 </div>

--- a/src/lib/components/GitStatusLine.svelte
+++ b/src/lib/components/GitStatusLine.svelte
@@ -103,7 +103,7 @@
   {/if}
 {:else if topRowHasContent}
   <div
-    style="padding: 0 12px 6px 6px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; line-height: 1.2;"
+    style="padding: 0 12px 2px 6px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; line-height: 1.2;"
   >
     {#if cwdItem}
       <div style="display: flex; align-items: center; min-width: 0;">

--- a/src/lib/components/GitStatusLine.svelte
+++ b/src/lib/components/GitStatusLine.svelte
@@ -22,8 +22,7 @@
 
   $: cwdItem = items.find((i) => i.id.endsWith(":cwd"));
   $: branchItem = items.find((i) => i.id.endsWith(":branch"));
-  $: prItem = items.find((i) => i.id.endsWith(":pr"));
-  $: dirtyItem = items.find((i) => i.id.endsWith(":dirty"));
+  $: worktreeDirtyItem = items.find((i) => i.id.endsWith(":dirty"));
 
   let fgMuted: string;
   $: fgMuted = ($theme["fgMuted"] ?? $theme.fgDim) as string;
@@ -49,22 +48,10 @@
     document.dispatchEvent(event);
   }
 
-  function prCiVariant(
-    item: StatusItem,
-  ): "success" | "warning" | "error" | "muted" {
-    const ci = item.metadata?.ciStatus;
-    if (ci === "passing") return "success";
-    if (ci === "failing") return "error";
-    return "muted";
-  }
-
   $: topRowHasContent = Boolean(cwdItem || branchItem);
-  // Inactive rows collapse to the top line (cwd + branch); PR and dirty
-  // details only render for the active workspace so the sidebar stays
-  // scannable.
-  $: bottomRowHasContent = isActiveWorkspace && Boolean(prItem || dirtyItem);
   $: nestedRowHasContent =
-    Boolean(worktreeBranch) || (isActiveWorkspace && Boolean(dirtyItem));
+    Boolean(worktreeBranch) ||
+    (isActiveWorkspace && Boolean(worktreeDirtyItem));
 </script>
 
 {#if isNested}
@@ -82,37 +69,39 @@
           title={`worktree branch: ${worktreeBranch}`}>⌥ {worktreeBranch}</span
         >
       {/if}
-      {#if worktreeBranch && dirtyItem && isActiveWorkspace}
+      {#if worktreeBranch && worktreeDirtyItem && isActiveWorkspace}
         <span
           aria-hidden="true"
           style="font-size: 10px; color: {fgMuted}; opacity: 0.4;">|</span
         >
       {/if}
-      {#if dirtyItem && isActiveWorkspace}
-        {#if dirtyItem.action && isActiveWorkspace}
+      {#if worktreeDirtyItem && isActiveWorkspace}
+        {#if worktreeDirtyItem.action && isActiveWorkspace}
           <button
             style="font-size: 10px; color: {variantColor(
-              dirtyItem.variant,
+              worktreeDirtyItem.variant,
               fgMuted,
             )}; text-decoration: underline; cursor: pointer; white-space: nowrap; background: none; border: none; padding: 0; font-family: inherit;"
-            title={dirtyItem.tooltip || dirtyItem.label}
-            aria-label={dirtyItem.tooltip || dirtyItem.label}
-            on:click|stopPropagation={() => handleAction(dirtyItem.action)}
-            >{dirtyItem.label}</button
+            title={worktreeDirtyItem.tooltip || worktreeDirtyItem.label}
+            aria-label={worktreeDirtyItem.tooltip || worktreeDirtyItem.label}
+            on:click|stopPropagation={() =>
+              handleAction(worktreeDirtyItem.action)}
+            >{worktreeDirtyItem.label}</button
           >
         {:else}
           <span
             style="font-size: 10px; color: {variantColor(
-              dirtyItem.variant,
+              worktreeDirtyItem.variant,
               fgMuted,
             )}; white-space: nowrap;"
-            title={dirtyItem.tooltip || dirtyItem.label}>{dirtyItem.label}</span
+            title={worktreeDirtyItem.tooltip || worktreeDirtyItem.label}
+            >{worktreeDirtyItem.label}</span
           >
         {/if}
       {/if}
     </div>
   {/if}
-{:else if topRowHasContent || bottomRowHasContent}
+{:else if topRowHasContent}
   <div
     style="padding: 0 12px 6px 6px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; line-height: 1.2;"
   >
@@ -155,83 +144,6 @@
           >
           {branchItem.label}
         </span>
-      </div>
-    {/if}
-
-    {#if bottomRowHasContent}
-      <div style="display: flex; align-items: center; gap: 6px; min-width: 0;">
-        {#if prItem}
-          {@const variant = prItem.metadata?.prNumber
-            ? prCiVariant(prItem)
-            : (prItem.variant ?? "muted")}
-          {#if prItem.action && isActiveWorkspace}
-            <button
-              style="font-size: 10px; color: {variantColor(
-                variant,
-                fgMuted,
-              )}; text-decoration: underline; cursor: pointer; white-space: nowrap; display: inline-flex; gap: 4px; align-items: center; background: none; border: none; padding: 0; font-family: inherit;"
-              title={prItem.tooltip || prItem.label}
-              aria-label={prItem.tooltip || prItem.label}
-              on:click|stopPropagation={() => handleAction(prItem.action)}
-            >
-              {prItem.metadata?.prNumber
-                ? `PR #${prItem.metadata.prNumber}`
-                : prItem.label}
-              {#if prItem.metadata?.reviewState}
-                <span style="opacity: 0.7;"
-                  >[{prItem.metadata.reviewState}]</span
-                >
-              {/if}
-            </button>
-          {:else}
-            <span
-              style="font-size: 10px; color: {variantColor(
-                variant,
-                fgMuted,
-              )}; white-space: nowrap; display: inline-flex; gap: 4px; align-items: center;"
-              title={prItem.tooltip || prItem.label}
-            >
-              {prItem.metadata?.prNumber
-                ? `PR #${prItem.metadata.prNumber}`
-                : prItem.label}
-              {#if prItem.metadata?.reviewState}
-                <span style="opacity: 0.7;"
-                  >[{prItem.metadata.reviewState}]</span
-                >
-              {/if}
-            </span>
-          {/if}
-        {/if}
-        {#if prItem && dirtyItem}
-          <span
-            aria-hidden="true"
-            style="font-size: 10px; color: {fgMuted}; opacity: 0.4; flex-shrink: 0;"
-            >|</span
-          >
-        {/if}
-        {#if dirtyItem}
-          {#if dirtyItem.action && isActiveWorkspace}
-            <button
-              style="font-size: 10px; color: {variantColor(
-                dirtyItem.variant,
-                fgMuted,
-              )}; text-decoration: underline; cursor: pointer; white-space: nowrap; background: none; border: none; padding: 0; font-family: inherit;"
-              title={dirtyItem.tooltip || dirtyItem.label}
-              aria-label={dirtyItem.tooltip || dirtyItem.label}
-              on:click|stopPropagation={() => handleAction(dirtyItem.action)}
-              >{dirtyItem.label}</button
-            >
-          {:else}
-            <span
-              style="font-size: 10px; color: {variantColor(
-                dirtyItem.variant,
-                fgMuted,
-              )}; white-space: nowrap;"
-              title={dirtyItem.tooltip || dirtyItem.label}
-              >{dirtyItem.label}</span
-            >
-          {/if}
-        {/if}
       </div>
     {/if}
   </div>

--- a/src/lib/components/PseudoWorkspaceRow.svelte
+++ b/src/lib/components/PseudoWorkspaceRow.svelte
@@ -61,10 +61,7 @@
   $: gripVisible =
     $shortcutHintsActive || (rowHovered && $reorderContext === null);
 
-  let closeHovered = false;
-
-  function handleClose(e: MouseEvent): void {
-    e.stopPropagation();
+  function handleClose(): void {
     unregisterPseudoWorkspace(pseudo.id);
     pseudo.onClose?.();
   }
@@ -111,6 +108,8 @@
       railOpacity={1}
       alwaysShowDots={true}
       fadeRight={!gripVisible}
+      onClose={pseudo.onClose ? handleClose : undefined}
+      closeTooltip={"Close " + pseudo.label}
     />
     <div
       aria-hidden="true"
@@ -178,25 +177,4 @@
       </span>
     {/if}
   </div>
-  {#if pseudo.onClose && rowHovered}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      data-pseudo-workspace-close
-      on:click={handleClose}
-      on:mouseenter={() => (closeHovered = true)}
-      on:mouseleave={() => (closeHovered = false)}
-      style="
-        display: flex; align-items: center; justify-content: center;
-        width: 20px; flex-shrink: 0;
-        color: {closeHovered ? $theme.danger : $theme.fgDim};
-        font-size: 11px;
-      "
-      title="Close {pseudo.label}"
-      role="button"
-      tabindex="-1"
-    >
-      ×
-    </div>
-  {/if}
 </div>

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -171,8 +171,12 @@
     {/if}
 
     {#if showPr && pr}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden; cursor: pointer;"
+        title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+        on:click={() => pr && invoke("open_url", { url: pr.url })}
       >
         <svg
           width="10"
@@ -189,11 +193,9 @@
         <span
           style="font-size: 10px; color: {isDraft
             ? fgMuted
-            : '#4ec957'}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;"
-          title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+            : '#4ec957'}; white-space: nowrap; flex-shrink: 0;"
         >
           #{pr.number}{isDraft ? " draft" : ""}
-          <span style="opacity: 0.75;">{pr.title}</span>
         </span>
       </div>
     {/if}

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -164,14 +164,18 @@
         <svg
           width="10"
           height="10"
-          viewBox="0 0 16 16"
-          fill={iconFg}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={iconFg}
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
           style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
-          <path
-            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
-          />
+          <path d="M12 3v14" />
+          <path d="M5 10h14" />
+          <path d="M5 21h14" />
         </svg>
         {#if diffSegments.length > 0}
           {#each diffSegments as seg}
@@ -200,14 +204,19 @@
         <svg
           width="10"
           height="10"
-          viewBox="0 0 16 16"
-          fill={isDraft ? fgMuted : iconFg}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={iconFg}
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
           style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
-          <path
-            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
-          />
+          <circle cx="18" cy="18" r="3" />
+          <circle cx="6" cy="6" r="3" />
+          <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+          <line x1="6" x2="6" y1="9" y2="21" />
         </svg>
         <span
           style="font-size: 10px; color: {prColor}; white-space: nowrap; flex-shrink: 0; text-decoration: underline;"

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -41,6 +41,43 @@
   $: diffLabel = dirtyItem?.label ?? "";
   $: showDiff = diffLabel.length > 0;
 
+  interface DirtyCounts {
+    modified: number;
+    added: number;
+    deleted: number;
+    renamed: number;
+    untracked: number;
+    staged: number;
+  }
+
+  $: counts = (dirtyItem?.metadata as DirtyCounts | undefined) ?? null;
+  $: modifiedOnly = counts
+    ? Math.max(
+        0,
+        counts.modified +
+          counts.staged -
+          counts.added -
+          counts.deleted -
+          counts.renamed,
+      )
+    : 0;
+  $: diffSegments = counts
+    ? [
+        modifiedOnly > 0
+          ? { label: `~${modifiedOnly}`, color: "#e8b73a" }
+          : null,
+        counts.added > 0
+          ? { label: `+${counts.added}`, color: "#4ec957" }
+          : null,
+        counts.deleted > 0
+          ? { label: `-${counts.deleted}`, color: "#e85454" }
+          : null,
+        counts.untracked > 0
+          ? { label: `?${counts.untracked}`, color: fgMuted }
+          : null,
+      ].filter(Boolean)
+    : [];
+
   interface GhPrView {
     number: number;
     title: string;
@@ -102,26 +139,22 @@
   >
     {#if showDiff}
       <div
-        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+        style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden;"
+        title={dirtyItem?.tooltip ?? diffLabel}
       >
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 16 16"
-          fill={iconFg}
-          style="flex-shrink: 0; opacity: 0.7;"
-          aria-hidden="true"
-        >
-          <path
-            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
-          />
-        </svg>
-        <span
-          style="font-size: 10px; color: #e8b73a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
-          title={dirtyItem?.tooltip ?? diffLabel}
-        >
-          {diffLabel}
-        </span>
+        {#if diffSegments.length > 0}
+          {#each diffSegments as seg}
+            <span
+              style="font-size: 10px; color: {seg?.color}; white-space: nowrap; flex-shrink: 0;"
+              >{seg?.label}</span
+            >
+          {/each}
+        {:else}
+          <span
+            style="font-size: 10px; color: #e8b73a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+            >{diffLabel}</span
+          >
+        {/if}
       </div>
     {/if}
 

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -146,8 +146,8 @@
           width="10"
           height="10"
           viewBox="0 0 16 16"
-          fill={fgMuted}
-          style="flex-shrink: 0; opacity: 0.6;"
+          fill={iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
           aria-hidden="true"
         >
           <path

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -14,12 +14,17 @@
   import { onDestroy } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { theme } from "../stores/theme";
+  import { workspaces } from "../stores/workspace";
   import { getWorkspaceStatusByCategory } from "../services/status-registry";
   import { GIT_STATUS_SOURCE } from "../services/git-status-service";
+  import { wsMeta } from "../services/service-helpers";
   import type { StatusItem } from "../types/status";
 
   export let workspaceId: string;
   export let accentColor: string | undefined = undefined;
+
+  $: currentWs = $workspaces.find((w) => w.id === workspaceId);
+  $: isNested = Boolean(currentWs && wsMeta(currentWs).groupId);
 
   $: fgMuted = ($theme["fgMuted"] ?? $theme.fgDim) as string;
   $: iconFg = accentColor ?? fgMuted;
@@ -85,13 +90,21 @@
     url: string;
     headRefName: string;
     isDraft: boolean;
+    ciStatus: string;
+  }
+
+  function ciColor(status: string, fallback: string): string {
+    if (status === "SUCCESS") return "#4ec957";
+    if (status === "FAILURE") return "#e85454";
+    if (status === "PENDING") return "#e8b73a";
+    return fallback;
   }
 
   let pr: GhPrView | null = null;
   let prTimer: ReturnType<typeof setInterval> | null = null;
   let lastRepoRoot: string | null = null;
 
-  const PR_REFRESH_MS = 60_000;
+  const PR_REFRESH_MS = 5_000;
 
   async function refreshPr(root: string): Promise<void> {
     try {
@@ -129,8 +142,14 @@
 
   onDestroy(() => stopPrPolling());
 
-  $: showPr = pr !== null && (pr.state === "OPEN" || pr.state === "open");
+  $: showPr =
+    !isNested && pr !== null && (pr.state === "OPEN" || pr.state === "open");
   $: isDraft = pr?.isDraft ?? false;
+  $: prColor = pr
+    ? isDraft
+      ? fgMuted
+      : ciColor(pr.ciStatus, "#4ec957")
+    : fgMuted;
 </script>
 
 {#if showDiff || showPr}
@@ -191,9 +210,7 @@
           />
         </svg>
         <span
-          style="font-size: 10px; color: {isDraft
-            ? fgMuted
-            : '#4ec957'}; white-space: nowrap; flex-shrink: 0;"
+          style="font-size: 10px; color: {prColor}; white-space: nowrap; flex-shrink: 0; text-decoration: underline;"
         >
           #{pr.number}{isDraft ? " draft" : ""}
         </span>

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  /**
+   * WorkspaceDiffPrSubtitle — compact diff + PR statusline for individual
+   * workspace rows. Registered via workspace-subtitle-registry at priority 20.
+   *
+   * Diff data comes from the git-status-service status registry (already
+   * polled) — no duplicate git polling. PR is fetched directly via
+   * `gh_view_pr` on a 60s timer, keyed on the repo root from the branch
+   * item's metadata.
+   *
+   * Renders the same two rows as DiffPrStatusLine but driven by the
+   * status registry instead of self-contained polling.
+   */
+  import { onDestroy } from "svelte";
+  import { invoke } from "@tauri-apps/api/core";
+  import { theme } from "../stores/theme";
+  import { getWorkspaceStatusByCategory } from "../services/status-registry";
+  import { GIT_STATUS_SOURCE } from "../services/git-status-service";
+  import type { StatusItem } from "../types/status";
+
+  export let workspaceId: string;
+  export let accentColor: string | undefined = undefined;
+
+  $: fgMuted = ($theme["fgMuted"] ?? $theme.fgDim) as string;
+  $: iconFg = accentColor ?? fgMuted;
+
+  $: gitStatusStore = getWorkspaceStatusByCategory(workspaceId, "git");
+  $: gitItems = $gitStatusStore;
+  $: branchItem = gitItems.find(
+    (i: StatusItem) =>
+      i.source === GIT_STATUS_SOURCE && i.id.endsWith(":branch"),
+  );
+  $: dirtyItem = gitItems.find(
+    (i: StatusItem) =>
+      i.source === GIT_STATUS_SOURCE && i.id.endsWith(":dirty"),
+  );
+
+  $: repoRoot = (branchItem?.metadata as Record<string, unknown> | undefined)
+    ?.repoRoot as string | undefined;
+
+  $: diffLabel = dirtyItem?.label ?? "";
+  $: showDiff = diffLabel.length > 0;
+
+  interface GhPrView {
+    number: number;
+    title: string;
+    state: string;
+    url: string;
+    headRefName: string;
+    isDraft: boolean;
+  }
+
+  let pr: GhPrView | null = null;
+  let prTimer: ReturnType<typeof setInterval> | null = null;
+  let lastRepoRoot: string | null = null;
+
+  const PR_REFRESH_MS = 60_000;
+
+  async function refreshPr(root: string): Promise<void> {
+    try {
+      const result = await invoke<GhPrView | null>("gh_view_pr", {
+        repoPath: root,
+      });
+      pr = result ?? null;
+    } catch {
+      pr = null;
+    }
+  }
+
+  function startPrPolling(root: string): void {
+    if (prTimer) clearInterval(prTimer);
+    lastRepoRoot = root;
+    void refreshPr(root);
+    prTimer = setInterval(() => void refreshPr(root), PR_REFRESH_MS);
+  }
+
+  function stopPrPolling(): void {
+    if (prTimer) {
+      clearInterval(prTimer);
+      prTimer = null;
+    }
+  }
+
+  $: if (repoRoot && repoRoot !== lastRepoRoot) {
+    startPrPolling(repoRoot);
+  }
+  $: if (!repoRoot && lastRepoRoot) {
+    stopPrPolling();
+    pr = null;
+    lastRepoRoot = null;
+  }
+
+  onDestroy(() => stopPrPolling());
+
+  $: showPr = pr !== null && (pr.state === "OPEN" || pr.state === "open");
+  $: isDraft = pr?.isDraft ?? false;
+</script>
+
+{#if showDiff || showPr}
+  <div
+    style="display: flex; flex-direction: column; gap: 1px; padding: 0 12px 4px 6px; overflow: hidden;"
+  >
+    {#if showDiff}
+      <div
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
+          />
+        </svg>
+        <span
+          style="font-size: 10px; color: #e8b73a; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+          title={dirtyItem?.tooltip ?? diffLabel}
+        >
+          {diffLabel}
+        </span>
+      </div>
+    {/if}
+
+    {#if showPr && pr}
+      <div
+        style="display: flex; align-items: center; gap: 3px; min-width: 0; overflow: hidden;"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={isDraft ? fgMuted : iconFg}
+          style="flex-shrink: 0; opacity: 0.7;"
+          aria-hidden="true"
+        >
+          <path
+            d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"
+          />
+        </svg>
+        <span
+          style="font-size: 10px; color: {isDraft
+            ? fgMuted
+            : '#4ec957'}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;"
+          title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
+        >
+          #{pr.number}{isDraft ? " draft" : ""}
+          <span style="opacity: 0.75;">{pr.title}</span>
+        </span>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -142,6 +142,18 @@
         style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden;"
         title={dirtyItem?.tooltip ?? diffLabel}
       >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 16 16"
+          fill={fgMuted}
+          style="flex-shrink: 0; opacity: 0.6;"
+          aria-hidden="true"
+        >
+          <path
+            d="M8 3.5a.5.5 0 0 1 .5.5v3.5H12a.5.5 0 0 1 0 1H8.5V12a.5.5 0 0 1-1 0V8.5H4a.5.5 0 0 1 0-1h3.5V4a.5.5 0 0 1 .5-.5zM3 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5z"
+          />
+        </svg>
         {#if diffSegments.length > 0}
           {#each diffSegments as seg}
             <span

--- a/src/lib/components/WorkspaceGroupSectionContent.svelte
+++ b/src/lib/components/WorkspaceGroupSectionContent.svelte
@@ -3,6 +3,7 @@
   import type { Readable } from "svelte/store";
   import ContainerRow from "./ContainerRow.svelte";
   import PathStatusLine from "./PathStatusLine.svelte";
+  import DiffPrStatusLine from "./DiffPrStatusLine.svelte";
   import SplitButton from "./SplitButton.svelte";
   import WorkspaceListView from "./WorkspaceListView.svelte";
   import { resolveGroupColor } from "../theme-data";
@@ -514,6 +515,13 @@
               path: group.path,
               isGit: group.isGit,
             }}
+            fgColor={subtitleFg}
+            iconColor={groupHex}
+          />
+          <DiffPrStatusLine
+            id={group.id}
+            path={group.path}
+            isGit={group.isGit}
             fgColor={subtitleFg}
             iconColor={groupHex}
           />

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -103,6 +103,17 @@
     );
     return hasAgent ? (allSurfaces.find((s) => s.id === sid) ?? null) : null;
   })();
+  $: activeAgentItem = (() => {
+    const sid = activePaneInWs?.activeSurfaceId;
+    if (!sid) return null;
+    return (
+      processItems.find(
+        (item) =>
+          (item.metadata as Record<string, unknown> | undefined)?.surfaceId ===
+          sid,
+      ) ?? null
+    );
+  })();
 
   $: subtitleComponents = $workspaceSubtitleStore;
 
@@ -427,19 +438,19 @@
       {/if}
     {/each}
 
-    {#if !hideStatusBadges && activeSurfaceForAgent?.title}
+    {#if !hideStatusBadges && activeAgentItem && activeAgentItem.label !== "closed"}
       <div
         data-harness-title-row
         style="padding: 0 12px 4px 6px; display: flex; align-items: center; min-width: 0; overflow: hidden; line-height: 1.2;"
       >
         <span
           style="font-size: 10px; color: {$theme.fgDim}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; display: inline-flex; align-items: center; gap: 3px;"
-          title={activeSurfaceForAgent.title}
+          title={activeSurfaceForAgent?.title ?? activeAgentItem.label}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
+            width="10"
+            height="10"
             viewBox="0 0 24 24"
             fill="none"
             stroke={railColor}
@@ -456,7 +467,9 @@
             <path d="M15 13v2" />
             <path d="M9 13v2" />
           </svg>
-          {activeSurfaceForAgent.title}
+          {activeAgentItem.label === "idle"
+            ? "idle"
+            : (activeSurfaceForAgent?.title ?? activeAgentItem.label)}
         </span>
       </div>
     {/if}

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -12,7 +12,6 @@
   import { modLabel } from "../terminal-service";
   import { shortcutHint } from "../actions/shortcut-hint";
   import { shortcutHintsActive } from "../stores/shortcut-hints";
-  import { tooltip } from "../actions/tooltip";
   import { discoEmojiFor, discoColorFor } from "../utils/disco-decoration";
 
   $: isDisco = $theme.name === "Molly Disco";
@@ -49,7 +48,6 @@
   export let hideStatusBadges: boolean = false;
 
   let hovered = false;
-  let closeHovered = false;
   let nameEl: HTMLSpanElement;
   let _renaming = false;
 
@@ -181,7 +179,6 @@
   on:mouseenter={() => (hovered = true)}
   on:mouseleave={() => {
     hovered = false;
-    closeHovered = false;
   }}
   on:mousedown={(e) => onGripMouseDown?.(e)}
 >
@@ -203,6 +200,8 @@
         $shortcutHintsActive ||
         (hovered && !$anyReorderActive)
       )}
+      onClose={!isDashboardWs || isDashboardWorkspaceRow ? onClose : undefined}
+      closeTooltip="Close Workspace (⇧⌘W)"
     />
     <!-- Drag-edge fade: continues the rail's dot pattern from the
          very left of the row into the row body for ~14px, dropping
@@ -251,7 +250,7 @@
     style="flex: 1; min-width: 0;"
   >
     <div
-      style="padding: 4px 6px; display: flex; align-items: center; gap: 8px;"
+      style="padding: 4px 24px 4px 6px; display: flex; align-items: center; gap: 8px;"
     >
       <div
         style="flex: 1; overflow: hidden; display: flex; align-items: center; gap: 4px;"
@@ -439,39 +438,43 @@
     {/each}
 
     {#if !hideStatusBadges && activeAgentItem && activeAgentItem.label !== "closed"}
-      <div
+      <span
         data-harness-title-row
-        style="padding: 0 12px 4px 6px; display: flex; align-items: center; min-width: 0; overflow: hidden; line-height: 1.2;"
+        title={activeAgentItem.label === "idle"
+          ? "idle"
+          : (activeSurfaceForAgent?.title ?? activeAgentItem.label)}
+        aria-hidden="true"
+        style="
+          position: absolute;
+          top: 50%; right: 6px;
+          transform: translateY(-50%);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          pointer-events: none;
+        "
       >
-        <span
-          style="font-size: 10px; color: {$theme.fgDim}; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; display: inline-flex; align-items: center; gap: 3px;"
-          title={activeSurfaceForAgent?.title ?? activeAgentItem.label}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={railColor}
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          style="opacity: 0.7;"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke={railColor}
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            style="flex-shrink: 0; opacity: 0.7;"
-          >
-            <title>Active harness session</title>
-            <path d="M12 8V4H8" />
-            <rect width="16" height="12" x="4" y="8" rx="2" />
-            <path d="M2 14h2" />
-            <path d="M20 14h2" />
-            <path d="M15 13v2" />
-            <path d="M9 13v2" />
-          </svg>
-          {activeAgentItem.label === "idle"
-            ? "idle"
-            : (activeSurfaceForAgent?.title ?? activeAgentItem.label)}
-        </span>
-      </div>
+          <title>Active harness session</title>
+          <path d="M12 8V4H8" />
+          <rect width="16" height="12" x="4" y="8" rx="2" />
+          <path d="M2 14h2" />
+          <path d="M20 14h2" />
+          <path d="M15 13v2" />
+          <path d="M9 13v2" />
+        </svg>
+      </span>
     {/if}
 
     {#if latestNotification && !hideStatusBadges && !isInsideGroup && !agentChipColor}
@@ -482,35 +485,4 @@
       </div>
     {/if}
   </div>
-  <!-- Close button: absolutely positioned so it stays vertically
-       centered against the full row regardless of how many subtitle or
-       notification rows stack below the title. The content column
-       reserves 24px on the right to keep text from crashing into it. -->
-  {#if !isDashboardWs || isDashboardWorkspaceRow}
-    <button
-      use:tooltip={"Close Workspace (⇧⌘W)"}
-      aria-label="Close workspace"
-      style="
-        position: absolute;
-        top: 50%; right: 6px;
-        transform: translateY(-50%);
-        color: {closeHovered ? $theme.danger : $theme.fgDim};
-        background: {closeHovered
-        ? ($theme.bgHighlight ?? 'rgba(255,255,255,0.06)')
-        : 'transparent'};
-        border: 1px solid {$theme.border ?? 'transparent'};
-        border-radius: 4px;
-        font-size: 11px;
-        cursor: pointer;
-        padding: 2px 5px;
-        line-height: 1;
-        opacity: {hovered ? '1' : '0'};
-        -webkit-app-region: no-drag;
-        transition: opacity 0.15s, background 0.1s, color 0.1s;
-      "
-      on:click|stopPropagation={onClose}
-      on:mouseenter={() => (closeHovered = true)}
-      on:mouseleave={() => (closeHovered = false)}>×</button
-    >
-  {/if}
 </div>

--- a/src/lib/services/git-status-service.ts
+++ b/src/lib/services/git-status-service.ts
@@ -462,7 +462,15 @@ export function startGitStatusService(): void {
     void ensurePolling(ws.id);
   }
 
-  unsubWorkspaces = workspaces.subscribe(() => {
+  unsubWorkspaces = workspaces.subscribe((wsList) => {
+    // Kick off polling for any workspace whose pty CWD just became available
+    // (covers the case where the pty starts after the service was initialised).
+    for (const ws of wsList) {
+      if (!workspaceCwds.has(ws.id)) {
+        void ensurePolling(ws.id);
+      }
+    }
+
     if (!activeWorkspaceId) return;
     const cached = workspaceCwds.get(activeWorkspaceId);
     if (!cached) return;

--- a/src/lib/services/git-status-service.ts
+++ b/src/lib/services/git-status-service.ts
@@ -21,7 +21,8 @@ import {
   clearAllStatusForSourceAndWorkspace,
 } from "./status-registry";
 import { workspaces, activeWorkspace } from "../stores/workspace";
-import { getActiveCwd, getWorkspaceCwd } from "./service-helpers";
+import { getActiveCwd, getWorkspaceCwd, wsMeta } from "./service-helpers";
+import { getWorkspaceGroup } from "../stores/workspace-groups";
 
 export const GIT_STATUS_SOURCE = "git";
 
@@ -423,10 +424,24 @@ async function ensurePolling(wsId: string): Promise<void> {
   // Active workspace can use the cheaper live-surface lookup; other
   // workspaces walk their own split tree so newly-created-but-inactive
   // rows don't wait for the user to activate them before status fills.
-  const cwd =
+  let cwd =
     activeWorkspaceId === wsId
       ? await getActiveCwd()
       : await getWorkspaceCwd(wsId);
+
+  if (!cwd) {
+    // Nested workspaces that haven't been activated yet have no pty CWD.
+    // Fall back to the group's root path so their diff status still
+    // shows the project's dirty state until they're first opened.
+    const ws = get(workspaces).find((w) => w.id === wsId);
+    if (ws) {
+      const groupId = wsMeta(ws).groupId;
+      if (typeof groupId === "string") {
+        cwd = getWorkspaceGroup(groupId)?.path;
+      }
+    }
+  }
+
   if (!cwd) return;
   if (workspaceCwds.has(wsId)) return;
   startPolling(wsId, cwd);

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -604,6 +604,19 @@ const pendingRunningTitles = new Map<number, ReturnType<typeof setTimeout>>();
 // Uses get_all_pty_cwds to batch all PTYs into a single IPC round-trip,
 // then applies a single workspaces.update() only when at least one cwd changed.
 let cwdPollTimer: ReturnType<typeof setInterval> | null = null;
+let cwdChangeHook: (() => void) | null = null;
+
+export function registerCwdChangeHook(cb: () => void): void {
+  cwdChangeHook = cb;
+}
+
+export function _stopCwdPolling(): void {
+  if (cwdPollTimer) {
+    clearInterval(cwdPollTimer);
+    cwdPollTimer = null;
+  }
+  cwdChangeHook = null;
+}
 
 export function startCwdPolling() {
   if (cwdPollTimer) return;
@@ -631,6 +644,7 @@ export function startCwdPolling() {
         // all subscribers on any .update() invocation regardless.
         if (anyChanged) {
           workspaces.update((l) => l);
+          cwdChangeHook?.();
         }
       })
       .catch(() => {});
@@ -923,6 +937,7 @@ function createOsc7Handler(
       surface.title = basename || "~";
     }
     workspaces.update((l) => [...l]);
+    cwdChangeHook?.();
     return true;
   };
 }


### PR DESCRIPTION
## Summary

- Adds a `gh_view_pr` Tauri command that returns the open PR for the current HEAD branch (or `None` when there is no PR — normal for main/dev)
- `DiffPrStatusLine.svelte`: self-contained diff + PR poller for workspace **group** container row banners (diff 30s, PR 60s)
- `WorkspaceDiffPrSubtitle.svelte`: registered subtitle (priority 20) for individual workspace rows — reads diff from the existing status registry (no duplicate polling), polls `gh_view_pr` at 60s keyed on repo root changes
- Strips dirty and legacy PR rendering from `GitStatusLine`'s active-workspace bottom row; `WorkspaceDiffPrSubtitle` is now the single source of truth for diff display

Visual design (same for both components):
- Row 1 — [± icon] `M3 A1 D1` in amber, only when working tree is dirty
- Row 2 — [PR octicon] `#42 my title` in green (muted if draft), only when an open PR exists for HEAD

## Test plan

- [ ] Open gnar-term with a git repo workspace. Make a change in that repo. The workspace row shows the dirty shorthand (e.g. `M1`) below the branch name.
- [ ] With a clean working tree, the diff row is absent.
- [ ] On a branch that has an open GitHub PR (`gh pr view` returns OPEN), the PR row shows `#N title` in green beneath the diff row (or alone if tree is clean).
- [ ] On a branch with a draft PR, the PR row shows `#N draft title` in muted colour.
- [ ] On `main`/`dev` (no PR), the PR row is absent.
- [ ] Open a workspace group that contains a git repo. The group banner also shows the diff row (and PR row if applicable).
- [ ] The diff row does **not** appear twice on an active workspace (no double display from old `GitStatusLine` bottom row).
- [ ] Worktree workspaces still show branch + dirty in `GitStatusLine`'s inline row when active.
- [ ] All 1581 tests pass: `npm test`.
- [ ] `cargo check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)