### PR TITLE
fix(build): clean stale DMG artifacts before tauri build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Terminal workspace manager for AI coding agents",
   "scripts": {
     "dev": "tauri dev",
+    "prebuild": "rm -f src-tauri/target/release/bundle/macos/*.dmg src-tauri/target/release/bundle/macos/rw.*.dmg src-tauri/target/release/bundle/dmg/*.dmg",
     "build": "tauri build",
     "vite": "vite",
     "vite:build": "vite build",


### PR DESCRIPTION
## Summary
- `npm run build` failed with `failed to run bundle_dmg.sh` whenever a prior bundle of the same version was already on disk
- Real cause (hidden by tauri swallowing the script's stderr): `hdiutil: convert failed - File exists` — `hdiutil convert` refuses to overwrite existing `.dmg` outputs
- Add a `prebuild` npm hook that removes stale `.dmg` and `rw.*.dmg` artifacts before `tauri build` runs, so the build self-heals on repeat local runs

## Test plan
- [x] Reproduce: with a fresh `GnarTerm_<v>_aarch64.dmg` already in `src-tauri/target/release/bundle/macos/`, run `npm run build` — confirm it previously failed
- [x] With the fix applied, run `npm run build` twice in a row at the same version — both succeed and produce a fresh DMG
- [x] `npm test` — 348 tests pass
- [ ] Run on a clean checkout (no prior `bundle/` dir) — `npm run build` still succeeds end-to-end (the `rm -f` is a no-op when nothing matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)