### PR TITLE
ci: add nightly builds from dev branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,90 @@
+name: "Nightly"
+
+# Builds GnarTerm from the `dev` branch and publishes a rolling
+# `nightly` prerelease (Apple Silicon only). Scheduled workflows must
+# live on the default branch to fire, so this workflow stays on `main`
+# and explicitly checks out `dev` to build.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 08:00 UTC = 01:00 PT / 04:00 ET
+  workflow_dispatch:
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  build-nightly:
+    permissions:
+      contents: write
+    runs-on: macos-latest
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: "npm"
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Compute nightly version
+        id: version
+        shell: bash
+        run: |
+          BASE=$(grep '^version' src-tauri/Cargo.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y%m%d)
+          VERSION="${BASE}-nightly.${DATE}.${SHORT_SHA}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Nightly version: $VERSION"
+
+      - name: Set version in Cargo.toml
+        shell: bash
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml && rm -f src-tauri/Cargo.toml.bak
+
+      - name: Install frontend dependencies
+        run: npm install
+
+      - name: Delete previous nightly release and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release delete nightly --yes --cleanup-tag || true
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: nightly
+          releaseName: "GnarTerm Nightly (${{ steps.version.outputs.VERSION }})"
+          releaseBody: |
+            Automated nightly build from the `dev` branch. Unstable — for testing only.
+
+            Built from commit ${{ github.sha }}.
+          releaseDraft: false
+          prerelease: true
+          args: --target aarch64-apple-darwin --config {"version":"${{ steps.version.outputs.VERSION }}"}


### PR DESCRIPTION
## Summary

- New `.github/workflows/nightly.yml` runs daily at 08:00 UTC (and on-demand via `workflow_dispatch`) and publishes a rolling `nightly` GitHub prerelease built from the `dev` branch.
- Apple Silicon only (`aarch64-apple-darwin`) — most users are on Mac, and limiting to one runner keeps the macOS-minute cost low. Tagged releases continue to ship the full mac/linux matrix via `release.yml`.
- Versions the artifact as `<base>-nightly.<YYYYMMDD>.<short-sha>` so each build is identifiable.
- Deletes the previous `nightly` release/tag before each run, so `…/releases/tag/nightly` is always the freshest build.
- Re-uses the same Apple signing/notarization secrets as `release.yml`.

The workflow file must live on `main` (default branch) for `schedule:` triggers to fire — that's why this PR targets main even though the build pulls from `dev`.

## Test plan

- [ ] Merge to main, then trigger manually: **Actions → Nightly → Run workflow** (defaults).
- [ ] Confirm job runs on `macos-latest`, checks out `dev`, and completes within ~25 min.
- [ ] Confirm a prerelease appears at `https://github.com/TheGnarCo/gnar-term/releases/tag/nightly` titled `GnarTerm Nightly (0.3.1-nightly.<date>.<sha>)` with a single `.dmg` asset for Apple Silicon.
- [ ] Download the DMG, install, and verify the app launches and shows the nightly version string.
- [ ] Trigger a second manual run; confirm the prior `nightly` release is deleted and replaced (URL still works, content is the new build).
- [ ] Wait for one scheduled run (or change cron temporarily) to confirm the cron trigger fires.
- [ ] Spot-check that signing/notarization succeeded — DMG opens on a clean Mac without Gatekeeper warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)