### PR TITLE
feat(cli): `gnar-term --preview` for files and URLs

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": {
+        "parser": "svelte"
+      }
+    }
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,10 @@ pub struct CliArgs {
     /// Path to config file
     #[arg(short = 'c', long)]
     pub config: Option<String>,
+
+    /// Open a preview surface for a file path or URL (file://, http://, https://)
+    #[arg(long)]
+    pub preview: Option<String>,
 }
 
 /// Flags accepted by CliArgs that take a value argument.
@@ -48,6 +52,7 @@ const VALUE_FLAGS: &[&str] = &[
     "--title",
     "-w", "--workspace",
     "-c", "--config",
+    "--preview",
 ];
 
 /// Flags accepted by CliArgs that are standalone (no value).
@@ -2281,5 +2286,36 @@ mod tests {
             filter_known_args(input.into_iter()),
             args(&["gnar-term", "-w", "dev", "-e", "bash", "~/Documents"])
         );
+    }
+
+    #[test]
+    fn filter_keeps_preview_with_path() {
+        let input = args(&["gnar-term", "--preview", "/tmp/foo.md"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn filter_keeps_preview_with_url() {
+        let input = args(&["gnar-term", "--preview", "https://example.com/foo.md"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn filter_keeps_preview_equals_form() {
+        let input = args(&["gnar-term", "--preview=spacebase://abc123"]);
+        assert_eq!(filter_known_args(input.clone().into_iter()), input);
+    }
+
+    #[test]
+    fn cli_args_parse_preview_flag() {
+        let parsed = CliArgs::parse_from(args(&["gnar-term", "--preview", "/tmp/foo.md"]));
+        assert_eq!(parsed.preview.as_deref(), Some("/tmp/foo.md"));
+        assert!(parsed.path.is_none());
+    }
+
+    #[test]
+    fn cli_args_parse_preview_url() {
+        let parsed = CliArgs::parse_from(args(&["gnar-term", "--preview", "https://example.com/x.md"]));
+        assert_eq!(parsed.preview.as_deref(), Some("https://example.com/x.md"));
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -167,10 +167,10 @@
     })),
     { name: "Save Current Workspace...", action: () => saveCurrentWorkspace() },
     {
-      name: `Preview File...`,
+      name: `Preview...`,
       action: async () => {
-        const path = await showInputPrompt("Path to file");
-        if (path) openPreviewInPane(path);
+        const target = await showInputPrompt("File path or URL");
+        if (target) openPreviewInPane(target);
       },
     },
     ...getWorkspaceCommands().map((cmd) => ({
@@ -407,6 +407,7 @@
     title: string | null;
     workspace: string | null;
     config: string | null;
+    preview: string | null;
   }
 
   // ---- Initialization ----
@@ -470,6 +471,10 @@
       if (!autoloaded) {
         await createWorkspace("Workspace 1");
       }
+    }
+
+    if (cliArgs.preview) {
+      pendingAction.set({ type: "open-preview", payload: cliArgs.preview });
     }
 
     listen<string>("menu-theme", (event) => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,19 +2,71 @@
   import { onMount } from "svelte";
   import { listen } from "@tauri-apps/api/event";
   import { theme, themes, xtermTheme } from "./lib/stores/theme";
-  import { primarySidebarVisible, secondarySidebarVisible, commandPaletteOpen, findBarVisible, pendingAction, showInputPrompt } from "./lib/stores/ui";
-  import { workspaces, activeWorkspaceIdx, activeWorkspace, activePane, activeSurface } from "./lib/stores/workspace";
+  import {
+    primarySidebarVisible,
+    secondarySidebarVisible,
+    commandPaletteOpen,
+    findBarVisible,
+    pendingAction,
+    showInputPrompt,
+  } from "./lib/stores/ui";
+  import {
+    workspaces,
+    activeWorkspaceIdx,
+    activeWorkspace,
+    activePane,
+    activeSurface,
+  } from "./lib/stores/workspace";
   import { invoke } from "@tauri-apps/api/core";
-  import { loadConfig, saveConfig, getConfig, getWorkspaceCommands, type WorkspaceDef } from "./lib/config";
-  import { setupListeners, fontReady, startCwdPolling, isMac, modLabel, shiftModLabel } from "./lib/terminal-service";
+  import {
+    loadConfig,
+    saveConfig,
+    getConfig,
+    getWorkspaceCommands,
+    type WorkspaceDef,
+  } from "./lib/config";
+  import {
+    setupListeners,
+    fontReady,
+    startCwdPolling,
+    isMac,
+    modLabel,
+    shiftModLabel,
+  } from "./lib/terminal-service";
   import { getAllSurfaces, isTerminalSurface } from "./lib/types";
   import { refreshPreviewStyles } from "./preview/index";
   import "./preview/init";
 
   // Services
-  import { createWorkspace, createWorkspaceFromDef, switchWorkspace, closeWorkspace, renameWorkspace, reorderWorkspaces, saveCurrentWorkspace } from "./lib/services/workspace-service";
-  import { splitPane, closePane, focusPane, reorderTab, focusDirection, flashFocusedPane, splitFromSidebar } from "./lib/services/pane-service";
-  import { selectSurface, closeSurfaceById, newSurface, nextSurface, prevSurface, selectSurfaceByNumber, closeActiveSurface, openPreviewInPane, newSurfaceFromSidebar } from "./lib/services/surface-service";
+  import {
+    createWorkspace,
+    createWorkspaceFromDef,
+    switchWorkspace,
+    closeWorkspace,
+    renameWorkspace,
+    reorderWorkspaces,
+    saveCurrentWorkspace,
+  } from "./lib/services/workspace-service";
+  import {
+    splitPane,
+    closePane,
+    focusPane,
+    reorderTab,
+    focusDirection,
+    flashFocusedPane,
+    splitFromSidebar,
+  } from "./lib/services/pane-service";
+  import {
+    selectSurface,
+    closeSurfaceById,
+    newSurface,
+    nextSurface,
+    prevSurface,
+    selectSurfaceByNumber,
+    closeActiveSurface,
+    openPreviewInPane,
+    newSurfaceFromSidebar,
+  } from "./lib/services/surface-service";
   import { initMcpServer } from "./lib/services/mcp-server";
 
   // Components
@@ -46,31 +98,86 @@
   // ---- Command palette ----
 
   $: paletteCommands = [
-    { name: "New Workspace", shortcut: `${shiftModLabel}N`, action: () => createWorkspace(`Workspace ${$workspaces.length + 1}`) },
-    { name: "New Surface (Tab)", shortcut: `${shiftModLabel}T`, action: () => newSurfaceFromSidebar() },
-    { name: "Split Right", shortcut: isMac ? `${modLabel}D` : `${shiftModLabel}D`, action: () => splitFromSidebar("horizontal") },
-    { name: "Split Down", shortcut: `${shiftModLabel}D`, action: () => splitFromSidebar("vertical") },
-    { name: "Close Surface", shortcut: isMac ? `${modLabel}W` : `${shiftModLabel}W`, action: () => closeActiveSurface() },
-    { name: "Close Workspace", shortcut: `${shiftModLabel}W`, action: () => closeWorkspace($activeWorkspaceIdx) },
-    { name: "Next Surface", shortcut: `${shiftModLabel}]`, action: () => nextSurface() },
-    { name: "Previous Surface", shortcut: `${shiftModLabel}[`, action: () => prevSurface() },
-    { name: "Toggle Primary Sidebar", shortcut: `${shiftModLabel}B`, action: () => primarySidebarVisible.update(v => !v) },
-    { name: "Toggle Secondary Sidebar", action: () => secondarySidebarVisible.update(v => !v) },
-    { name: "Toggle Find Bar", shortcut: `${shiftModLabel}F`, action: () => findBarVisible.update(v => !v) },
-    { name: "Clear Scrollback", shortcut: `${shiftModLabel}K`, action: () => { const s = $activeSurface; if (s && isTerminalSurface(s)) s.terminal.clear(); } },
+    {
+      name: "New Workspace",
+      shortcut: `${shiftModLabel}N`,
+      action: () => createWorkspace(`Workspace ${$workspaces.length + 1}`),
+    },
+    {
+      name: "New Surface (Tab)",
+      shortcut: `${shiftModLabel}T`,
+      action: () => newSurfaceFromSidebar(),
+    },
+    {
+      name: "Split Right",
+      shortcut: isMac ? `${modLabel}D` : `${shiftModLabel}D`,
+      action: () => splitFromSidebar("horizontal"),
+    },
+    {
+      name: "Split Down",
+      shortcut: `${shiftModLabel}D`,
+      action: () => splitFromSidebar("vertical"),
+    },
+    {
+      name: "Close Surface",
+      shortcut: isMac ? `${modLabel}W` : `${shiftModLabel}W`,
+      action: () => closeActiveSurface(),
+    },
+    {
+      name: "Close Workspace",
+      shortcut: `${shiftModLabel}W`,
+      action: () => closeWorkspace($activeWorkspaceIdx),
+    },
+    {
+      name: "Next Surface",
+      shortcut: `${shiftModLabel}]`,
+      action: () => nextSurface(),
+    },
+    {
+      name: "Previous Surface",
+      shortcut: `${shiftModLabel}[`,
+      action: () => prevSurface(),
+    },
+    {
+      name: "Toggle Primary Sidebar",
+      shortcut: `${shiftModLabel}B`,
+      action: () => primarySidebarVisible.update((v) => !v),
+    },
+    {
+      name: "Toggle Secondary Sidebar",
+      action: () => secondarySidebarVisible.update((v) => !v),
+    },
+    {
+      name: "Toggle Find Bar",
+      shortcut: `${shiftModLabel}F`,
+      action: () => findBarVisible.update((v) => !v),
+    },
+    {
+      name: "Clear Scrollback",
+      shortcut: `${shiftModLabel}K`,
+      action: () => {
+        const s = $activeSurface;
+        if (s && isTerminalSurface(s)) s.terminal.clear();
+      },
+    },
     ...$workspaces.map((ws, i) => ({
       name: `Switch to: ${ws.name}`,
       shortcut: i < 9 ? `${modLabel}${i + 1}` : undefined,
       action: () => switchWorkspace(i),
     })),
     { name: "Save Current Workspace...", action: () => saveCurrentWorkspace() },
-    { name: `Preview File...`, action: async () => {
-      const path = await showInputPrompt("Path to file");
-      if (path) openPreviewInPane(path);
-    }},
-    ...getWorkspaceCommands().map(cmd => ({
+    {
+      name: `Preview File...`,
+      action: async () => {
+        const path = await showInputPrompt("Path to file");
+        if (path) openPreviewInPane(path);
+      },
+    },
+    ...getWorkspaceCommands().map((cmd) => ({
       name: cmd.name,
-      action: () => { if (cmd.workspace) createWorkspaceFromDef(cmd.workspace); },
+      action: () => {
+        if (cmd.workspace) createWorkspaceFromDef(cmd.workspace);
+      },
     })),
     ...Object.entries(themes).map(([id, t]) => ({
       name: `Theme: ${t.name}`,
@@ -98,57 +205,198 @@
     const shift = e.shiftKey;
     const alt = e.altKey;
     const ctrl = e.ctrlKey;
-    const cmd = isMac ? e.metaKey : (ctrl && shift);
+    const cmd = isMac ? e.metaKey : ctrl && shift;
 
     // macOS: Cmd+key (no shift) shortcuts
     if (isMac && e.metaKey && !shift && !alt) {
-      if (e.key === "n") { e.preventDefault(); createWorkspace(`Workspace ${$workspaces.length + 1}`); return; }
-      if (e.key === "t") { e.preventDefault(); newSurfaceFromSidebar(); return; }
-      if (e.key === "d") { e.preventDefault(); splitFromSidebar("horizontal"); return; }
-      if (e.key === "w") { e.preventDefault(); closeActiveSurface(); return; }
-      if (e.key >= "1" && e.key <= "8") { e.preventDefault(); switchWorkspace(parseInt(e.key) - 1); return; }
-      if (e.key === "9") { e.preventDefault(); switchWorkspace($workspaces.length - 1); return; }
-      if (e.key === "b") { e.preventDefault(); primarySidebarVisible.update(v => !v); return; }
-      if (e.key === "k") { e.preventDefault(); const s = $activeSurface; if (s && isTerminalSurface(s)) s.terminal.clear(); return; }
-      if (e.key === "p") { e.preventDefault(); commandPaletteOpen.update(v => !v); return; }
-      if (e.key === "f") { e.preventDefault(); findBarVisible.update(v => !v); return; }
-      if (e.key === "g") { e.preventDefault(); findBarVisible.set(true); findBarComponent?.findNext(); return; }
+      if (e.key === "n") {
+        e.preventDefault();
+        createWorkspace(`Workspace ${$workspaces.length + 1}`);
+        return;
+      }
+      if (e.key === "t") {
+        e.preventDefault();
+        newSurfaceFromSidebar();
+        return;
+      }
+      if (e.key === "d") {
+        e.preventDefault();
+        splitFromSidebar("horizontal");
+        return;
+      }
+      if (e.key === "w") {
+        e.preventDefault();
+        closeActiveSurface();
+        return;
+      }
+      if (e.key >= "1" && e.key <= "8") {
+        e.preventDefault();
+        switchWorkspace(parseInt(e.key) - 1);
+        return;
+      }
+      if (e.key === "9") {
+        e.preventDefault();
+        switchWorkspace($workspaces.length - 1);
+        return;
+      }
+      if (e.key === "b") {
+        e.preventDefault();
+        primarySidebarVisible.update((v) => !v);
+        return;
+      }
+      if (e.key === "k") {
+        e.preventDefault();
+        const s = $activeSurface;
+        if (s && isTerminalSurface(s)) s.terminal.clear();
+        return;
+      }
+      if (e.key === "p") {
+        e.preventDefault();
+        commandPaletteOpen.update((v) => !v);
+        return;
+      }
+      if (e.key === "f") {
+        e.preventDefault();
+        findBarVisible.update((v) => !v);
+        return;
+      }
+      if (e.key === "g") {
+        e.preventDefault();
+        findBarVisible.set(true);
+        findBarComponent?.findNext();
+        return;
+      }
     }
 
     // macOS: Ctrl+number selects surfaces
-    if (isMac && ctrl && !e.metaKey && !shift && !alt && e.key >= "1" && e.key <= "8") { e.preventDefault(); selectSurfaceByNumber(parseInt(e.key)); return; }
-    if (isMac && ctrl && !e.metaKey && !shift && !alt && e.key === "9") { e.preventDefault(); selectSurfaceByNumber(9); return; }
+    if (
+      isMac &&
+      ctrl &&
+      !e.metaKey &&
+      !shift &&
+      !alt &&
+      e.key >= "1" &&
+      e.key <= "8"
+    ) {
+      e.preventDefault();
+      selectSurfaceByNumber(parseInt(e.key));
+      return;
+    }
+    if (isMac && ctrl && !e.metaKey && !shift && !alt && e.key === "9") {
+      e.preventDefault();
+      selectSurfaceByNumber(9);
+      return;
+    }
 
     // Shared Cmd+Shift / Ctrl+Shift shortcuts
     if (cmd && shift && !alt) {
       const k = e.key.toLowerCase();
-      if (k === "t") { e.preventDefault(); newSurfaceFromSidebar(); return; }
-      if (k === "n") { e.preventDefault(); createWorkspace(`Workspace ${$workspaces.length + 1}`); return; }
-      if (k === "d") { e.preventDefault(); splitFromSidebar("vertical"); return; }
-      if (k === "w") { e.preventDefault(); closeWorkspace($activeWorkspaceIdx); return; }
-      if (k === "h") { e.preventDefault(); flashFocusedPane(); return; }
-      if (k === "r") { e.preventDefault(); sidebarComponent?.startRename($activeWorkspaceIdx); return; }
-      if (k === "g") { e.preventDefault(); findBarVisible.set(true); findBarComponent?.findPrev(); return; }
-      if (k === "b") { e.preventDefault(); primarySidebarVisible.update(v => !v); return; }
-      if (k === "p") { e.preventDefault(); commandPaletteOpen.update(v => !v); return; }
-      if (k === "k") { e.preventDefault(); const s = $activeSurface; if (s && isTerminalSurface(s)) s.terminal.clear(); return; }
-      if (k === "f") { e.preventDefault(); findBarVisible.update(v => !v); return; }
-      if (e.key === "]") { e.preventDefault(); nextSurface(); return; }
-      if (e.key === "[") { e.preventDefault(); prevSurface(); return; }
+      if (k === "t") {
+        e.preventDefault();
+        newSurfaceFromSidebar();
+        return;
+      }
+      if (k === "n") {
+        e.preventDefault();
+        createWorkspace(`Workspace ${$workspaces.length + 1}`);
+        return;
+      }
+      if (k === "d") {
+        e.preventDefault();
+        splitFromSidebar("vertical");
+        return;
+      }
+      if (k === "w") {
+        e.preventDefault();
+        closeWorkspace($activeWorkspaceIdx);
+        return;
+      }
+      if (k === "h") {
+        e.preventDefault();
+        flashFocusedPane();
+        return;
+      }
+      if (k === "r") {
+        e.preventDefault();
+        sidebarComponent?.startRename($activeWorkspaceIdx);
+        return;
+      }
+      if (k === "g") {
+        e.preventDefault();
+        findBarVisible.set(true);
+        findBarComponent?.findPrev();
+        return;
+      }
+      if (k === "b") {
+        e.preventDefault();
+        primarySidebarVisible.update((v) => !v);
+        return;
+      }
+      if (k === "p") {
+        e.preventDefault();
+        commandPaletteOpen.update((v) => !v);
+        return;
+      }
+      if (k === "k") {
+        e.preventDefault();
+        const s = $activeSurface;
+        if (s && isTerminalSurface(s)) s.terminal.clear();
+        return;
+      }
+      if (k === "f") {
+        e.preventDefault();
+        findBarVisible.update((v) => !v);
+        return;
+      }
+      if (e.key === "]") {
+        e.preventDefault();
+        nextSurface();
+        return;
+      }
+      if (e.key === "[") {
+        e.preventDefault();
+        prevSurface();
+        return;
+      }
     }
 
     // Ctrl+Tab / Ctrl+Shift+Tab
-    if (ctrl && !alt && e.key === "Tab") { e.preventDefault(); if (shift) prevSurface(); else nextSurface(); return; }
+    if (ctrl && !alt && e.key === "Tab") {
+      e.preventDefault();
+      if (shift) prevSurface();
+      else nextSurface();
+      return;
+    }
 
     // Alt+Cmd/Ctrl+arrows for pane navigation
     if (alt && (isMac ? e.metaKey : ctrl) && !shift) {
-      if (e.key === "ArrowLeft") { e.preventDefault(); focusDirection("left"); return; }
-      if (e.key === "ArrowRight") { e.preventDefault(); focusDirection("right"); return; }
-      if (e.key === "ArrowUp") { e.preventDefault(); focusDirection("up"); return; }
-      if (e.key === "ArrowDown") { e.preventDefault(); focusDirection("down"); return; }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        focusDirection("left");
+        return;
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        focusDirection("right");
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        focusDirection("up");
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        focusDirection("down");
+        return;
+      }
     }
 
-    if (e.key === "Escape" && $findBarVisible) { e.preventDefault(); findBarVisible.set(false); return; }
+    if (e.key === "Escape" && $findBarVisible) {
+      e.preventDefault();
+      findBarVisible.set(false);
+      return;
+    }
   }
 
   // ---- CLI args type ----
@@ -178,12 +426,14 @@
 
     if (cliArgs.workspace) {
       const cmd = config.commands?.find(
-        c => c.name === cliArgs.workspace && c.workspace
+        (c) => c.name === cliArgs.workspace && c.workspace,
       );
       if (cmd?.workspace) {
         await createWorkspaceFromDef(cmd.workspace);
       } else {
-        console.warn(`[cli] Workspace "${cliArgs.workspace}" not found in config`);
+        console.warn(
+          `[cli] Workspace "${cliArgs.workspace}" not found in config`,
+        );
         await createWorkspace(cliArgs.title || "Workspace 1");
       }
     } else if (cliCwd || cliArgs.command) {
@@ -193,20 +443,24 @@
         cwd: cliCwd || undefined,
         layout: {
           pane: {
-            surfaces: [{
-              type: "terminal",
-              cwd: cliCwd || undefined,
-              command: cliArgs.command || undefined,
-            }]
-          }
-        }
+            surfaces: [
+              {
+                type: "terminal",
+                cwd: cliCwd || undefined,
+                command: cliArgs.command || undefined,
+              },
+            ],
+          },
+        },
       };
       await createWorkspaceFromDef(def);
     } else {
       let autoloaded = false;
       if (config.autoload && config.autoload.length > 0 && config.commands) {
         for (const name of config.autoload) {
-          const cmd = config.commands.find(c => c.name === name && c.workspace);
+          const cmd = config.commands.find(
+            (c) => c.name === name && c.workspace,
+          );
           if (cmd?.workspace) {
             await createWorkspaceFromDef(cmd.workspace);
             autoloaded = true;
@@ -223,7 +477,7 @@
     });
 
     await listen("menu-cmd-palette", () => {
-      commandPaletteOpen.update(v => !v);
+      commandPaletteOpen.update((v) => !v);
     });
 
     await listen("menu-close-tab", () => {
@@ -237,7 +491,8 @@
 <div id="app" style="display: flex; height: 100vh; overflow: hidden;">
   <PrimarySidebar
     bind:this={sidebarComponent}
-    onNewWorkspace={() => createWorkspace(`Workspace ${$workspaces.length + 1}`)}
+    onNewWorkspace={() =>
+      createWorkspace(`Workspace ${$workspaces.length + 1}`)}
     onSwitchWorkspace={switchWorkspace}
     onCloseWorkspace={closeWorkspace}
     onRenameWorkspace={renameWorkspace}
@@ -245,10 +500,12 @@
     onReorderWorkspaces={reorderWorkspaces}
   />
 
-  <div style="
+  <div
+    style="
     flex: 1; display: flex; flex-direction: column;
     background: {$theme.bg}; min-width: 0; min-height: 0; overflow: hidden;
-  ">
+  "
+  >
     <TitleBar />
 
     <div

--- a/src/__tests__/app-render.test.ts
+++ b/src/__tests__/app-render.test.ts
@@ -32,7 +32,9 @@ describe("App.svelte structure verification", () => {
     // createTerminalSurface already pushes to pane.surfaces
     // App.svelte should NOT have pane.surfaces.push(surface) after calling it
     const lines = source.split("\n");
-    const createCalls = lines.filter(l => l.includes("createTerminalSurface"));
+    const createCalls = lines.filter((l) =>
+      l.includes("createTerminalSurface"),
+    );
     // Check that createTerminalSurface calls are NOT followed by a push on the next few lines
     for (let i = 0; i < lines.length; i++) {
       if (lines[i].includes("createTerminalSurface")) {
@@ -59,9 +61,11 @@ describe("App.svelte structure verification", () => {
   it("terminal area has overflow: hidden for viewport containment", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync("src/App.svelte", "utf-8");
-    expect(source).toContain("id=\"terminal-area\"");
+    expect(source).toContain('id="terminal-area"');
     // The terminal-area must have overflow hidden to prevent viewport overflow
-    const termAreaMatch = source.match(/id="terminal-area"[^>]*style="([^"]*)"/);
+    const termAreaMatch = source.match(
+      /id="terminal-area"[^>]*style="([^"]*)"/,
+    );
     expect(termAreaMatch).not.toBeNull();
     expect(termAreaMatch![1]).toContain("overflow: hidden");
     expect(termAreaMatch![1]).toContain("min-height: 0");
@@ -71,7 +75,10 @@ describe("App.svelte structure verification", () => {
 describe("TerminalSurface component structure", () => {
   it("opens terminal via surface.termElement in onMount (context menu lives there)", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/TerminalSurface.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/TerminalSurface.svelte",
+      "utf-8",
+    );
     expect(source).toContain("onMount");
     // Must open into surface.termElement (not termEl) so context menu listeners fire correctly
     expect(source).toContain("surface.terminal.open(surface.termElement)");
@@ -89,7 +96,10 @@ describe("TerminalSurface component structure", () => {
 
   it("uses display: none for hidden surfaces (not conditional rendering)", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/TerminalSurface.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/TerminalSurface.svelte",
+      "utf-8",
+    );
     // Must use CSS visibility, NOT {#if visible} which would destroy the terminal
     expect(source).toContain("display: {visible");
     expect(source).not.toContain("{#if visible}");
@@ -130,7 +140,9 @@ describe("pty-exit workspace recovery", () => {
     const fs = await import("fs");
     const source = fs.readFileSync("src/lib/terminal-service.ts", "utf-8");
     // After splicing a workspace from the list, activeWorkspaceIdx must be clamped
-    expect(source).toContain("activeWorkspaceIdx.set(Math.max(0, wsList.length - 1))");
+    expect(source).toContain(
+      "activeWorkspaceIdx.set(Math.max(0, wsList.length - 1))",
+    );
   });
 
   it("creates default workspace when all workspaces are removed", async () => {
@@ -151,7 +163,10 @@ describe("pty-exit workspace recovery", () => {
 describe("Preview scrolling works", () => {
   it("PreviewSurface container allows scrolling (not overflow: hidden)", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PreviewSurface.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PreviewSurface.svelte",
+      "utf-8",
+    );
     // Container must allow vertical scrolling
     expect(source).toContain("overflow-y: auto");
     // Must NOT have overflow: hidden which would clip scrollable content
@@ -178,14 +193,19 @@ describe("Config loads per-project files", () => {
 describe("Workspace from config definition", () => {
   it("createWorkspaceFromDef is implemented in workspace-service", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/workspace-service.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/workspace-service.ts",
+      "utf-8",
+    );
     expect(source).toContain("async function createWorkspaceFromDef");
   });
 
   it("command palette wires workspace commands to createWorkspaceFromDef", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync("src/App.svelte", "utf-8");
-    expect(source).toContain("cmd.workspace) createWorkspaceFromDef(cmd.workspace)");
+    expect(source).toContain(
+      "cmd.workspace) createWorkspaceFromDef(cmd.workspace)",
+    );
   });
 
   it("autoloads workspaces from config on startup", async () => {
@@ -199,11 +219,14 @@ describe("Workspace from config definition", () => {
 
   it("handles layout with splits and surface definitions", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/workspace-service.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/workspace-service.ts",
+      "utf-8",
+    );
     expect(source).toContain("buildTree(nodeDef.children[0]");
     expect(source).toContain("buildTree(nodeDef.children[1]");
     expect(source).toContain("sDef.command");
-    expect(source).toContain('startupCommand');
+    expect(source).toContain("startupCommand");
     expect(source).toContain('sDef.type === "markdown"');
   });
 });
@@ -218,7 +241,10 @@ describe("New tab inherits cwd from active surface", () => {
 
   it("getActiveCwd reads cwd from active surface", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/service-helpers.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/service-helpers.ts",
+      "utf-8",
+    );
     expect(source).toContain("surface.cwd");
   });
 });
@@ -226,7 +252,10 @@ describe("New tab inherits cwd from active surface", () => {
 describe("No spurious fit/scrollToBottom on store updates", () => {
   it("TerminalSurface does not call fit() reactively (PaneView ResizeObserver handles it)", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/TerminalSurface.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/TerminalSurface.svelte",
+      "utf-8",
+    );
     // Reactive fit() races with ResizeObserver and measures stale dimensions.
     // Only the onMount fit (for initial open) should exist.
     const afterOnMount = source.split("onMount")[1] || "";
@@ -237,15 +266,16 @@ describe("No spurious fit/scrollToBottom on store updates", () => {
 
   it("switchWorkspace does not directly call fit or scrollToBottom", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/workspace-service.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/workspace-service.ts",
+      "utf-8",
+    );
     const start = source.indexOf("function switchWorkspace");
     const end = source.indexOf("\nexport function ", start + 1);
     const fn = source.slice(start, end);
     expect(fn).not.toMatch(/\.fitAddon\.fit\(\)/);
     expect(fn).not.toMatch(/\.scrollToBottom\(\)/);
   });
-
-
 });
 
 describe("Flash focused pane", () => {
@@ -264,7 +294,10 @@ describe("Flash focused pane", () => {
 
   it("PaneView stores element ref on pane", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PaneView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PaneView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("pane.element = paneEl");
   });
 });
@@ -290,7 +323,10 @@ describe("Tab drag reorder within pane", () => {
 describe("Theme reactivity for previews", () => {
   it("PreviewSurface updates colors on theme change", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PreviewSurface.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PreviewSurface.svelte",
+      "utf-8",
+    );
     expect(source).toContain("$theme.bg");
     expect(source).toContain("$theme.fg");
     expect(source).toContain("surface.element.style.background");
@@ -327,16 +363,22 @@ describe("CWD polling fallback", () => {
 describe("Workspace save/restore", () => {
   it("serializeLayout produces config-compatible output", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/workspace-service.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/workspace-service.ts",
+      "utf-8",
+    );
     expect(source).toContain("function serializeLayout");
-    expect(source).toContain("node.type === \"pane\"");
+    expect(source).toContain('node.type === "pane"');
     expect(source).toContain("node.direction");
     expect(source).toContain("node.ratio");
   });
 
   it("saveCurrentWorkspace saves to config commands", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/services/workspace-service.ts", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/services/workspace-service.ts",
+      "utf-8",
+    );
     expect(source).toContain("async function saveCurrentWorkspace");
     expect(source).toContain("saveConfig({ commands }");
   });
@@ -390,7 +432,7 @@ describe("Keyboard shortcuts completeness", () => {
     const fs = await import("fs");
     const source = fs.readFileSync("src/App.svelte", "utf-8");
     // Must have Cmd+K handler that calls terminal.clear()
-    expect(source).toMatch(/e\.key === "k".*terminal\.clear\(\)/);
+    expect(source).toMatch(/e\.key === "k"[\s\S]*?terminal\.clear\(\)/);
   });
 
   it("Cmd+G dispatches to FindBar findNext", async () => {
@@ -410,7 +452,10 @@ describe("Keyboard shortcuts completeness", () => {
 
   it("FindBar exports findNext and findPrev methods", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/FindBar.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/FindBar.svelte",
+      "utf-8",
+    );
     expect(source).toContain("export function findNext()");
     expect(source).toContain("export function findPrev()");
   });
@@ -419,29 +464,41 @@ describe("Keyboard shortcuts completeness", () => {
 describe("SplitNodeView has draggable dividers with ratio support", () => {
   it("renders divider element between split children", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/SplitNodeView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/SplitNodeView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("split-divider");
     expect(source).toContain("use:dragResize");
   });
 
   it("uses ratio for flex sizing instead of hardcoded flex: 1", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/SplitNodeView.svelte", "utf-8");
-    expect(source).toContain("flex: {node.ratio}");
-    expect(source).toContain("flex: {1 - node.ratio}");
+    const source = fs.readFileSync(
+      "src/lib/components/SplitNodeView.svelte",
+      "utf-8",
+    );
+    expect(source).toMatch(/flex:\s*\{node\.ratio\}/);
+    expect(source).toMatch(/flex:\s*\{1\s*-\s*node\.ratio\}/);
     // Should NOT have hardcoded flex: 1 for split children
     expect(source).not.toMatch(/style="flex: 1;[^"]*">\s*<SplitNodeView/);
   });
 
   it("clamps ratio between 0.1 and 0.9 during drag", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/SplitNodeView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/SplitNodeView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("Math.max(0.1, Math.min(0.9");
   });
 
   it("uses correct cursor for horizontal vs vertical splits", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/SplitNodeView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/SplitNodeView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("cursor: row-resize");
     expect(source).toContain("cursor: col-resize");
   });
@@ -450,14 +507,20 @@ describe("SplitNodeView has draggable dividers with ratio support", () => {
 describe("PaneView has ResizeObserver for terminal fitting", () => {
   it("creates ResizeObserver in onMount", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PaneView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PaneView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("new ResizeObserver");
     expect(source).toContain("resizeObserver.observe");
   });
 
   it("debounces resize events to avoid excessive fitAddon.fit() calls", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PaneView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PaneView.svelte",
+      "utf-8",
+    );
     // Must have a debounce timer, not call fit() directly in the observer
     expect(source).toContain("setTimeout");
     expect(source).toContain("clearTimeout");
@@ -466,7 +529,10 @@ describe("PaneView has ResizeObserver for terminal fitting", () => {
 
   it("disconnects ResizeObserver and clears timer on destroy", async () => {
     const fs = await import("fs");
-    const source = fs.readFileSync("src/lib/components/PaneView.svelte", "utf-8");
+    const source = fs.readFileSync(
+      "src/lib/components/PaneView.svelte",
+      "utf-8",
+    );
     expect(source).toContain("onDestroy");
     expect(source).toContain("resizeObserver?.disconnect()");
     expect(source).toContain("clearTimeout(resizeTimer)");

--- a/src/__tests__/preview.test.ts
+++ b/src/__tests__/preview.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async (cmd: string, args: any) => {
+    if (cmd === "read_file") {
+      return `# Local file\n\npath was: ${args.path}`;
+    }
+    if (cmd === "watch_file") {
+      return 0;
+    }
+    return undefined;
+  }),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+import "../preview/init";
+import { openPreview, parsePreviewTarget } from "../preview/index";
+
+describe("parsePreviewTarget", () => {
+  it("plain absolute path → kind: path", () => {
+    expect(parsePreviewTarget("/tmp/foo.md")).toEqual({
+      kind: "path",
+      path: "/tmp/foo.md",
+    });
+  });
+
+  it("relative path → kind: path", () => {
+    expect(parsePreviewTarget("./README.md")).toEqual({
+      kind: "path",
+      path: "./README.md",
+    });
+  });
+
+  it("file:// URL → kind: path with scheme stripped", () => {
+    expect(parsePreviewTarget("file:///tmp/foo.md")).toEqual({
+      kind: "path",
+      path: "/tmp/foo.md",
+    });
+  });
+
+  it("file:// URL with percent-encoding decodes", () => {
+    expect(parsePreviewTarget("file:///tmp/with%20space.md")).toEqual({
+      kind: "path",
+      path: "/tmp/with space.md",
+    });
+  });
+
+  it("https URL → kind: url", () => {
+    expect(parsePreviewTarget("https://example.com/foo.md")).toEqual({
+      kind: "url",
+      url: "https://example.com/foo.md",
+    });
+  });
+
+  it("http URL → kind: url", () => {
+    expect(parsePreviewTarget("http://example.com/foo")).toEqual({
+      kind: "url",
+      url: "http://example.com/foo",
+    });
+  });
+
+  it("unknown scheme falls through as a path (plugins will dispatch later)", () => {
+    expect(parsePreviewTarget("spacebase://R9qNOvRHbR0x")).toEqual({
+      kind: "path",
+      path: "spacebase://R9qNOvRHbR0x",
+    });
+  });
+});
+
+describe("openPreview", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("local path opens via the registered previewer", async () => {
+    const surface = await openPreview("/tmp/foo.md");
+    expect(surface.title).toBe("foo.md");
+    expect(surface.filePath).toBe("/tmp/foo.md");
+    expect(surface.element).toBeInstanceOf(HTMLElement);
+  });
+
+  it("file:// URL opens via the registered previewer", async () => {
+    const surface = await openPreview("file:///tmp/foo.md");
+    expect(surface.title).toBe("foo.md");
+    expect(surface.filePath).toBe("/tmp/foo.md");
+  });
+
+  it("https URL fetches and renders as markdown when content-type is text/markdown", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ "content-type": "text/markdown" }),
+      text: async () => "# Remote\n\nbody",
+    } as any);
+
+    const surface = await openPreview("https://example.com/notes");
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/notes", {
+      redirect: "follow",
+    });
+    expect(surface.title).toBe("notes");
+    // Markdown previewer rendered the content into the element
+    expect(surface.element.textContent).toContain("Remote");
+  });
+
+  it("https URL renders as markdown when path ends in .md regardless of content-type", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ "content-type": "text/plain" }),
+      text: async () => "# By extension",
+    } as any);
+
+    const surface = await openPreview("https://example.com/foo.md?ref=main");
+    expect(surface.title).toBe("foo.md");
+    expect(surface.element.textContent).toContain("By extension");
+  });
+
+  it("https URL with non-markdown content renders as code block", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ "content-type": "text/plain" }),
+      text: async () => "plain text body",
+    } as any);
+
+    const surface = await openPreview("https://example.com/raw.txt");
+    expect(surface.title).toBe("raw.txt");
+    expect(surface.element.textContent).toContain("plain text body");
+  });
+
+  it("https URL throws if fetch fails", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      headers: new Headers(),
+      text: async () => "",
+    } as any);
+
+    await expect(openPreview("https://example.com/missing.md")).rejects.toThrow(
+      /404/,
+    );
+  });
+
+  it("https URL throws if content-length exceeds cap", async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ "content-length": String(20 * 1024 * 1024) }),
+      text: async () => "",
+    } as any);
+
+    await expect(openPreview("https://example.com/huge.md")).rejects.toThrow(
+      /too large/i,
+    );
+  });
+});

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -18,7 +18,7 @@
   let selectedIdx = 0;
 
   $: filtered = query
-    ? commands.filter(c => c.name.toLowerCase().includes(query.toLowerCase()))
+    ? commands.filter((c) => c.name.toLowerCase().includes(query.toLowerCase()))
     : commands;
 
   $: if (filtered.length > 0 && selectedIdx >= filtered.length) {
@@ -40,10 +40,24 @@
 
   function handleKeydown(e: KeyboardEvent) {
     e.stopPropagation();
-    if (e.key === "Escape") { close(); return; }
-    if (e.key === "ArrowDown") { e.preventDefault(); selectedIdx = Math.min(selectedIdx + 1, filtered.length - 1); return; }
-    if (e.key === "ArrowUp") { e.preventDefault(); selectedIdx = Math.max(selectedIdx - 1, 0); return; }
-    if (e.key === "Enter" && filtered[selectedIdx]) { execute(filtered[selectedIdx]); return; }
+    if (e.key === "Escape") {
+      close();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIdx = Math.min(selectedIdx + 1, filtered.length - 1);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIdx = Math.max(selectedIdx - 1, 0);
+      return;
+    }
+    if (e.key === "Enter" && filtered[selectedIdx]) {
+      execute(filtered[selectedIdx]);
+      return;
+    }
   }
 
   function handleOverlayClick(e: MouseEvent) {
@@ -68,18 +82,22 @@
     on:mousedown={handleOverlayClick}
     on:keydown={handleKeydown}
   >
-    <div style="
+    <div
+      style="
       width: 500px; max-height: 400px; background: {$theme.bgFloat};
       border: 1px solid {$theme.border}; border-radius: 12px;
       box-shadow: 0 12px 40px rgba(0,0,0,0.6);
       display: flex; flex-direction: column; overflow: hidden;
-    ">
+    "
+    >
       <input
         bind:this={inputEl}
         type="text"
         placeholder="Type a command..."
         bind:value={query}
-        on:input={() => { selectedIdx = 0; }}
+        on:input={() => {
+          selectedIdx = 0;
+        }}
         style="
           padding: 14px 18px; background: transparent; border: none;
           border-bottom: 1px solid {$theme.border}; color: {$theme.fg};
@@ -94,15 +112,19 @@
             style="
               padding: 8px 18px; cursor: pointer; display: flex;
               align-items: center; justify-content: space-between;
-              background: {i === selectedIdx ? $theme.bgHighlight : 'transparent'};
+              background: {i === selectedIdx
+              ? $theme.bgHighlight
+              : 'transparent'};
               color: {$theme.fg}; font-size: 13px;
             "
-            on:mouseenter={() => selectedIdx = i}
+            on:mouseenter={() => (selectedIdx = i)}
             on:click={() => execute(cmd)}
           >
             <span>{cmd.name}</span>
             {#if cmd.shortcut}
-              <span style="font-size: 11px; color: {$theme.fgDim};">{cmd.shortcut}</span>
+              <span style="font-size: 11px; color: {$theme.fgDim};"
+                >{cmd.shortcut}</span
+              >
             {/if}
           </div>
         {/each}

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -47,7 +47,9 @@
   >
     {#each $contextMenu.items as item}
       {#if item.separator}
-        <div style="height: 1px; background: {$theme.border}; margin: 4px 8px;"></div>
+        <div
+          style="height: 1px; background: {$theme.border}; margin: 4px 8px;"
+        ></div>
       {:else}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -58,7 +60,11 @@
           style="
             padding: 6px 16px; cursor: {item.disabled ? 'default' : 'pointer'};
             display: flex; align-items: center; justify-content: space-between;
-            color: {item.disabled ? $theme.fgDim : item.danger ? $theme.danger : $theme.fg};
+            color: {item.disabled
+            ? $theme.fgDim
+            : item.danger
+              ? $theme.danger
+              : $theme.fg};
             opacity: {item.disabled ? '0.5' : '1'};
           "
           on:click|stopPropagation={() => {
@@ -71,7 +77,9 @@
             if (!item.disabled) {
               const el = e.currentTarget;
               if (el instanceof HTMLElement)
-                el.style.background = item.danger ? `color-mix(in srgb, ${$theme.danger} 20%, transparent)` : $theme.bgHighlight;
+                el.style.background = item.danger
+                  ? `color-mix(in srgb, ${$theme.danger} 20%, transparent)`
+                  : $theme.bgHighlight;
             }
           }}
           on:mouseleave={(e) => {
@@ -81,7 +89,10 @@
         >
           <span>{item.label}</span>
           {#if item.shortcut}
-            <span style="font-size: 11px; color: {$theme.fgDim}; margin-left: 24px;">{item.shortcut}</span>
+            <span
+              style="font-size: 11px; color: {$theme.fgDim}; margin-left: 24px;"
+              >{item.shortcut}</span
+            >
           {/if}
         </div>
       {/if}

--- a/src/lib/components/ExtensionSidebarSection.svelte
+++ b/src/lib/components/ExtensionSidebarSection.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { theme } from "../stores/theme";
-  import type { SidebarItem, SidebarSection } from "../stores/extension-sidebar";
+  import type {
+    SidebarItem,
+    SidebarSection,
+  } from "../stores/extension-sidebar";
   import { pushEvent } from "../services/mcp-event-buffer";
 
   export let section: SidebarSection;
@@ -23,7 +26,10 @@
     });
   }
 
-  function flatten(items: SidebarItem[], depth: number): Array<SidebarItem & { depth: number }> {
+  function flatten(
+    items: SidebarItem[],
+    depth: number,
+  ): Array<SidebarItem & { depth: number }> {
     const out: Array<SidebarItem & { depth: number }> = [];
     for (const item of items) {
       out.push({ ...item, depth });
@@ -53,7 +59,9 @@
         on:click={() => handleClick(item)}
       >
         {#if item.icon}
-          <span class="extension-section-icon" aria-hidden="true">{item.icon}</span>
+          <span class="extension-section-icon" aria-hidden="true"
+            >{item.icon}</span
+          >
         {/if}
         <span class="extension-section-label">{item.label}</span>
       </button>

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -47,11 +47,18 @@
     inputEl?.select();
   }
 
-  export function findNext() { doSearch("next"); }
-  export function findPrev() { doSearch("prev"); }
+  export function findNext() {
+    doSearch("next");
+  }
+  export function findPrev() {
+    doSearch("prev");
+  }
 
   $: if ($findBarVisible && inputEl) {
-    tick().then(() => { inputEl?.focus(); inputEl?.select(); });
+    tick().then(() => {
+      inputEl?.focus();
+      inputEl?.select();
+    });
   }
 </script>
 
@@ -86,21 +93,48 @@
       on:click={() => doSearch("prev")}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="12,10 8,6 4,10"/></svg>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"><polyline points="12,10 8,6 4,10" /></svg
+      >
     </button>
     <button
       title="Next match (⌘G)"
       on:click={() => doSearch("next")}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4,6 8,10 12,6"/></svg>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"><polyline points="4,6 8,10 12,6" /></svg
+      >
     </button>
     <button
       title="Close (Esc)"
       on:click={close}
       style="background: none; border: none; color: {$theme.fgMuted}; cursor: pointer; padding: 2px 4px; border-radius: 3px; display: flex; align-items: center;"
     >
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        ><line x1="4" y1="4" x2="12" y2="12" /><line
+          x1="12"
+          y1="4"
+          x2="4"
+          y2="12"
+        /></svg
+      >
     </button>
   </div>
 {/if}

--- a/src/lib/components/InputPrompt.svelte
+++ b/src/lib/components/InputPrompt.svelte
@@ -20,12 +20,21 @@
 
   function handleKeydown(e: KeyboardEvent) {
     e.stopPropagation();
-    if (e.key === "Enter") { e.preventDefault(); submit(); }
-    if (e.key === "Escape") { e.preventDefault(); cancel(); }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancel();
+    }
   }
 
   $: if ($inputPrompt) {
-    tick().then(() => { inputEl?.focus(); inputEl?.select(); });
+    tick().then(() => {
+      inputEl?.focus();
+      inputEl?.select();
+    });
   }
 </script>
 
@@ -67,15 +76,15 @@
           style="
             padding: 6px 16px; border-radius: 6px; border: 1px solid {$theme.border};
             background: transparent; color: {$theme.fgMuted}; cursor: pointer; font-size: 13px;
-          "
-        >Cancel</button>
+          ">Cancel</button
+        >
         <button
           on:click={submit}
           style="
             padding: 6px 16px; border-radius: 6px; border: none;
             background: {$theme.accent}; color: white; cursor: pointer; font-size: 13px;
-          "
-        >OK</button>
+          ">OK</button
+        >
       </div>
     </div>
   </div>

--- a/src/lib/components/PaneView.svelte
+++ b/src/lib/components/PaneView.svelte
@@ -15,16 +15,22 @@
   export let onSplitDown: () => void;
   export let onClosePane: () => void;
   export let onFocusPane: () => void;
-  export let onReorderTab: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  export let onReorderTab:
+    | ((fromIdx: number, toIdx: number) => void)
+    | undefined = undefined;
 
   let paneEl: HTMLElement;
   let resizeObserver: ResizeObserver;
   let resizeTimer: ReturnType<typeof setTimeout> | null = null;
 
   function fitActiveTerminal() {
-    const active = pane.surfaces.find(s => s.id === pane.activeSurfaceId);
+    const active = pane.surfaces.find((s) => s.id === pane.activeSurfaceId);
     if (active && isTerminalSurface(active)) {
-      try { active.fitAddon.fit(); } catch (e) { console.warn("fitAddon.fit() failed on resize:", e); }
+      try {
+        active.fitAddon.fit();
+      } catch (e) {
+        console.warn("fitAddon.fit() failed on resize:", e);
+      }
     }
   }
 
@@ -68,7 +74,11 @@
 
   {#each pane.surfaces as surface (surface.id)}
     {#if isTerminalSurface(surface)}
-      <TerminalSurface {surface} visible={surface.id === pane.activeSurfaceId} cwd={surface.cwd} />
+      <TerminalSurface
+        {surface}
+        visible={surface.id === pane.activeSurfaceId}
+        cwd={surface.cwd}
+      />
     {:else if isPreviewSurface(surface)}
       <PreviewSurface {surface} visible={surface.id === pane.activeSurfaceId} />
     {/if}

--- a/src/lib/components/PreviewSurface.svelte
+++ b/src/lib/components/PreviewSurface.svelte
@@ -29,5 +29,7 @@
 
 <div
   bind:this={container}
-  style="flex: 1; min-height: 0; overflow-y: auto; display: {visible ? 'flex' : 'none'}; flex-direction: column;"
+  style="flex: 1; min-height: 0; overflow-y: auto; display: {visible
+    ? 'flex'
+    : 'none'}; flex-direction: column;"
 ></div>

--- a/src/lib/components/PrimarySidebar.svelte
+++ b/src/lib/components/PrimarySidebar.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { theme } from "../stores/theme";
-  import { primarySidebarVisible, primarySidebarWidth, contextMenu } from "../stores/ui";
+  import {
+    primarySidebarVisible,
+    primarySidebarWidth,
+    contextMenu,
+  } from "../stores/ui";
   import { dragResize } from "../actions/drag-resize";
   import { workspaces, activeWorkspaceIdx } from "../stores/workspace";
   import { primarySections } from "../stores/extension-sidebar";
@@ -28,8 +32,19 @@
 
   function showWorkspaceContextMenu(x: number, y: number, idx: number) {
     const items: MenuItem[] = [
-      { label: "Rename Workspace", shortcut: "⇧⌘R", action: () => startRename(idx) },
-      { label: "New Surface", shortcut: "⌘T", action: () => { onSwitchWorkspace(idx); onNewSurface(); } },
+      {
+        label: "Rename Workspace",
+        shortcut: "⇧⌘R",
+        action: () => startRename(idx),
+      },
+      {
+        label: "New Surface",
+        shortcut: "⌘T",
+        action: () => {
+          onSwitchWorkspace(idx);
+          onNewSurface();
+        },
+      },
       { label: "", action: () => {}, separator: true },
       {
         label: "Close Other Workspaces",
@@ -50,7 +65,6 @@
     ];
     contextMenu.set({ x, y, items });
   }
-
 </script>
 
 {#if $primarySidebarVisible}
@@ -64,65 +78,73 @@
       flex-shrink: 0;
     "
   >
-  <div style="flex: 1; display: flex; flex-direction: column; overflow: hidden;">
-    <!-- Top row: controls + drag region for window chrome -->
     <div
-      data-tauri-drag-region=""
-      style="
+      style="flex: 1; display: flex; flex-direction: column; overflow: hidden;"
+    >
+      <!-- Top row: controls + drag region for window chrome -->
+      <div
+        data-tauri-drag-region=""
+        style="
         height: 38px; flex-shrink: 0; display: flex; align-items: center;
         justify-content: flex-end; padding: 0 6px;
         -webkit-app-region: drag;
       "
-    >
-      <button
-        title="New Workspace (⌘N)"
-        style="
+      >
+        <button
+          title="New Workspace (⌘N)"
+          style="
           background: none; border: none; cursor: pointer;
           width: 26px; height: 26px; border-radius: 4px;
           display: flex; align-items: center; justify-content: center;
           color: {$theme.fgDim}; font-size: 18px; line-height: 1;
           -webkit-app-region: no-drag;
         "
-        on:click={onNewWorkspace}
-      >+</button>
-    </div>
+          on:click={onNewWorkspace}>+</button
+        >
+      </div>
 
-    <!-- Workspace list (always first) + extension sections -->
-    <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
-      {#each $workspaces as ws, idx (ws.id)}
-        <WorkspaceItem
-          bind:this={workspaceItems[ws.id]}
-          workspace={ws}
-          index={idx}
-          isActive={idx === $activeWorkspaceIdx}
-          onSelect={() => onSwitchWorkspace(idx)}
-          onClose={() => onCloseWorkspace(idx)}
-          onRename={(name) => onRenameWorkspace(idx, name)}
-          onContextMenu={(x, y) => showWorkspaceContextMenu(x, y, idx)}
-          onReorder={onReorderWorkspaces}
-        />
-      {/each}
-      {#each $primarySections as section (section.sectionId)}
-        <ExtensionSidebarSection {section} />
-      {/each}
+      <!-- Workspace list (always first) + extension sections -->
+      <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
+        {#each $workspaces as ws, idx (ws.id)}
+          <WorkspaceItem
+            bind:this={workspaceItems[ws.id]}
+            workspace={ws}
+            index={idx}
+            isActive={idx === $activeWorkspaceIdx}
+            onSelect={() => onSwitchWorkspace(idx)}
+            onClose={() => onCloseWorkspace(idx)}
+            onRename={(name) => onRenameWorkspace(idx, name)}
+            onContextMenu={(x, y) => showWorkspaceContextMenu(x, y, idx)}
+            onReorder={onReorderWorkspaces}
+          />
+        {/each}
+        {#each $primarySections as section (section.sectionId)}
+          <ExtensionSidebarSection {section} />
+        {/each}
+      </div>
     </div>
-  </div>
-  <div
-    class="sidebar-resize-handle"
-    style="
+    <div
+      class="sidebar-resize-handle"
+      style="
       width: 4px; cursor: col-resize; flex-shrink: 0;
       background: {dragging ? $theme.accent : $theme.sidebarBorder};
       transition: background 0.15s;
     "
-    use:dragResize={{
-      onDrag: (ev) => {
-        const maxWidth = window.innerWidth * 0.33;
-        primarySidebarWidth.set(Math.max(140, Math.min(maxWidth, ev.clientX)));
-      },
-      onStart: () => { dragging = true; },
-      onEnd: () => { dragging = false; },
-    }}
-  ></div>
+      use:dragResize={{
+        onDrag: (ev) => {
+          const maxWidth = window.innerWidth * 0.33;
+          primarySidebarWidth.set(
+            Math.max(140, Math.min(maxWidth, ev.clientX)),
+          );
+        },
+        onStart: () => {
+          dragging = true;
+        },
+        onEnd: () => {
+          dragging = false;
+        },
+      }}
+    ></div>
   </div>
 {/if}
 

--- a/src/lib/components/SecondarySidebar.svelte
+++ b/src/lib/components/SecondarySidebar.svelte
@@ -19,64 +19,76 @@
       flex-shrink: 0;
     "
   >
-  <div
-    class="sidebar-resize-handle"
-    style="
+    <div
+      class="sidebar-resize-handle"
+      style="
       width: 4px; cursor: col-resize; flex-shrink: 0;
       background: {dragging ? $theme.accent : $theme.sidebarBorder};
       transition: background 0.15s;
     "
-    use:dragResize={{
-      onDrag: (ev) => {
-        const maxWidth = window.innerWidth * 0.33;
-        secondarySidebarWidth.set(Math.max(140, Math.min(maxWidth, window.innerWidth - ev.clientX)));
-      },
-      onStart: () => { dragging = true; },
-      onEnd: () => { dragging = false; },
-    }}
-  ></div>
-  <div style="flex: 1; display: flex; flex-direction: column; overflow: hidden;">
-    <!-- Top row: tab bar -->
+      use:dragResize={{
+        onDrag: (ev) => {
+          const maxWidth = window.innerWidth * 0.33;
+          secondarySidebarWidth.set(
+            Math.max(140, Math.min(maxWidth, window.innerWidth - ev.clientX)),
+          );
+        },
+        onStart: () => {
+          dragging = true;
+        },
+        onEnd: () => {
+          dragging = false;
+        },
+      }}
+    ></div>
     <div
-      data-tauri-drag-region=""
-      style="
+      style="flex: 1; display: flex; flex-direction: column; overflow: hidden;"
+    >
+      <!-- Top row: tab bar -->
+      <div
+        data-tauri-drag-region=""
+        style="
         height: 38px; display: flex; align-items: center;
         border-bottom: 1px solid {$theme.border};
         padding: 0 6px;
         overflow-x: auto; scrollbar-width: none;
         -webkit-app-region: drag;
       "
-    >
-      <!-- Tab area (scrollable, future tabs go here) -->
-    </div>
+      >
+        <!-- Tab area (scrollable, future tabs go here) -->
+      </div>
 
-    <!-- Control row: extension-supplied quick actions (only rendered when populated) -->
-    {#if $$slots.controls}
-      <div
-        id="secondary-sidebar-controls"
-        style="
+      <!-- Control row: extension-supplied quick actions (only rendered when populated) -->
+      {#if $$slots.controls}
+        <div
+          id="secondary-sidebar-controls"
+          style="
           height: 28px; display: flex; align-items: center; gap: 2px;
           padding: 0 6px; flex-shrink: 0;
           background: {$theme.tabBarBg}; border-bottom: 1px solid {$theme.tabBarBorder};
         "
-      >
-        <slot name="controls" />
-      </div>
-    {/if}
-
-    <!-- Content area: extension-declared sections or placeholder -->
-    <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
-      {#if $secondarySections.length === 0}
-        <div style="display: flex; align-items: center; justify-content: center; padding: 16px 8px;">
-          <span style="color: {$theme.fgDim}; font-size: 12px;">No Secondary Sidebar Content</span>
+        >
+          <slot name="controls" />
         </div>
-      {:else}
-        {#each $secondarySections as section (section.sectionId)}
-          <ExtensionSidebarSection {section} />
-        {/each}
       {/if}
+
+      <!-- Content area: extension-declared sections or placeholder -->
+      <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
+        {#if $secondarySections.length === 0}
+          <div
+            style="display: flex; align-items: center; justify-content: center; padding: 16px 8px;"
+          >
+            <span style="color: {$theme.fgDim}; font-size: 12px;"
+              >No Secondary Sidebar Content</span
+            >
+          </div>
+        {:else}
+          {#each $secondarySections as section (section.sectionId)}
+            <ExtensionSidebarSection {section} />
+          {/each}
+        {/if}
+      </div>
     </div>
-  </div>
   </div>
 {/if}
 

--- a/src/lib/components/SplitNodeView.svelte
+++ b/src/lib/components/SplitNodeView.svelte
@@ -14,7 +14,9 @@
   export let onSplitDown: (paneId: string) => void;
   export let onClosePane: (paneId: string) => void;
   export let onFocusPane: (paneId: string) => void;
-  export let onReorderTab: ((paneId: string, fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  export let onReorderTab:
+    | ((paneId: string, fromIdx: number, toIdx: number) => void)
+    | undefined = undefined;
 
   let dragging = false;
   let dragRect: DOMRect | null = null;
@@ -23,7 +25,9 @@
     onStart: (e: MouseEvent) => {
       if (node.type !== "split") return false;
       dragging = true;
-      dragRect = (e.target as HTMLElement).parentElement!.getBoundingClientRect();
+      dragRect = (
+        e.target as HTMLElement
+      ).parentElement!.getBoundingClientRect();
     },
     onDrag: (ev: MouseEvent) => {
       if (node.type !== "split" || !dragRect) return;
@@ -50,14 +54,20 @@
     onSplitDown={() => onSplitDown(node.pane.id)}
     onClosePane={() => onClosePane(node.pane.id)}
     onFocusPane={() => onFocusPane(node.pane.id)}
-    onReorderTab={onReorderTab ? (from, to) => onReorderTab!(node.pane.id, from, to) : undefined}
+    onReorderTab={onReorderTab
+      ? (from, to) => onReorderTab!(node.pane.id, from, to)
+      : undefined}
   />
 {:else}
-  <div style="
+  <div
+    style="
     display: flex; flex: 1; min-width: 0; min-height: 0; gap: 0;
     flex-direction: {node.direction === 'vertical' ? 'column' : 'row'};
-  ">
-    <div style="flex: {node.ratio}; display: flex; min-width: 0; min-height: 0;">
+  "
+  >
+    <div
+      style="flex: {node.ratio}; display: flex; min-width: 0; min-height: 0;"
+    >
       <SplitNodeView
         node={node.children[0]}
         {workspace}
@@ -74,14 +84,19 @@
     <div
       class="split-divider"
       style="
-        {node.direction === 'vertical' ? 'height: 6px; cursor: row-resize;' : 'width: 6px; cursor: col-resize;'}
+        {node.direction === 'vertical'
+        ? 'height: 6px; cursor: row-resize;'
+        : 'width: 6px; cursor: col-resize;'}
         background: {dragging ? $theme.accent : $theme.border};
         flex-shrink: 0;
         transition: background 0.15s;
       "
       use:dragResize={splitDragOptions}
     ></div>
-    <div style="flex: {1 - node.ratio}; display: flex; min-width: 0; min-height: 0;">
+    <div
+      style="flex: {1 -
+        node.ratio}; display: flex; min-width: 0; min-height: 0;"
+    >
       <SplitNodeView
         node={node.children[1]}
         {workspace}

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -7,7 +7,8 @@
   export let isActive: boolean;
   export let onSelect: () => void;
   export let onClose: () => void;
-  export let onReorder: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  export let onReorder: ((fromIdx: number, toIdx: number) => void) | undefined =
+    undefined;
 
   let hovered = false;
   let closeHovered = false;
@@ -36,22 +37,28 @@
   style="
     padding: 2px 10px; font-size: 11px; cursor: pointer;
     color: {isActive ? $theme.fg : $theme.fgMuted};
-    background: {isActive ? $theme.bgActive : hovered ? $theme.bgHighlight : 'transparent'};
+    background: {isActive
+    ? $theme.bgActive
+    : hovered
+      ? $theme.bgHighlight
+      : 'transparent'};
     border-bottom: 2px solid {isActive ? $theme.accent : 'transparent'};
     border-radius: 4px 4px 0 0; white-space: nowrap;
     display: flex; align-items: center; gap: 4px;
     {dragOver ? `outline: 1px solid ${$theme.accent};` : ''}
   "
   on:click={onSelect}
-  on:mouseenter={() => hovered = true}
-  on:mouseleave={() => hovered = false}
+  on:mouseenter={() => (hovered = true)}
+  on:mouseleave={() => (hovered = false)}
   on:dragstart={handleDragStart}
-  on:dragover|preventDefault={() => dragOver = true}
-  on:dragleave={() => dragOver = false}
+  on:dragover|preventDefault={() => (dragOver = true)}
+  on:dragleave={() => (dragOver = false)}
   on:drop={handleDrop}
 >
   {#if surface.hasUnread && !isActive}
-    <span style="width: 5px; height: 5px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"></span>
+    <span
+      style="width: 5px; height: 5px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"
+    ></span>
   {/if}
   <span style="overflow: hidden; text-overflow: ellipsis;">
     {surface.title || `Shell ${index + 1}`}
@@ -60,11 +67,15 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <span
     style="
-      color: {closeHovered ? $theme.danger : $theme.fgDim}; font-size: 13px; cursor: pointer;
-      margin-left: 4px; visibility: {isActive || hovered ? 'visible' : 'hidden'};
+      color: {closeHovered
+      ? $theme.danger
+      : $theme.fgDim}; font-size: 13px; cursor: pointer;
+      margin-left: 4px; visibility: {isActive || hovered
+      ? 'visible'
+      : 'hidden'};
     "
     on:click|stopPropagation={onClose}
-    on:mouseenter={() => closeHovered = true}
-    on:mouseleave={() => closeHovered = false}
-  >×</span>
+    on:mouseenter={() => (closeHovered = true)}
+    on:mouseleave={() => (closeHovered = false)}>×</span
+  >
 </div>

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -10,7 +10,9 @@
   export let onSplitRight: () => void;
   export let onSplitDown: () => void;
   export let onClosePane: () => void;
-  export let onReorderTab: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  export let onReorderTab:
+    | ((fromIdx: number, toIdx: number) => void)
+    | undefined = undefined;
 </script>
 
 <div
@@ -37,12 +39,14 @@
   <span
     title="New surface (⌘T)"
     style="color: {$theme.fgDim}; cursor: pointer; font-size: 14px; padding: 0 6px;"
-    on:click={onNewSurface}
-  >+</span>
+    on:click={onNewSurface}>+</span
+  >
 
   <div style="flex: 1;"></div>
 
-  <div style="display: flex; align-items: center; gap: 2px; padding-right: 2px;">
+  <div
+    style="display: flex; align-items: center; gap: 2px; padding-right: 2px;"
+  >
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <span
@@ -50,7 +54,20 @@
       style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onSplitRight}
     >
-      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="12" height="12" rx="1"/><line x1="7" y1="1" x2="7" y2="13"/></svg>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        ><rect x="1" y="1" width="12" height="12" rx="1" /><line
+          x1="7"
+          y1="1"
+          x2="7"
+          y2="13"
+        /></svg
+      >
     </span>
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -59,7 +76,20 @@
       style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onSplitDown}
     >
-      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="1" width="12" height="12" rx="1"/><line x1="1" y1="7" x2="13" y2="7"/></svg>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        ><rect x="1" y="1" width="12" height="12" rx="1" /><line
+          x1="1"
+          y1="7"
+          x2="13"
+          y2="7"
+        /></svg
+      >
     </span>
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -68,7 +98,21 @@
       style="color: {$theme.fgDim}; cursor: pointer; width: 24px; height: 24px; border-radius: 4px; display: flex; align-items: center; justify-content: center;"
       on:click|stopPropagation={onClosePane}
     >
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="2" y1="2" x2="10" y2="10"/><line x1="10" y1="2" x2="2" y2="10"/></svg>
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 12 12"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        ><line x1="2" y1="2" x2="10" y2="10" /><line
+          x1="10"
+          y1="2"
+          x2="2"
+          y2="10"
+        /></svg
+      >
     </span>
   </div>
 </div>

--- a/src/lib/components/TerminalSurface.svelte
+++ b/src/lib/components/TerminalSurface.svelte
@@ -34,7 +34,9 @@
     dragOver = false;
     const files = e.dataTransfer?.files;
     if (!files || files.length === 0 || surface.ptyId < 0) return;
-    const paths = Array.from(files).map(f => shellEscape((f as any).path || f.name));
+    const paths = Array.from(files).map((f) =>
+      shellEscape((f as any).path || f.name),
+    );
     invoke("write_pty", { ptyId: surface.ptyId, data: paths.join(" ") });
   }
 
@@ -45,16 +47,21 @@
       surface.terminal.open(surface.termElement);
 
       await tick();
-      await new Promise(r => requestAnimationFrame(r));
+      await new Promise((r) => requestAnimationFrame(r));
 
-      try { surface.fitAddon.fit(); } catch (e) { console.warn("fitAddon.fit() failed on mount:", e); }
+      try {
+        surface.fitAddon.fit();
+      } catch (e) {
+        console.warn("fitAddon.fit() failed on mount:", e);
+      }
       await connectPty(surface, cwd);
 
       // Send startup command after PTY is connected (not on a timer)
       if (surface.startupCommand && surface.ptyId >= 0) {
-        invoke("write_pty", { ptyId: surface.ptyId, data: `${surface.startupCommand}\n` }).catch((e) =>
-          console.warn("Failed to send startup command:", e)
-        );
+        invoke("write_pty", {
+          ptyId: surface.ptyId,
+          data: `${surface.startupCommand}\n`,
+        }).catch((e) => console.warn("Failed to send startup command:", e));
         surface.startupCommand = undefined;
       }
 
@@ -85,11 +92,14 @@
     }
 
     // Tauri native file drop (more reliable than HTML5 on Linux WebKitGTK)
-    unlistenDragDrop = await listen<{ paths: string[]; position: { x: number; y: number } }>("tauri://drag-drop", (event) => {
+    unlistenDragDrop = await listen<{
+      paths: string[];
+      position: { x: number; y: number };
+    }>("tauri://drag-drop", (event) => {
       if (!visible || surface.ptyId < 0) return;
       const { paths } = event.payload;
       if (paths.length > 0) {
-        const escaped = paths.map(p => shellEscape(p)).join(" ");
+        const escaped = paths.map((p) => shellEscape(p)).join(" ");
         invoke("write_pty", { ptyId: surface.ptyId, data: escaped });
       }
     });
@@ -104,7 +114,9 @@
       try {
         surface.fitAddon.fit();
         surface.terminal.scrollToBottom();
-      } catch (e) { console.warn("fitAddon.fit() failed on visibility change:", e); }
+      } catch (e) {
+        console.warn("fitAddon.fit() failed on visibility change:", e);
+      }
     });
   }
 </script>
@@ -115,5 +127,9 @@
   on:dragover={handleDragOver}
   on:dragleave={handleDragLeave}
   on:drop={handleDrop}
-  style="flex: 1; min-height: 0; min-width: 0; overflow: hidden; display: {visible ? 'flex' : 'none'}; flex-direction: column; {dragOver ? `box-shadow: inset 0 0 0 2px ${$theme.accent}; border-radius: 4px;` : ''}"
+  style="flex: 1; min-height: 0; min-width: 0; overflow: hidden; display: {visible
+    ? 'flex'
+    : 'none'}; flex-direction: column; {dragOver
+    ? `box-shadow: inset 0 0 0 2px ${$theme.accent}; border-radius: 4px;`
+    : ''}"
 ></div>

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -23,25 +23,59 @@
   "
 >
   <button
-    style="{btnStyle} color: {$primarySidebarVisible ? $theme.fg : $theme.fgDim};"
+    style="{btnStyle} color: {$primarySidebarVisible
+      ? $theme.fg
+      : $theme.fgDim};"
     title="Toggle Primary Sidebar (⌘B)"
-    on:click={() => primarySidebarVisible.update(v => !v)}
+    on:click={() => primarySidebarVisible.update((v) => !v)}
   >
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="2" width="14" height="12" rx="1.5"/><line x1="5.5" y1="2" x2="5.5" y2="14"/></svg>
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      ><rect x="1" y="2" width="14" height="12" rx="1.5" /><line
+        x1="5.5"
+        y1="2"
+        x2="5.5"
+        y2="14"
+      /></svg
+    >
   </button>
 
-  <div style="flex: 1; display: flex; justify-content: center; pointer-events: none;">
-    <span style="
+  <div
+    style="flex: 1; display: flex; justify-content: center; pointer-events: none;"
+  >
+    <span
+      style="
       font-size: 11px; font-weight: 600; letter-spacing: 1.5px;
       color: {$theme.fgDim};
-    ">GNARTERM</span>
+    ">GNARTERM</span
+    >
   </div>
 
   <button
-    style="{btnStyle} color: {$secondarySidebarVisible ? $theme.fg : $theme.fgDim};"
+    style="{btnStyle} color: {$secondarySidebarVisible
+      ? $theme.fg
+      : $theme.fgDim};"
     title="Toggle Secondary Sidebar"
-    on:click={() => secondarySidebarVisible.update(v => !v)}
+    on:click={() => secondarySidebarVisible.update((v) => !v)}
   >
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="1" y="2" width="14" height="12" rx="1.5"/><line x1="10.5" y1="2" x2="10.5" y2="14"/></svg>
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      ><rect x="1" y="2" width="14" height="12" rx="1.5" /><line
+        x1="10.5"
+        y1="2"
+        x2="10.5"
+        y2="14"
+      /></svg
+    >
   </button>
 </div>

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -8,8 +8,68 @@
   import { getAllPanes, getAllSurfaces } from "../types";
   import type { MenuItem } from "../context-menu-types";
 
-  const discoEmojis = ["✨","🦄","🌈","💜","🪩","⚡","💫","🔮","🎀","💎","🌸","🍭","🫧","💗","🦋","🎠","🧚","💖","🌺","🎵","🩵","🪻","🎪","🧸","🌟","💐","🩷","🏄","🐬","🌊","🎨","🧜","🫶","💕","🌙","🐾","🍬","🎶","🌻","🐱","💝","🎈","🪼","🦩","🫀","🧁","🍩","🎯"];
-  const discoColors = ["#e91e63","#c026d3","#2979ff","#00bfa5","#ff4081","#e040fb","#448aff","#1de9b6","#ff9100","#18ffff"];
+  const discoEmojis = [
+    "✨",
+    "🦄",
+    "🌈",
+    "💜",
+    "🪩",
+    "⚡",
+    "💫",
+    "🔮",
+    "🎀",
+    "💎",
+    "🌸",
+    "🍭",
+    "🫧",
+    "💗",
+    "🦋",
+    "🎠",
+    "🧚",
+    "💖",
+    "🌺",
+    "🎵",
+    "🩵",
+    "🪻",
+    "🎪",
+    "🧸",
+    "🌟",
+    "💐",
+    "🩷",
+    "🏄",
+    "🐬",
+    "🌊",
+    "🎨",
+    "🧜",
+    "🫶",
+    "💕",
+    "🌙",
+    "🐾",
+    "🍬",
+    "🎶",
+    "🌻",
+    "🐱",
+    "💝",
+    "🎈",
+    "🪼",
+    "🦩",
+    "🫀",
+    "🧁",
+    "🍩",
+    "🎯",
+  ];
+  const discoColors = [
+    "#e91e63",
+    "#c026d3",
+    "#2979ff",
+    "#00bfa5",
+    "#ff4081",
+    "#e040fb",
+    "#448aff",
+    "#1de9b6",
+    "#ff9100",
+    "#18ffff",
+  ];
 
   // Stable emoji per workspace based on id hash
   function discoEmojiFor(id: string): string {
@@ -39,10 +99,10 @@
   let dragOver = false;
 
   $: allSurfaces = getAllSurfaces(workspace);
-  $: hasUnread = allSurfaces.some(s => s.hasUnread);
+  $: hasUnread = allSurfaces.some((s) => s.hasUnread);
   $: paneCount = getAllPanes(workspace.splitRoot).length;
   $: surfaceCount = allSurfaces.length;
-  $: latestNotification = allSurfaces.find(s => s.notification)?.notification;
+  $: latestNotification = allSurfaces.find((s) => s.notification)?.notification;
   $: metaParts = [
     ...(paneCount > 1 ? [`${paneCount}p`] : []),
     ...(surfaceCount > 1 ? [`${surfaceCount}s`] : []),
@@ -95,14 +155,20 @@
 <div
   draggable="true"
   style="
-    margin: {dragOver ? '24px' : '2px'} 8px 2px 8px; border-radius: 6px; overflow: hidden;
-    background: {isActive ? $theme.bgActive : hovered ? $theme.bgHighlight : 'transparent'};
+    margin: {dragOver
+    ? '24px'
+    : '2px'} 8px 2px 8px; border-radius: 6px; overflow: hidden;
+    background: {isActive
+    ? $theme.bgActive
+    : hovered
+      ? $theme.bgHighlight
+      : 'transparent'};
     border-left: 3px solid {isActive ? $theme.accent : 'transparent'};
     transition: margin 0.15s, opacity 0.15s;
   "
   on:dragstart={handleDragStart}
-  on:dragover|preventDefault={() => dragOver = true}
-  on:dragleave={() => dragOver = false}
+  on:dragover|preventDefault={() => (dragOver = true)}
+  on:dragleave={() => (dragOver = false)}
   on:drop={handleDrop}
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -110,53 +176,77 @@
     style="padding: 8px 12px; cursor: pointer; display: flex; align-items: center; gap: 8px;"
     on:click={onSelect}
     on:contextmenu|preventDefault={(e) => onContextMenu(e.clientX, e.clientY)}
-    on:mouseenter={() => hovered = true}
-    on:mouseleave={() => { hovered = false; closeHovered = false; }}
+    on:mouseenter={() => (hovered = true)}
+    on:mouseleave={() => {
+      hovered = false;
+      closeHovered = false;
+    }}
   >
     <div style="flex: 1; overflow: hidden; display: flex; align-items: center;">
       <span
         bind:this={nameEl}
         style="
           font-weight: {isActive ? '600' : '400'};
-          color: {isDisco ? discoColorFor(workspace.id) : isActive ? $theme.fg : $theme.fgMuted};
+          color: {isDisco
+          ? discoColorFor(workspace.id)
+          : isActive
+            ? $theme.fg
+            : $theme.fgMuted};
           font-size: 13px; overflow: hidden;
           text-overflow: ellipsis; white-space: nowrap;
           outline: none; padding: 2px 4px; margin-left: -4px; border-radius: 4px;
         "
         on:blur={finishRename}
         on:keydown={(e) => {
-          if (e.key === "Enter") { e.preventDefault(); nameEl.blur(); }
-          if (e.key === "Escape") { e.preventDefault(); nameEl.textContent = workspace.name; nameEl.blur(); }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            nameEl.blur();
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            nameEl.textContent = workspace.name;
+            nameEl.blur();
+          }
         }}
-      >{#if isDisco}{discoEmojiFor(workspace.id)} {/if}{workspace.name}</span>
+        >{#if isDisco}{discoEmojiFor(workspace.id)}
+        {/if}{workspace.name}</span
+      >
     </div>
 
     {#if metaParts.length > 0}
-      <span style="font-size: 10px; color: {$theme.fgDim}; background: {$theme.bgSurface}; padding: 1px 5px; border-radius: 8px;">
+      <span
+        style="font-size: 10px; color: {$theme.fgDim}; background: {$theme.bgSurface}; padding: 1px 5px; border-radius: 8px;"
+      >
         {metaParts.join(" ")}
       </span>
     {/if}
 
     {#if hasUnread}
-      <span style="width: 8px; height: 8px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"></span>
+      <span
+        style="width: 8px; height: 8px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"
+      ></span>
     {/if}
 
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <span
       title="Close Workspace (⇧⌘W)"
       style="
-        color: {closeHovered ? $theme.danger : $theme.fgDim}; font-size: 14px; cursor: pointer;
+        color: {closeHovered
+        ? $theme.danger
+        : $theme.fgDim}; font-size: 14px; cursor: pointer;
         opacity: {hovered ? '1' : '0'}; transition: opacity 0.15s;
         padding: 0 2px; flex-shrink: 0;
       "
       on:click|stopPropagation={onClose}
-      on:mouseenter={() => closeHovered = true}
-      on:mouseleave={() => closeHovered = false}
-    >×</span>
+      on:mouseenter={() => (closeHovered = true)}
+      on:mouseleave={() => (closeHovered = false)}>×</span
+    >
   </div>
 
   {#if latestNotification}
-    <div style="padding: 2px 12px 6px; font-size: 11px; color: {$theme.notify}; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+    <div
+      style="padding: 2px 12px 6px; font-size: 11px; color: {$theme.notify}; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+    >
       {latestNotification}
     </div>
   {/if}

--- a/src/lib/components/WorkspaceView.svelte
+++ b/src/lib/components/WorkspaceView.svelte
@@ -11,10 +11,16 @@
   export let onSplitDown: (paneId: string) => void;
   export let onClosePane: (paneId: string) => void;
   export let onFocusPane: (paneId: string) => void;
-  export let onReorderTab: ((paneId: string, fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  export let onReorderTab:
+    | ((paneId: string, fromIdx: number, toIdx: number) => void)
+    | undefined = undefined;
 </script>
 
-<div style="flex: 1; display: flex; min-height: 0; min-width: 0; {visible ? '' : 'display: none;'}">
+<div
+  style="flex: 1; display: flex; min-height: 0; min-width: 0; {visible
+    ? ''
+    : 'display: none;'}"
+>
   <SplitNodeView
     node={workspace.splitRoot}
     {workspace}

--- a/src/preview/index.ts
+++ b/src/preview/index.ts
@@ -1,6 +1,6 @@
 /**
  * Preview System — modular file preview in tabs
- * 
+ *
  * Each previewer registers file extensions it handles.
  * Usage: const surface = await openPreview("/path/to/file.md");
  */
@@ -35,19 +35,49 @@ export function registerPreviewer(previewer: Previewer) {
 
 export function canPreview(filePath: string): boolean {
   const ext = getExtension(filePath);
-  return previewers.some(p => p.extensions.includes(ext));
+  return previewers.some((p) => p.extensions.includes(ext));
 }
 
 export function getSupportedExtensions(): string[] {
-  return previewers.flatMap(p => p.extensions);
+  return previewers.flatMap((p) => p.extensions);
+}
+
+// --- Target parsing ---
+
+/** A `gnar-term preview <target>` argument, after dispatching by scheme.
+ *  Local paths and `file://` URLs become "path"; `http(s)://` become "url". */
+export type PreviewTarget =
+  | { kind: "path"; path: string }
+  | { kind: "url"; url: string };
+
+export function parsePreviewTarget(input: string): PreviewTarget {
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    return { kind: "url", url: input };
+  }
+  if (input.startsWith("file://")) {
+    // Strip scheme; decode percent-encoding for non-ASCII paths
+    return {
+      kind: "path",
+      path: decodeURIComponent(input.slice("file://".length)),
+    };
+  }
+  return { kind: "path", path: input };
 }
 
 // --- Open a preview surface ---
 
-export async function openPreview(filePath: string): Promise<PreviewSurface> {
+export async function openPreview(target: string): Promise<PreviewSurface> {
+  const parsed = parsePreviewTarget(target);
+  if (parsed.kind === "url") {
+    return openPreviewFromUrl(parsed.url);
+  }
+  return openPreviewFromPath(parsed.path);
+}
+
+async function openPreviewFromPath(filePath: string): Promise<PreviewSurface> {
   const ext = getExtension(filePath);
-  const previewer = previewers.find(p => p.extensions.includes(ext));
-  
+  const previewer = previewers.find((p) => p.extensions.includes(ext));
+
   if (!previewer) {
     throw new Error(`No previewer registered for .${ext}`);
   }
@@ -69,7 +99,29 @@ export async function openPreview(filePath: string): Promise<PreviewSurface> {
   injectStyles();
 
   // Binary formats (pdf, image, video) read files themselves — skip text read
-  const binaryExts = new Set(["pdf", "png", "jpg", "jpeg", "gif", "webp", "svg", "ico", "bmp", "heic", "heif", "tiff", "tif", "avif", "mp4", "webm", "mov", "avi", "mkv", "m4v", "ogv"]);
+  const binaryExts = new Set([
+    "pdf",
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "webp",
+    "svg",
+    "ico",
+    "bmp",
+    "heic",
+    "heif",
+    "tiff",
+    "tif",
+    "avif",
+    "mp4",
+    "webm",
+    "mov",
+    "avi",
+    "mkv",
+    "m4v",
+    "ogv",
+  ]);
   const isBinary = binaryExts.has(ext);
 
   let content = "";
@@ -88,11 +140,19 @@ export async function openPreview(filePath: string): Promise<PreviewSurface> {
   if (!isBinary) {
     try {
       watchId = await invoke<number>("watch_file", { path: filePath });
-      await listen<{ watch_id: number; content: string }>("file-changed", (event) => {
-        if (event.payload.watch_id === watchId) {
-          renderWithChrome(previewer, event.payload.content, filePath, element);
-        }
-      });
+      await listen<{ watch_id: number; content: string }>(
+        "file-changed",
+        (event) => {
+          if (event.payload.watch_id === watchId) {
+            renderWithChrome(
+              previewer,
+              event.payload.content,
+              filePath,
+              element,
+            );
+          }
+        },
+      );
     } catch {}
   }
 
@@ -106,7 +166,9 @@ export function openPreviewFromContent(
   title: string,
   previewId?: string,
 ): PreviewSurface {
-  const id = previewId ?? `preview-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const id =
+    previewId ??
+    `preview-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
 
   const element = document.createElement("div");
   element.style.cssText = `
@@ -120,7 +182,7 @@ export function openPreviewFromContent(
 
   injectStyles();
 
-  const mdPreviewer = previewers.find(p => p.extensions.includes("md"));
+  const mdPreviewer = previewers.find((p) => p.extensions.includes("md"));
   if (mdPreviewer) {
     mdPreviewer.render(content, "", element);
   } else {
@@ -130,6 +192,43 @@ export function openPreviewFromContent(
   return { id, filePath: "", title, element, watchId: 0 };
 }
 
+// --- URL-based preview ---
+
+/** Cap remote response size to avoid OOM on a runaway curl. */
+const MAX_URL_BYTES = 5 * 1024 * 1024;
+
+async function openPreviewFromUrl(url: string): Promise<PreviewSurface> {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  const lenHeader = res.headers.get("content-length");
+  if (lenHeader && Number(lenHeader) > MAX_URL_BYTES) {
+    throw new Error(
+      `Response too large (${lenHeader} bytes, max ${MAX_URL_BYTES})`,
+    );
+  }
+
+  const contentType = (res.headers.get("content-type") || "").toLowerCase();
+  const text = await res.text();
+  if (text.length > MAX_URL_BYTES) {
+    throw new Error(
+      `Response too large (${text.length} bytes, max ${MAX_URL_BYTES})`,
+    );
+  }
+
+  // Strip query/fragment before extension/title sniffing
+  const cleanUrl = url.split("?")[0].split("#")[0];
+  const isMarkdown =
+    contentType.includes("markdown") ||
+    /\.md$/i.test(cleanUrl) ||
+    /\.markdown$/i.test(cleanUrl);
+
+  const title = cleanUrl.split("/").filter(Boolean).pop() || url;
+  const rendered = isMarkdown ? text : "```\n" + text + "\n```";
+  return openPreviewFromContent(rendered, title);
+}
+
 // --- Helpers ---
 
 function getExtension(path: string): string {
@@ -137,13 +236,20 @@ function getExtension(path: string): string {
   return parts.length > 1 ? parts.pop()!.toLowerCase() : "";
 }
 
-function renderWithChrome(previewer: Previewer, content: string, filePath: string, element: HTMLElement) {
+function renderWithChrome(
+  previewer: Previewer,
+  content: string,
+  filePath: string,
+  element: HTMLElement,
+) {
   // Just render the content directly — the path is already in the tab title
   previewer.render(content, filePath, element);
 }
 
 function injectStyles() {
-  let style = document.getElementById("preview-styles") as HTMLStyleElement | null;
+  let style = document.getElementById(
+    "preview-styles",
+  ) as HTMLStyleElement | null;
   if (!style) {
     style = document.createElement("style");
     style.id = "preview-styles";


### PR DESCRIPTION
Closes #122.

## Summary

- New `--preview <path-or-url>` CLI flag opens a preview surface in the active workspace at startup. Supports local paths, `file://`, and `http(s)://`.
- Generalized the existing `Preview File...` palette entry to `Preview...` — it accepts the same path/URL input and shares the resolver.
- HTTP(S) bodies render as markdown when the URL ends in `.md`/`.markdown` or `Content-Type: text/markdown`; otherwise as a fenced code block. Response size capped at 5 MB.
- Bundled with a small chore commit: the `prettier-plugin-svelte` dependency was installed but never configured, so the lefthook pre-commit hook silently failed on any commit that staged a `.svelte` file. Added a minimal `.prettierrc.json` and ran prettier across all 16 existing `.svelte` sources for a one-shot baseline.

## Out of scope (follow-ups)

- Single-instance routing — CLI invocations currently spawn a new window if one is already open. Will need `tauri-plugin-single-instance` wiring; non-trivial enough to warrant its own PR.
- Plugin extension point for custom URL scheme handlers (e.g. `spacebase://`) — the motivating use case but a different surface change.

## Test plan

- [x] Unit: `parsePreviewTarget` maps local paths, `file://`, and `https?://` correctly (7 cases).
- [x] Unit: `openPreview` dispatches to local path / fetched URL paths; markdown is rendered as markdown when content-type or extension says so (7 cases).
- [x] Unit: HTTP failure surfaces as a thrown error; oversized `Content-Length` is rejected.
- [x] Unit (Rust): `filter_known_args` keeps `--preview` with both space-separated and `=`-form values.
- [x] Unit (Rust): `CliArgs::parse_from` parses `--preview` for paths and URLs.
- [x] `npm test` green (362 tests).
- [x] `npm run build` green (release bundle produced).
- [ ] Manual: `gnar-term --preview ./README.md` opens the file in a preview surface in the active workspace.
- [ ] Manual: `gnar-term --preview file:///tmp/foo.md` opens it.
- [ ] Manual: `gnar-term --preview https://raw.githubusercontent.com/TheGnarCo/gnar-term/main/README.md` fetches and renders.
- [ ] Manual: Cmd+P → `Preview...` → enter a URL → opens.
- [ ] Manual: Cmd+P → `Preview...` → enter a local path → opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)