### PR TITLE
fix(sidebar): collapsed-rail behavior, per-row popover, switcher cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ bun.lock
 *.key
 *.cert
 *.pfx
-docs/superpowers/brainstorm/
+docs/superpowers/
 docs/implement/
 docs/gnar-term/
 .superpowers/

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -121,6 +121,10 @@
     restoreWindowBounds,
     saveWindowBounds,
   } from "./lib/services/window-bounds-service";
+  import {
+    restoreSidebarVisible,
+    persistSidebarVisibleChanges,
+  } from "./lib/services/sidebar-persistence-service";
   import { confirmQuit } from "./lib/services/quit-confirmation-service";
 
   // Components
@@ -729,6 +733,11 @@
     // getState() so we don't need to thread the value back through the
     // bootstrap signature. Best-effort; failures are logged and ignored.
     void restoreWindowBounds(getState().windowBounds, getCurrentWindow());
+    // Apply the persisted sidebar expanded/collapsed state, then start
+    // persisting subsequent toggles. Must run after restore so the first
+    // emission (the just-restored value) is the one we skip.
+    restoreSidebarVisible(getState());
+    persistSidebarVisibleChanges();
     // Promote standalone runtime workspaces to Roots and rebuild each
     // Workspace's branchedWorkspaceIds from rootWorkspaceId now that the
     // workspaces store is populated.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -892,10 +892,18 @@
     <TitleBar />
   {/if}
 
+  <!-- Row container is position: relative so the collapsed sidebar can
+       overlay the main column. When collapsed, the sidebar floats on top
+       of the terminal canvas and the main column gains a left padding so
+       its content scoots out from under the rail. This eliminates the
+       flex-sibling boundary that otherwise reads as a vertical seam at
+       the rail/terminal edge. Expanded mode keeps the historical flex
+       layout untouched. -->
   <div
     style="
       flex: 1; display: flex; flex-direction: row;
       min-height: 0; min-width: 0; overflow: hidden;
+      position: relative;
     "
   >
     <Sidebar bind:this={sidebarComponent} />
@@ -904,6 +912,7 @@
       style="
         flex: 1; display: flex; flex-direction: column;
         background: {$theme.bg}; min-width: 0; min-height: 0; overflow: hidden;
+        {$sidebarVisible ? '' : 'padding-left: 12px;'}
       "
     >
       {#if $sidebarVisible}

--- a/src/__tests__/agents-sidebar.test.ts
+++ b/src/__tests__/agents-sidebar.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from "vitest";
 import { buildAgentRows } from "../lib/services/agents-sidebar";
 import type { DetectedAgent } from "../lib/services/agent-detection-service";
 import type { Workspace } from "../lib/types";
-import type { WorkspaceRecord } from "../lib/config";
+import type { RootWorkspace } from "../lib/config";
 
 // --- Helpers ---
 
@@ -41,7 +41,7 @@ function makeBranch(
   };
 }
 
-function makeWorkspace(id: string, name: string): WorkspaceRecord {
+function makeWorkspace(id: string, name: string): RootWorkspace {
   return {
     id,
     name,

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -150,7 +150,7 @@ import {
   resetWorkspaceActions,
 } from "../lib/services/workspace-action-registry";
 import { setWorkspaces } from "../lib/stores/workspace";
-import type { WorkspaceRecord } from "../lib/config";
+import type { RootWorkspace } from "../lib/config";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -1988,7 +1988,7 @@ describe("WorkspaceSectionContent", () => {
 
   it("renders workspace-tile zone actions as buttons in the banner row", async () => {
     // Without any workspace-tile actions, no branch button renders.
-    const workspace: WorkspaceRecord = {
+    const workspace: RootWorkspace = {
       id: "grp-1",
       name: "Test Workspace",
       path: "/tmp/test-workspace",

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1753,7 +1753,11 @@ describe("Sidebar", () => {
     expect(inlineNewButton).toBeUndefined();
   });
 
-  it("activates the overlay on hover when collapsed", async () => {
+  it("does not toggle a whole-sidebar overlay class on hover when collapsed", async () => {
+    // Post per-row-popover refactor: the wrapper no longer reacts to
+    // mouseenter/mouseleave with an `overlay-active` class — hover
+    // expansion is handled per-row by WorkspaceListBlock instead. The
+    // wrapper width and `.sidebar-content` width remain stable.
     sidebarVisible.set(false);
     sidebarWidth.set(220);
     const { container } = render(Sidebar, { props: sidebarProps });
@@ -1765,31 +1769,11 @@ describe("Sidebar", () => {
 
     slot.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
     await tick();
+    expect(slot.classList.contains("overlay-active")).toBe(false);
 
-    expect(slot.classList.contains("overlay-active")).toBe(true);
-  });
-
-  it("closes the overlay after the mouseleave grace period", async () => {
-    vi.useFakeTimers();
-    try {
-      sidebarVisible.set(false);
-      const { container } = render(Sidebar, { props: sidebarProps });
-      const slot = container.querySelector("#sidebar") as HTMLElement;
-
-      slot.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
-      await tick();
-      expect(slot.classList.contains("overlay-active")).toBe(true);
-
-      slot.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
-      await tick();
-      expect(slot.classList.contains("overlay-active")).toBe(true);
-
-      vi.advanceTimersByTime(200);
-      await tick();
-      expect(slot.classList.contains("overlay-active")).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
+    slot.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    await tick();
+    expect(slot.classList.contains("overlay-active")).toBe(false);
   });
 
   it("renders split button for workspace actions in the top row (sidebar toggles live in TitleBar)", () => {

--- a/src/__tests__/dashboard-tile-icon-only.test.ts
+++ b/src/__tests__/dashboard-tile-icon-only.test.ts
@@ -2,7 +2,7 @@
  * Dashboard buttons in WorkspaceSectionContent's btn-row slot render
  * icon-only: no text label, workspace name lives in the `aria-label`
  * attribute. Regression for the redesign that moved dashboard tiles
- * from WorkspaceListView's grid into the ContainerRow btn-row slot.
+ * from WorkspaceListView's grid into the SidebarBanner btn-row slot.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -59,7 +59,7 @@ describe("DragGrip", () => {
     expect(stripe!.style.width).toBe("8px");
   });
 
-  it("paints the rail stripe at 6px when narrowRail is set", () => {
+  it("paints the rail stripe at 4px when narrowRail is set", () => {
     const { container } = render(DragGrip, {
       props: {
         theme: stubTheme,
@@ -72,7 +72,7 @@ describe("DragGrip", () => {
       ".drag-grip > div",
     ) as HTMLElement | null;
     expect(stripe).not.toBeNull();
-    expect(stripe!.style.width).toBe("6px");
+    expect(stripe!.style.width).toBe("4px");
   });
 });
 

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -47,6 +47,33 @@ describe("DragGrip", () => {
     await fireEvent.mouseDown(grip);
     expect(onMouseDown).toHaveBeenCalledTimes(1);
   });
+
+  it("paints the rail stripe at 8px by default", () => {
+    const { container } = render(DragGrip, {
+      props: { theme: stubTheme, visible: false, railColor: "#abcdef" },
+    });
+    const stripe = container.querySelector(
+      ".drag-grip > div",
+    ) as HTMLElement | null;
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("8px");
+  });
+
+  it("paints the rail stripe at 6px when narrowRail is set", () => {
+    const { container } = render(DragGrip, {
+      props: {
+        theme: stubTheme,
+        visible: false,
+        railColor: "#abcdef",
+        narrowRail: true,
+      },
+    });
+    const stripe = container.querySelector(
+      ".drag-grip > div",
+    ) as HTMLElement | null;
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("6px");
+  });
 });
 
 const SOURCE = readFileSync(

--- a/src/__tests__/extension-loader.test.ts
+++ b/src/__tests__/extension-loader.test.ts
@@ -213,7 +213,7 @@ describe("createExtensionAPI", () => {
     ).toBeUndefined();
   });
 
-  it("getComponents returns WorkspaceListView, SplitButton, ColorPicker, DragGrip, DropGhost, ContainerRow, PathStatusLine", () => {
+  it("getComponents returns WorkspaceListView, SplitButton, ColorPicker, DragGrip, DropGhost, SidebarBanner, PathStatusLine", () => {
     const { api } = createExtensionAPI(manifest);
     const components = api.getComponents();
     for (const k of [
@@ -222,7 +222,7 @@ describe("createExtensionAPI", () => {
       "ColorPicker",
       "DragGrip",
       "DropGhost",
-      "ContainerRow",
+      "SidebarBanner",
       "PathStatusLine",
     ]) {
       expect(components).toHaveProperty(k);

--- a/src/__tests__/pane-view-notify.test.ts
+++ b/src/__tests__/pane-view-notify.test.ts
@@ -136,8 +136,12 @@ describe("PaneView notification chrome", () => {
 
     const root = container.firstChild as HTMLElement;
     expect(root.dataset.unread).toBe("true");
-    // The default github-dark theme.notify is #58a6ff = rgb(88, 166, 255)
-    expect(root.style.border).toContain("rgb(88, 166, 255)");
+    // The default github-dark theme.notify is #58a6ff = rgb(88, 166, 255).
+    // sidebarVisible defaults to true → all four sides paint the notify color.
+    expect(root.style.borderTop).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderRight).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderBottom).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderLeft).toContain("rgb(88, 166, 255)");
     // Corner pip is rendered
     const pip = container.querySelector('[title="New activity in this pane"]');
     expect(pip).not.toBeNull();
@@ -287,7 +291,10 @@ describe("PaneView notification chrome", () => {
 
     const root = container.firstChild as HTMLElement;
     expect(root.dataset.unread).toBe("true");
-    expect(root.style.border).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderTop).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderRight).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderBottom).toContain("rgb(88, 166, 255)");
+    expect(root.style.borderLeft).toContain("rgb(88, 166, 255)");
     // pip + glow are only rendered when paneHasUnread is true — proving the notify
     // ternary branch was taken, not the isActive accent branch.
     const pip = container.querySelector('[title="New activity in this pane"]');

--- a/src/__tests__/reorder-suppression.test.ts
+++ b/src/__tests__/reorder-suppression.test.ts
@@ -24,16 +24,16 @@ const EXTENSION_API = readFileSync(
 describe("grip visibility suppression", () => {
   it("WorkspaceItem keeps its own grip collapsed when any reorder is active unless the item is the drag source", () => {
     // SidebarRail owns the grip visibility logic for both row and
-    // container modes. The gate tracks rail-level hover and suppresses
-    // expansion while any reorder is in progress unless the row is the
-    // drag source (isDragging).
+    // container modes. The gate now uses the canSidebarDrag derived store
+    // (sidebarVisible && !anyReorderActive) via effectiveCanDrag, and
+    // suppresses expansion unless the row is the drag source (isDragging).
     const RAIL = readFileSync(
       "src/lib/components/SidebarRail.svelte",
       "utf-8",
     ).replace(/\s+/g, " ");
-    expect(RAIL).toContain("anyReorderActive");
+    expect(RAIL).toContain("canSidebarDrag");
     expect(RAIL).toMatch(
-      /isDragging\s*\|\|\s*\(\s*canDrag\s*&&\s*railHovered\s*&&\s*!\s*\$anyReorderActive\s*&&\s*!\s*locked\s*\)/,
+      /isDragging\s*\|\|\s*\(\s*effectiveCanDrag\s*&&\s*railHovered\s*&&\s*!\s*locked\s*\)/,
     );
   });
 
@@ -42,14 +42,14 @@ describe("grip visibility suppression", () => {
     // its own grip (flush with the row) and forwards onMouseDown to
     // core's startRootRowDrag. Gate: createDragReorder is present.
     expect(WORKSPACE_LIST_BLOCK).toContain("createDragReorder");
-    expect(WORKSPACE_LIST_BLOCK).toContain("anyReorderActive");
+    expect(WORKSPACE_LIST_BLOCK).toContain("canSidebarDrag");
   });
 });
 
 describe("canStart gating", () => {
-  it("WorkspaceListBlock's unified root drag gates canStart on anyReorderActive", () => {
+  it("WorkspaceListBlock's unified root drag gates canStart on canSidebarDrag", () => {
     expect(WORKSPACE_LIST_BLOCK).toMatch(
-      /canStart:\s*\(\)\s*=>\s*!\s*\$anyReorderActive/,
+      /canStart:\s*\(\)\s*=>\s*\$canSidebarDrag/,
     );
   });
 

--- a/src/__tests__/sidebar-archive-collapsed.test.ts
+++ b/src/__tests__/sidebar-archive-collapsed.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Verifies that the Archive zone is rendered only when the sidebar is
+ * expanded. While collapsed, the archive banner must not appear.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import Sidebar from "../lib/components/Sidebar.svelte";
+import { sidebarVisible } from "../lib/stores/ui";
+
+describe("Sidebar Archive visibility", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+  });
+
+  it("renders the archive zone when expanded", () => {
+    sidebarVisible.set(true);
+    const { container } = render(Sidebar);
+    expect(container.querySelector("[data-archive-zone]")).not.toBeNull();
+  });
+
+  it("hides the archive zone when collapsed", () => {
+    sidebarVisible.set(false);
+    const { container } = render(Sidebar);
+    expect(container.querySelector("[data-archive-zone]")).toBeNull();
+  });
+});

--- a/src/__tests__/sidebar-banner-with-slot.svelte
+++ b/src/__tests__/sidebar-banner-with-slot.svelte
@@ -1,13 +1,13 @@
 <script>
-  import ContainerRow from "../lib/components/ContainerRow.svelte";
+  import SidebarBanner from "../lib/components/SidebarBanner.svelte";
   export let color;
   export let filterIds;
   export let scopeId;
   export let workspaceListViewComponent;
 </script>
 
-<ContainerRow {color} {filterIds} {scopeId} {workspaceListViewComponent}>
+<SidebarBanner {color} {filterIds} {scopeId} {workspaceListViewComponent}>
   <svelte:fragment slot="btn-row" let:toggle>
     <button on:click={toggle}>toggle</button>
   </svelte:fragment>
-</ContainerRow>
+</SidebarBanner>

--- a/src/__tests__/sidebar-banner.test.ts
+++ b/src/__tests__/sidebar-banner.test.ts
@@ -38,7 +38,7 @@ Element.prototype.animate = vi.fn().mockImplementation(() => {
   };
 });
 
-import ContainerRowWithSlot from "./container-row-with-slot.svelte";
+import SidebarBannerWithSlot from "./sidebar-banner-with-slot.svelte";
 import WorkspaceListViewStub from "./workspace-list-view-stub.svelte";
 import { workspaces } from "../lib/stores/workspace";
 
@@ -54,7 +54,7 @@ const baseProps = {
   workspaceListViewComponent: WorkspaceListViewStub,
 };
 
-describe("ContainerRow collapse/expand", () => {
+describe("SidebarBanner collapse/expand", () => {
   beforeEach(() => workspaces.set([makeWs("ws-1"), makeWs("ws-2")] as never[]));
   afterEach(() => {
     workspaces.set([]);
@@ -62,47 +62,59 @@ describe("ContainerRow collapse/expand", () => {
   });
 
   it("is expanded by default and collapses on chevron click", async () => {
-    const { container } = render(ContainerRowWithSlot, { props: baseProps });
+    const { container } = render(SidebarBannerWithSlot, { props: baseProps });
 
-    expect(container.querySelector("[data-container-children]")).not.toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).not.toBeNull();
 
     const chevron = container.querySelector("button") as HTMLElement;
     await fireEvent.click(chevron);
     await tick();
 
-    expect(container.querySelector("[data-container-children]")).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).toBeNull();
   });
 
   it("auto-expands when a workspace is added while collapsed", async () => {
-    const { container, rerender } = render(ContainerRowWithSlot, {
+    const { container, rerender } = render(SidebarBannerWithSlot, {
       props: baseProps,
     });
 
     const chevron = container.querySelector("button") as HTMLElement;
     await fireEvent.click(chevron);
     await tick();
-    expect(container.querySelector("[data-container-children]")).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).toBeNull();
 
     await rerender({ filterIds: new Set(["ws-1", "ws-2"]) });
     await tick();
 
-    expect(container.querySelector("[data-container-children]")).not.toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).not.toBeNull();
   });
 
   it("stays collapsed when filterIds shrinks or stays the same size", async () => {
-    const { container, rerender } = render(ContainerRowWithSlot, {
+    const { container, rerender } = render(SidebarBannerWithSlot, {
       props: { ...baseProps, filterIds: new Set(["ws-1", "ws-2"]) },
     });
 
     const chevron = container.querySelector("button") as HTMLElement;
     await fireEvent.click(chevron);
     await tick();
-    expect(container.querySelector("[data-container-children]")).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).toBeNull();
 
     await rerender({ filterIds: new Set(["ws-1"]) });
     await tick();
 
-    expect(container.querySelector("[data-container-children]")).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-banner-children]"),
+    ).toBeNull();
   });
 
   it("clears banner hover state when the cursor leaves the document", async () => {
@@ -113,9 +125,9 @@ describe("ContainerRow collapse/expand", () => {
     // different edge. A body-level mouseleave is the authoritative
     // "cursor left the app" signal — `bannerHovered` must reset to
     // false in response.
-    const { container } = render(ContainerRowWithSlot, { props: baseProps });
+    const { container } = render(SidebarBannerWithSlot, { props: baseProps });
     const banner = container.querySelector(
-      "[data-container-banner]",
+      "[data-sidebar-banner-row]",
     ) as HTMLElement;
     expect(banner).not.toBeNull();
 

--- a/src/__tests__/sidebar-collapsed-bg.test.ts
+++ b/src/__tests__/sidebar-collapsed-bg.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Verifies the primary sidebar paints a transparent background when
+ * collapsed so the terminal area's bg shows through (seamless rail look).
+ * When expanded the sidebar still paints `$theme.sidebarBg`.
+ *
+ * JSDOM normalisation notes:
+ *   - `background: transparent` is the CSS initial value; JSDOM strips it from
+ *     both the style object and the raw attribute string.  We therefore assert
+ *     its absence by checking that style.background is empty ("") rather than
+ *     checking for the string "transparent".
+ *   - `background: #hex` values are normalised to rgb() by JSDOM, so the
+ *     expanded-state assertion converts the expected hex to rgb() first.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import Sidebar from "../lib/components/Sidebar.svelte";
+import { sidebarVisible } from "../lib/stores/ui";
+import { theme } from "../lib/stores/theme";
+
+/** Convert a hex colour like "#0d1117" to the rgb() string JSDOM stores. */
+function hexToRgb(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+describe("Sidebar collapsed background", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+  });
+
+  it("uses transparent bg on the wrapper and content when collapsed", () => {
+    sidebarVisible.set(false);
+    const { container } = render(Sidebar);
+    const wrapper = container.querySelector("#sidebar") as HTMLElement;
+    const content = wrapper.querySelector(".sidebar-content") as HTMLElement;
+    // JSDOM strips `background: transparent` (it is the CSS initial value),
+    // leaving style.background as an empty string — which is the correct
+    // signal that no opaque background is painted.
+    expect(wrapper.style.background).toBe("");
+    expect(content.style.background).toBe("");
+  });
+
+  it("uses theme.sidebarBg on wrapper and content when expanded", () => {
+    sidebarVisible.set(true);
+    const { container } = render(Sidebar);
+    const wrapper = container.querySelector("#sidebar") as HTMLElement;
+    const content = wrapper.querySelector(".sidebar-content") as HTMLElement;
+    // JSDOM normalises hex colours to rgb() in the style object.
+    const rawExpected = get(theme).sidebarBg;
+    const expected = rawExpected.startsWith("#")
+      ? hexToRgb(rawExpected)
+      : rawExpected;
+    expect(wrapper.style.background).toBe(expected);
+    expect(content.style.background).toBe(expected);
+  });
+});

--- a/src/__tests__/sidebar-collapsed-bg.test.ts
+++ b/src/__tests__/sidebar-collapsed-bg.test.ts
@@ -1,15 +1,12 @@
 /**
- * Verifies the primary sidebar paints a transparent background when
- * collapsed so the terminal area's bg shows through (seamless rail look).
- * When expanded the sidebar still paints `$theme.sidebarBg`.
+ * Verifies the primary sidebar paints `$theme.bg` when collapsed so the
+ * 12px rail strip is visually continuous with the terminal area (no
+ * vertical seam from the hardcoded body bg in index.html, which only
+ * matches one theme). When expanded the sidebar paints `$theme.sidebarBg`.
  *
- * JSDOM normalisation notes:
- *   - `background: transparent` is the CSS initial value; JSDOM strips it from
- *     both the style object and the raw attribute string.  We therefore assert
- *     its absence by checking that style.background is empty ("") rather than
- *     checking for the string "transparent".
- *   - `background: #hex` values are normalised to rgb() by JSDOM, so the
- *     expanded-state assertion converts the expected hex to rgb() first.
+ * JSDOM normalisation note: `background: #hex` values are normalised to
+ * rgb() in the style object, so we convert expected hex values to rgb()
+ * before comparing.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
@@ -32,16 +29,17 @@ describe("Sidebar collapsed background", () => {
     sidebarVisible.set(true);
   });
 
-  it("uses transparent bg on the wrapper and content when collapsed", () => {
+  it("paints theme.bg on the wrapper and content when collapsed", () => {
     sidebarVisible.set(false);
     const { container } = render(Sidebar);
     const wrapper = container.querySelector("#sidebar") as HTMLElement;
     const content = wrapper.querySelector(".sidebar-content") as HTMLElement;
-    // JSDOM strips `background: transparent` (it is the CSS initial value),
-    // leaving style.background as an empty string — which is the correct
-    // signal that no opaque background is painted.
-    expect(wrapper.style.background).toBe("");
-    expect(content.style.background).toBe("");
+    const rawExpected = get(theme).bg;
+    const expected = rawExpected.startsWith("#")
+      ? hexToRgb(rawExpected)
+      : rawExpected;
+    expect(wrapper.style.background).toBe(expected);
+    expect(content.style.background).toBe(expected);
   });
 
   it("uses theme.sidebarBg on wrapper and content when expanded", () => {

--- a/src/__tests__/sidebar-drag-disabled-collapsed.test.ts
+++ b/src/__tests__/sidebar-drag-disabled-collapsed.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Verifies that banner drag is disabled while the sidebar is collapsed:
+ *   - SidebarRail (container mode) does not surface the grip on hover
+ *   - the unified root drag pipeline refuses to start a drag
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import SidebarRail from "../lib/components/SidebarRail.svelte";
+import {
+  sidebarVisible,
+  canSidebarDrag,
+  reorderContext,
+} from "../lib/stores/ui";
+
+describe("SidebarRail drag affordance gating", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+    reorderContext.set(null);
+  });
+
+  it("forbids drag when sidebar is collapsed (canSidebarDrag is false)", () => {
+    sidebarVisible.set(false);
+    expect(get(canSidebarDrag)).toBe(false);
+  });
+
+  it("allows drag when sidebar is expanded and not already reordering", () => {
+    sidebarVisible.set(true);
+    reorderContext.set(null);
+    expect(get(canSidebarDrag)).toBe(true);
+  });
+
+  it("does not invoke onGripMouseDown when collapsed even on rail hover+mousedown", async () => {
+    sidebarVisible.set(false);
+    const onGripMouseDown = vi.fn();
+    const { container } = render(SidebarRail, {
+      props: {
+        mode: "container",
+        color: "#abc",
+        canDrag: true,
+        onGripMouseDown,
+      },
+    });
+    const rail = container.querySelector(
+      "[data-sidebar-rail='container']",
+    ) as HTMLElement;
+    await fireEvent.mouseEnter(rail);
+    await fireEvent.mouseDown(rail);
+    expect(onGripMouseDown).not.toHaveBeenCalled();
+  });
+
+  it("invokes onGripMouseDown when expanded on rail hover+mousedown", async () => {
+    sidebarVisible.set(true);
+    reorderContext.set(null);
+    const onGripMouseDown = vi.fn();
+    const { container } = render(SidebarRail, {
+      props: {
+        mode: "container",
+        color: "#abc",
+        canDrag: true,
+        onGripMouseDown,
+      },
+    });
+    const rail = container.querySelector(
+      "[data-sidebar-rail='container']",
+    ) as HTMLElement;
+    await fireEvent.mouseEnter(rail);
+    await fireEvent.mouseDown(rail);
+    expect(onGripMouseDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/sidebar-rail-active-width.test.ts
+++ b/src/__tests__/sidebar-rail-active-width.test.ts
@@ -1,6 +1,6 @@
 /**
  * Verifies the collapsed-mode rail width policy:
- *   - inactive + not hovered + popover closed → 6px stripe (slim accent)
+ *   - inactive + not hovered + popover closed → 4px stripe (slim accent)
  *   - active OR popover open                  → 8px stripe (anchored)
  *   - expanded sidebar                        → always 8px (legacy)
  *
@@ -24,14 +24,14 @@ describe("SidebarRail collapsed-mode rail width", () => {
     sidebarVisible.set(true);
   });
 
-  it("paints a 6px stripe for an inactive row when collapsed", () => {
+  it("paints a 4px stripe for an inactive row when collapsed", () => {
     sidebarVisible.set(false);
     const { container } = render(SidebarRail, {
       props: { mode: "row", color: "#abc", isActive: false },
     });
     const stripe = railStripe(container);
     expect(stripe).not.toBeNull();
-    expect(stripe!.style.width).toBe("6px");
+    expect(stripe!.style.width).toBe("4px");
   });
 
   it("paints an 8px stripe when popoverActive is true (banner shown)", () => {

--- a/src/__tests__/sidebar-rail-active-width.test.ts
+++ b/src/__tests__/sidebar-rail-active-width.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Verifies the collapsed-mode rail width policy:
+ *   - inactive + not hovered + popover closed → 6px stripe (slim accent)
+ *   - active OR popover open                  → 8px stripe (anchored)
+ *   - expanded sidebar                        → always 8px (legacy)
+ *
+ * The grip wrapper itself is always 8px wide; only the painted stripe
+ * inside it changes width, so row layout never shifts when the policy
+ * toggles.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import SidebarRail from "../lib/components/SidebarRail.svelte";
+import { sidebarVisible } from "../lib/stores/ui";
+
+function railStripe(container: HTMLElement): HTMLElement | null {
+  // The stripe is the first absolutely-positioned div inside the grip.
+  return container.querySelector(".drag-grip > div") as HTMLElement | null;
+}
+
+describe("SidebarRail collapsed-mode rail width", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+  });
+
+  it("paints a 6px stripe for an inactive row when collapsed", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", isActive: false },
+    });
+    const stripe = railStripe(container);
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("6px");
+  });
+
+  it("paints an 8px stripe when popoverActive is true (banner shown)", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: {
+        mode: "row",
+        color: "#abc",
+        isActive: false,
+        popoverActive: true,
+      },
+    });
+    const stripe = railStripe(container);
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("8px");
+  });
+
+  it("paints an 8px stripe for an active row when collapsed", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", isActive: true },
+    });
+    const stripe = railStripe(container);
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("8px");
+  });
+
+  it("paints an 8px stripe regardless of active state when expanded", () => {
+    sidebarVisible.set(true);
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", isActive: false },
+    });
+    const stripe = railStripe(container);
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("8px");
+  });
+
+  it("widens the stripe to 8px in container mode when an active child is present", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: {
+        mode: "container",
+        color: "#abc",
+        canDrag: true,
+        isActive: true,
+      },
+    });
+    const stripe = railStripe(container);
+    expect(stripe).not.toBeNull();
+    expect(stripe!.style.width).toBe("8px");
+  });
+});

--- a/src/__tests__/sidebar-rail-click.test.ts
+++ b/src/__tests__/sidebar-rail-click.test.ts
@@ -3,7 +3,7 @@
  * callback. The rail is the colored stripe on the left edge of every
  * workspace / branch / dashboard row — historically it was drag-only,
  * which made the workspace's collapsed-mode rail appear inert. Wiring
- * onClick lets ContainerRow forward `onBannerClick` and SidebarElement
+ * onClick lets SidebarBanner forward `onBannerClick` and SidebarElement
  * forward `onRailClick`, so a rail click activates the row in any
  * sidebar mode.
  */

--- a/src/__tests__/sidebar-rail-click.test.ts
+++ b/src/__tests__/sidebar-rail-click.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test: clicking the SidebarRail invokes its `onClick`
+ * callback. The rail is the colored stripe on the left edge of every
+ * workspace / branch / dashboard row — historically it was drag-only,
+ * which made the workspace's collapsed-mode rail appear inert. Wiring
+ * onClick lets ContainerRow forward `onBannerClick` and SidebarElement
+ * forward `onRailClick`, so a rail click activates the row in any
+ * sidebar mode.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import SidebarRail from "../lib/components/SidebarRail.svelte";
+
+describe("SidebarRail onClick", () => {
+  afterEach(() => cleanup());
+
+  it("invokes onClick when the rail is clicked", async () => {
+    const onClick = vi.fn();
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", onClick },
+    });
+    const rail = container.querySelector(
+      '[data-sidebar-rail="row"]',
+    ) as HTMLElement;
+    expect(rail).not.toBeNull();
+    await fireEvent.click(rail);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when no onClick is provided", async () => {
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc" },
+    });
+    const rail = container.querySelector(
+      '[data-sidebar-rail="row"]',
+    ) as HTMLElement;
+    // Should not throw.
+    await fireEvent.click(rail);
+    expect(rail).not.toBeNull();
+  });
+});

--- a/src/__tests__/sidebar-rail-collapsed-border.test.ts
+++ b/src/__tests__/sidebar-rail-collapsed-border.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Verifies that when the sidebar is collapsed, SidebarRail (container
+ * mode) drops its 1px left border so there's no vertical seam between
+ * the sidebar slot and the terminal area.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import SidebarRail from "../lib/components/SidebarRail.svelte";
+import { sidebarVisible } from "../lib/stores/ui";
+
+describe("SidebarRail collapsed border", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+  });
+
+  it("drops border-left when sidebar is collapsed (container mode)", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: { mode: "container", color: "#abc", canDrag: true },
+    });
+    const rail = container.querySelector(
+      "[data-sidebar-rail='container']",
+    ) as HTMLElement;
+    expect(rail).not.toBeNull();
+    expect(rail.style.borderLeft).toBe("");
+  });
+
+  it("keeps border-left when sidebar is expanded (container mode)", () => {
+    sidebarVisible.set(true);
+    const { container } = render(SidebarRail, {
+      props: { mode: "container", color: "#abc", canDrag: true },
+    });
+    const rail = container.querySelector(
+      "[data-sidebar-rail='container']",
+    ) as HTMLElement;
+    expect(rail).not.toBeNull();
+    expect(rail.style.borderLeft).toMatch(/1px solid/);
+  });
+});

--- a/src/__tests__/sidebar-rail-cursor.test.ts
+++ b/src/__tests__/sidebar-rail-cursor.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Verifies the rail cursor policy:
+ *   - collapsed sidebar + rail has onClick → `pointer` (click is primary)
+ *   - expanded sidebar                     → falls through to drag/default
+ *   - locked                                → `not-allowed`
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import SidebarRail from "../lib/components/SidebarRail.svelte";
+import { sidebarVisible } from "../lib/stores/ui";
+
+function grip(container: HTMLElement): HTMLElement | null {
+  return container.querySelector(".drag-grip") as HTMLElement | null;
+}
+
+describe("SidebarRail cursor policy", () => {
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+  });
+
+  it("uses pointer cursor when collapsed and onClick is wired", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", onClick: () => {} },
+    });
+    const g = grip(container);
+    expect(g).not.toBeNull();
+    expect(g!.style.cursor).toBe("pointer");
+  });
+
+  it("does NOT use pointer cursor when expanded, even if onClick is wired", () => {
+    sidebarVisible.set(true);
+    const { container } = render(SidebarRail, {
+      props: { mode: "row", color: "#abc", onClick: () => {} },
+    });
+    const g = grip(container);
+    expect(g).not.toBeNull();
+    expect(g!.style.cursor).not.toBe("pointer");
+  });
+
+  it("uses not-allowed cursor when locked, even when collapsed and clickable", () => {
+    sidebarVisible.set(false);
+    const { container } = render(SidebarRail, {
+      props: {
+        mode: "row",
+        color: "#abc",
+        onClick: () => {},
+        locked: true,
+      },
+    });
+    const g = grip(container);
+    expect(g).not.toBeNull();
+    expect(g!.style.cursor).toBe("not-allowed");
+  });
+});

--- a/src/__tests__/sidebar-row-popover.test.ts
+++ b/src/__tests__/sidebar-row-popover.test.ts
@@ -89,7 +89,9 @@ describe("WorkspaceListBlock per-row popover (collapsed sidebar)", () => {
     ) as HTMLElement | null;
     expect(popover).not.toBeNull();
     expect(popover!.style.position).toBe("fixed");
-    expect(popover!.style.width).toBe("220px");
+    // Popover renders at left:4 so it aligns with the expanded sidebar's
+    // 4px left gutter; effective width is sidebarWidth - 4 (216 of 220).
+    expect(popover!.style.width).toBe("216px");
     expect(get(hoveredRootRowKey)).toBe(row!.getAttribute("data-root-row-key"));
   });
 

--- a/src/__tests__/sidebar-row-popover.test.ts
+++ b/src/__tests__/sidebar-row-popover.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Verifies the per-row popover behavior of WorkspaceListBlock when the
+ * sidebar is collapsed:
+ *   - No popover is rendered initially.
+ *   - Hovering a rendered row produces exactly one popover element.
+ *   - Leaving the row clears the popover after the grace period.
+ *   - Expanding the sidebar mid-hover dismisses the popover.
+ *
+ * The test mounts WorkspaceListBlock with a single workspace registered
+ * so the unified drag pipeline produces a single .root-row.
+ */
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+import WorkspaceListBlock from "../lib/components/WorkspaceListBlock.svelte";
+import {
+  sidebarVisible,
+  sidebarWidth,
+  hoveredRootRowKey,
+} from "../lib/stores/ui";
+import { workspaces } from "../lib/stores/workspace";
+import { rootRowOrder } from "../lib/stores/root-row-order";
+import { registerRootRowRenderer } from "../lib/services/root-row-renderer-registry";
+import WorkspaceRowBody from "../lib/components/WorkspaceRowBody.svelte";
+import { initCoreExtensionAPI } from "../lib/bootstrap/init-core-extension-api";
+
+// Minimal workspace fixture sufficient for the rendered-rows derivation.
+function fakeWorkspace(id: string) {
+  return {
+    id,
+    name: `WS ${id}`,
+    color: "blue",
+    path: `/tmp/${id}`,
+    branchedWorkspaceIds: [],
+    isGit: false,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("WorkspaceListBlock per-row popover (collapsed sidebar)", () => {
+  beforeEach(() => {
+    // Workspace rows render through the registered "workspace"
+    // root-row renderer (mounted via ExtensionWrapper). Without this,
+    // no [data-root-row-key] element is produced.
+    initCoreExtensionAPI();
+    registerRootRowRenderer({
+      id: "workspace",
+      source: "core",
+      component: WorkspaceRowBody,
+      label: (id: string) => {
+        let result: string | undefined;
+        workspaces.subscribe((list) => {
+          result = list.find((w) => w.id === id)?.name;
+        })();
+        return result;
+      },
+    });
+    sidebarWidth.set(220);
+    sidebarVisible.set(false);
+    workspaces.set([fakeWorkspace("ws-1") as never]);
+    rootRowOrder.set([{ kind: "workspace", id: "ws-1" }]);
+    hoveredRootRowKey.set(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+    workspaces.set([]);
+    rootRowOrder.set([]);
+    hoveredRootRowKey.set(null);
+  });
+
+  it("does not render a popover when no row is hovered", () => {
+    const { container } = render(WorkspaceListBlock);
+    expect(container.querySelector("[data-root-row-popover]")).toBeNull();
+  });
+
+  it("renders one popover positioned at the hovered row when the sidebar is collapsed", async () => {
+    const { container } = render(WorkspaceListBlock);
+    const row = container.querySelector(
+      "[data-root-row-key]",
+    ) as HTMLElement | null;
+    expect(row).not.toBeNull();
+    await fireEvent.mouseEnter(row!);
+    await tick();
+    const popover = container.querySelector(
+      "[data-root-row-popover]",
+    ) as HTMLElement | null;
+    expect(popover).not.toBeNull();
+    expect(popover!.style.position).toBe("fixed");
+    expect(popover!.style.width).toBe("220px");
+    expect(get(hoveredRootRowKey)).toBe(row!.getAttribute("data-root-row-key"));
+  });
+
+  it("clears the popover after mouseleave grace period", async () => {
+    vi.useFakeTimers();
+    const { container } = render(WorkspaceListBlock);
+    const row = container.querySelector("[data-root-row-key]") as HTMLElement;
+    await fireEvent.mouseEnter(row);
+    await tick();
+    expect(container.querySelector("[data-root-row-popover]")).not.toBeNull();
+
+    await fireEvent.mouseLeave(row);
+    await tick();
+    // Still present — grace timer hasn't fired yet.
+    expect(container.querySelector("[data-root-row-popover]")).not.toBeNull();
+
+    vi.advanceTimersByTime(151);
+    await tick();
+    expect(container.querySelector("[data-root-row-popover]")).toBeNull();
+    expect(get(hoveredRootRowKey)).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("dismisses the popover when sidebar expands", async () => {
+    const { container } = render(WorkspaceListBlock);
+    const row = container.querySelector("[data-root-row-key]") as HTMLElement;
+    await fireEvent.mouseEnter(row);
+    await tick();
+    expect(container.querySelector("[data-root-row-popover]")).not.toBeNull();
+
+    sidebarVisible.set(true);
+    await tick();
+    expect(container.querySelector("[data-root-row-popover]")).toBeNull();
+    expect(get(hoveredRootRowKey)).toBeNull();
+  });
+
+  it("does not render a popover when sidebar is expanded", async () => {
+    sidebarVisible.set(true);
+    const { container } = render(WorkspaceListBlock);
+    const row = container.querySelector("[data-root-row-key]") as HTMLElement;
+    await fireEvent.mouseEnter(row);
+    await tick();
+    expect(container.querySelector("[data-root-row-popover]")).toBeNull();
+  });
+});

--- a/src/__tests__/workspace-runtime-no-duplicate-id.test.ts
+++ b/src/__tests__/workspace-runtime-no-duplicate-id.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression: createWorkspaceFromDef must not append a duplicate runtime
+ * Workspace when called twice with the same id for a Branch or Dashboard.
+ *
+ * The merge branch in createWorkspaceFromDef uses `getWorkspace(ws.id)` to
+ * detect "this is the Workspace's own root" and merge fields onto the
+ * existing record. `getWorkspace` filters to root-shaped entries, so a
+ * Branch (rootWorkspaceId set) or a Dashboard (isDashboard true) is never
+ * matched there — and would otherwise fall through to the append branch,
+ * landing as a duplicate in `workspaces`. App.svelte renders WorkspaceView
+ * inside a keyed each on `ws.id`, so a duplicate id surfaces as a Svelte
+ * `each_key_duplicate` runtime error. The append branch must dedupe by id.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
+import { createWorkspaceFromDef } from "../lib/services/workspace-runtime-service";
+import { resetWorkspacesForTest } from "../lib/stores/workspace";
+import { rootRowOrder } from "../lib/stores/root-row-order";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/terminal-service", () => ({
+  createTerminalSurface: vi
+    .fn()
+    .mockImplementation(
+      async (pane: { surfaces: unknown[]; activeSurfaceId: string | null }) => {
+        const surface = {
+          kind: "terminal" as const,
+          id: `surf-${Math.random().toString(36).slice(2)}`,
+          title: "Shell",
+          hasUnread: false,
+          opened: false,
+          ptyId: -1,
+          terminal: { focus: vi.fn() },
+        };
+        pane.surfaces.push(surface);
+        if (!pane.activeSurfaceId) pane.activeSurfaceId = surface.id;
+        return surface;
+      },
+    ),
+}));
+
+describe("createWorkspaceFromDef — duplicate id guard", () => {
+  beforeEach(() => {
+    resetWorkspacesForTest();
+    rootRowOrder.set([]);
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+  });
+
+  it("does not duplicate a Branch when called twice with the same id", async () => {
+    await createWorkspaceFromDef({
+      id: "branch-1",
+      name: "Branch 1",
+      rootWorkspaceId: "root-1",
+    });
+    await createWorkspaceFromDef({
+      id: "branch-1",
+      name: "Branch 1",
+      rootWorkspaceId: "root-1",
+    });
+
+    const list = get(workspaces);
+    expect(list.filter((w) => w.id === "branch-1")).toHaveLength(1);
+  });
+
+  it("does not duplicate a Dashboard when called twice with the same id", async () => {
+    await createWorkspaceFromDef({
+      id: "dash-1",
+      name: "Dashboard 1",
+      rootWorkspaceId: "root-1",
+      isDashboard: true,
+      dashboardContributionId: "core.overview",
+    });
+    await createWorkspaceFromDef({
+      id: "dash-1",
+      name: "Dashboard 1",
+      rootWorkspaceId: "root-1",
+      isDashboard: true,
+      dashboardContributionId: "core.overview",
+    });
+
+    const list = get(workspaces);
+    expect(list.filter((w) => w.id === "dash-1")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/workspace-section-active-descendant.test.ts
+++ b/src/__tests__/workspace-section-active-descendant.test.ts
@@ -1,33 +1,209 @@
 /**
- * Regression test: in collapsed mode the workspace's left rail must be
- * full-width whenever ANY descendant is the active workspace — not only
- * when the root/primary workspace itself is selected.
+ * Regression: in collapsed mode the workspace's rail must be full-width
+ * whenever ANY descendant is the active workspace — not only when the
+ * Root Workspace itself is selected.
  *
- * The bug: WorkspaceSectionContent used to forward
+ * Before the fix WorkspaceSectionContent forwarded
  *   hasActiveChild={isPrimaryActive}
- * which meant a branched workspace or dashboard child being active left
- * the rail in its narrow inactive width (4px). The fix introduces a
- * dedicated `hasActiveDescendant` derivation that covers the root, every
- * branched workspace, and every dashboard child of the workspace.
+ * which left the rail in its narrow inactive width (4px) whenever a
+ * Branch or Dashboard child was active. The fix derives
+ * `hasActiveDescendant` (root + any descendant whose
+ * `rootWorkspaceId === workspace.id`) and forwards that instead.
+ *
+ * The rail width is the user-visible behavior under test: 4px stripe
+ * when nothing in this banner is active, 8px when something is. We
+ * render the real WorkspaceSectionContent through the test harness and
+ * read the stripe out of the rendered SidebarRail.
  */
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { tick } from "svelte";
+import { render, cleanup } from "@testing-library/svelte";
 
-const SOURCE = readFileSync(
-  "src/lib/components/WorkspaceSectionContent.svelte",
-  "utf-8",
-);
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn().mockReturnValue(null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+});
+
+class MockResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+Element.prototype.animate = vi.fn().mockImplementation(() => {
+  let _onfinish: (() => void) | null = null;
+  return {
+    get onfinish() {
+      return _onfinish;
+    },
+    set onfinish(fn: (() => void) | null) {
+      _onfinish = fn;
+      if (fn) fn();
+    },
+    cancel: vi.fn(),
+  };
+});
+
+import WorkspaceSectionHarness from "./workspace-section-harness.svelte";
+import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
+import { sidebarVisible } from "../lib/stores/ui";
+import type { Workspace } from "../lib/types";
+
+const ROOT_ID = "root-1";
+
+function makeRoot(): Workspace {
+  return {
+    id: ROOT_ID,
+    name: "Root",
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p-root", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: "p-root",
+    color: "purple",
+    path: "/tmp/root",
+    isGit: true,
+    branchedWorkspaceIds: ["branch-1", "dash-1"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+  } as Workspace;
+}
+
+function makeBranch(): Workspace {
+  return {
+    id: "branch-1",
+    name: "Feature Branch",
+    rootWorkspaceId: ROOT_ID,
+    worktreePath: "/tmp/root-branch",
+    branch: "feature",
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p-branch", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: "p-branch",
+  } as Workspace;
+}
+
+function makeDashboard(): Workspace {
+  return {
+    id: "dash-1",
+    name: "Overview",
+    rootWorkspaceId: ROOT_ID,
+    isDashboard: true,
+    dashboardContributionId: "group",
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p-dash", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: "p-dash",
+  } as Workspace;
+}
+
+function makeUnrelated(): Workspace {
+  return {
+    id: "other-root",
+    name: "Other",
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p-other", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: "p-other",
+    color: "mint",
+    path: "/tmp/other",
+    isGit: false,
+    branchedWorkspaceIds: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+  } as Workspace;
+}
+
+// The root banner's full-height rail is the first `[data-sidebar-rail="container"]`
+// inside the root banner block; the painted stripe is its grip's first child div.
+// Its width reflects the active/descendant/popover state — 4px inactive, 8px active.
+function railStripeWidth(container: HTMLElement): string | null {
+  const rail = container.querySelector(
+    '[data-sidebar-banner-mode="root"] > [data-sidebar-rail="container"] .drag-grip > div',
+  ) as HTMLElement | null;
+  return rail?.style.width ?? null;
+}
 
 describe("WorkspaceSectionContent — collapsed rail tracks any descendant", () => {
-  it("derives hasActiveDescendant from root id + any rootWorkspaceId match", () => {
-    expect(SOURCE).toContain("hasActiveDescendant");
-    expect(SOURCE).toMatch(
-      /active\.id === workspace\.id \|\| active\.rootWorkspaceId === workspace\.id/,
-    );
+  beforeEach(() => {
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
+    sidebarVisible.set(false);
+  });
+  afterEach(() => {
+    cleanup();
+    sidebarVisible.set(true);
+    workspaces.set([]);
+    activeWorkspaceIdx.set(-1);
   });
 
-  it("forwards hasActiveDescendant (not isPrimaryActive) to ContainerRow", () => {
-    expect(SOURCE).toContain("hasActiveChild={hasActiveDescendant}");
-    expect(SOURCE).not.toContain("hasActiveChild={isPrimaryActive}");
+  it("widens the rail to 8px when an unrelated workspace becomes the Root itself", async () => {
+    workspaces.set([
+      makeRoot(),
+      makeBranch(),
+      makeDashboard(),
+      makeUnrelated(),
+    ]);
+    activeWorkspaceIdx.set(0); // Root is active
+    const { container } = render(WorkspaceSectionHarness, {
+      props: { rootWorkspaceId: ROOT_ID },
+    });
+    await tick();
+    expect(railStripeWidth(container)).toBe("8px");
+  });
+
+  it("widens the rail to 8px when a Branch descendant is active", async () => {
+    workspaces.set([
+      makeRoot(),
+      makeBranch(),
+      makeDashboard(),
+      makeUnrelated(),
+    ]);
+    activeWorkspaceIdx.set(1); // Branch under Root
+    const { container } = render(WorkspaceSectionHarness, {
+      props: { rootWorkspaceId: ROOT_ID },
+    });
+    await tick();
+    expect(railStripeWidth(container)).toBe("8px");
+  });
+
+  it("widens the rail to 8px when a Dashboard descendant is active", async () => {
+    workspaces.set([
+      makeRoot(),
+      makeBranch(),
+      makeDashboard(),
+      makeUnrelated(),
+    ]);
+    activeWorkspaceIdx.set(2); // Dashboard under Root
+    const { container } = render(WorkspaceSectionHarness, {
+      props: { rootWorkspaceId: ROOT_ID },
+    });
+    await tick();
+    expect(railStripeWidth(container)).toBe("8px");
+  });
+
+  it("keeps the rail at 4px when an unrelated workspace is active", async () => {
+    workspaces.set([
+      makeRoot(),
+      makeBranch(),
+      makeDashboard(),
+      makeUnrelated(),
+    ]);
+    activeWorkspaceIdx.set(3); // Unrelated workspace
+    const { container } = render(WorkspaceSectionHarness, {
+      props: { rootWorkspaceId: ROOT_ID },
+    });
+    await tick();
+    expect(railStripeWidth(container)).toBe("4px");
   });
 });

--- a/src/__tests__/workspace-section-active-descendant.test.ts
+++ b/src/__tests__/workspace-section-active-descendant.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test: in collapsed mode the workspace's left rail must be
+ * full-width whenever ANY descendant is the active workspace — not only
+ * when the root/primary workspace itself is selected.
+ *
+ * The bug: WorkspaceSectionContent used to forward
+ *   hasActiveChild={isPrimaryActive}
+ * which meant a branched workspace or dashboard child being active left
+ * the rail in its narrow inactive width (6px). The fix introduces a
+ * dedicated `hasActiveDescendant` derivation that covers the root, every
+ * branched workspace, and every dashboard child of the workspace.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+
+const SOURCE = readFileSync(
+  "src/lib/components/WorkspaceSectionContent.svelte",
+  "utf-8",
+);
+
+describe("WorkspaceSectionContent — collapsed rail tracks any descendant", () => {
+  it("derives hasActiveDescendant from root id + any rootWorkspaceId match", () => {
+    expect(SOURCE).toContain("hasActiveDescendant");
+    expect(SOURCE).toMatch(
+      /active\.id === workspace\.id \|\| active\.rootWorkspaceId === workspace\.id/,
+    );
+  });
+
+  it("forwards hasActiveDescendant (not isPrimaryActive) to ContainerRow", () => {
+    expect(SOURCE).toContain("hasActiveChild={hasActiveDescendant}");
+    expect(SOURCE).not.toContain("hasActiveChild={isPrimaryActive}");
+  });
+});

--- a/src/__tests__/workspace-section-active-descendant.test.ts
+++ b/src/__tests__/workspace-section-active-descendant.test.ts
@@ -6,7 +6,7 @@
  * The bug: WorkspaceSectionContent used to forward
  *   hasActiveChild={isPrimaryActive}
  * which meant a branched workspace or dashboard child being active left
- * the rail in its narrow inactive width (6px). The fix introduces a
+ * the rail in its narrow inactive width (4px). The fix introduces a
  * dedicated `hasActiveDescendant` derivation that covers the root, every
  * branched workspace, and every dashboard child of the workspace.
  */

--- a/src/__tests__/workspace-section-harness.svelte
+++ b/src/__tests__/workspace-section-harness.svelte
@@ -13,4 +13,8 @@
   });
 </script>
 
-<WorkspaceSectionContent {rootWorkspaceId} containerBlockId="" />
+<WorkspaceSectionContent
+  {rootWorkspaceId}
+  containerBlockId=""
+  onGripMouseDown={() => {}}
+/>

--- a/src/__tests__/workspace-switcher-filter.test.ts
+++ b/src/__tests__/workspace-switcher-filter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { filterWorkspaces } from "../lib/services/workspace-switcher-filter";
 import type { Workspace } from "../lib/types";
-import type { WorkspaceRecord } from "../lib/config";
+import type { RootWorkspace } from "../lib/config";
 
 // ---- Minimal stubs ----
 
@@ -22,7 +22,7 @@ function makeWs(
   } as Workspace;
 }
 
-function makeRoot(id: string, name: string): WorkspaceRecord {
+function makeRoot(id: string, name: string): RootWorkspace {
   return {
     id,
     name,
@@ -53,7 +53,7 @@ const standaloneWs = makeWs({ id: "nw-5", name: "standalone" });
 
 const allWorkspaces = [...branchesOfA, ...branchesOfB, standaloneWs];
 
-const rootMap = new Map<string, WorkspaceRecord>([
+const rootMap = new Map<string, RootWorkspace>([
   ["ws-a", rootA],
   ["ws-b", rootB],
 ]);
@@ -95,9 +95,10 @@ describe("filterWorkspaces — branch ordering within a Root", () => {
   });
 
   it("groups the Root workspace itself under its own header, above its dashboards", () => {
-    // ADR-004: the Root runtime Workspace shares its id with the Record,
-    // and its `rootWorkspaceId` is undefined. It should still appear
-    // nested under its own group, sorted as the type-0 main entry.
+    // ADR-004: the Root runtime Workspace shares its id with the
+    // RootWorkspace, and its `rootWorkspaceId` is undefined. It should
+    // still appear nested under its own group, sorted as the type-0
+    // main entry.
     const root = makeRoot("ws-x", "Agent Skills");
     const rootSelf = makeWs({ id: "ws-x", name: "Agent Skills" });
     const settings = makeWs({
@@ -284,7 +285,7 @@ describe("filterWorkspaces — flat mode (no rootWorkspaces)", () => {
     makeWs({ id: "nw-5", name: "standalone" }),
   ];
 
-  const flatRootMap = new Map<string, WorkspaceRecord>([
+  const flatRootMap = new Map<string, RootWorkspace>([
     ["ws-a", makeRoot("ws-a", "Alpha Root")],
     ["ws-b", makeRoot("ws-b", "Beta Corp")],
   ]);

--- a/src/__tests__/workspace-switcher-filter.test.ts
+++ b/src/__tests__/workspace-switcher-filter.test.ts
@@ -93,6 +93,47 @@ describe("filterWorkspaces — branch ordering within a Root", () => {
     const ids = result.filter((r) => r.kind === "branch").map((r) => r.ws.id);
     expect(ids).toEqual(["nw-main", "nw-branch", "nw-dash"]);
   });
+
+  it("groups the Root workspace itself under its own header, above its dashboards", () => {
+    // ADR-004: the Root runtime Workspace shares its id with the Record,
+    // and its `rootWorkspaceId` is undefined. It should still appear
+    // nested under its own group, sorted as the type-0 main entry.
+    const root = makeRoot("ws-x", "Agent Skills");
+    const rootSelf = makeWs({ id: "ws-x", name: "Agent Skills" });
+    const settings = makeWs({
+      id: "nw-settings",
+      name: "Settings",
+      rootWorkspaceId: "ws-x",
+      isDashboard: true,
+    });
+    const shortcuts = makeWs({
+      id: "nw-shortcuts",
+      name: "Keyboard Shortcuts",
+      rootWorkspaceId: "ws-x",
+      isDashboard: true,
+    });
+
+    // Supply in wrong order so we know the sort is doing the work.
+    const result = filterWorkspaces(
+      [settings, rootSelf, shortcuts],
+      new Map([["ws-x", root]]),
+      "",
+      [root],
+    );
+
+    // Order: header, root-self (depth=1), dashboards
+    expect(result.map((r) => ({ id: r.ws.id, kind: r.kind }))).toEqual([
+      { id: "ws-x", kind: "root" },
+      { id: "ws-x", kind: "branch" },
+      { id: "nw-settings", kind: "branch" },
+      { id: "nw-shortcuts", kind: "branch" },
+    ]);
+
+    const rootSelfRow = result.find(
+      (r) => r.kind === "branch" && r.ws.id === "ws-x",
+    );
+    expect(rootSelfRow?.depth).toBe(1);
+  });
 });
 
 describe("filterWorkspaces — grouped mode (rootWorkspaces provided)", () => {

--- a/src/__tests__/workspace-switcher.test.ts
+++ b/src/__tests__/workspace-switcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { filterWorkspaces } from "../lib/services/workspace-switcher-filter";
 import type { Workspace } from "../lib/types";
-import type { WorkspaceRecord } from "../lib/config";
+import type { RootWorkspace } from "../lib/config";
 
 // ---- Minimal stubs ----
 
@@ -22,7 +22,7 @@ function makeWs(
   } as Workspace;
 }
 
-function makeParent(id: string, name: string): WorkspaceRecord {
+function makeParent(id: string, name: string): RootWorkspace {
   return {
     id,
     name,
@@ -47,7 +47,7 @@ const branches = [
   makeWs({ id: "nw-5", name: "standalone" }), // no parent
 ];
 
-const parentMap = new Map<string, WorkspaceRecord>([
+const parentMap = new Map<string, RootWorkspace>([
   ["ws-a", parentA],
   ["ws-b", parentB],
 ]);

--- a/src/extensions/api.ts
+++ b/src/extensions/api.ts
@@ -844,10 +844,10 @@ export interface ExtensionAPI {
    *   Props: `{ theme: Readable<ThemeDef>, value: string (bindable), colors?: string[] }`
    * - **DragGrip** — left-border drag handle that appears on hover
    *   Props: `{ theme, visible, onMouseDown, ariaLabel? }`
-   * - **ContainerRow** — shared banner + child-list chrome for
-   *   "container workspaces" (workspaces, agent dashboards). Banner can
-   *   represent a first-class workspace by wiring onBannerClick/onClose
-   *   to switchWorkspace/closeWorkspace.
+   * - **SidebarBanner** — root-row chrome for a Workspace banner in the
+   *   primary sidebar. Owns grip + visible bar + nested list. Banner
+   *   can represent a first-class workspace by wiring
+   *   onBannerClick/onClose to switchWorkspace/closeWorkspace.
    *   Props: `{ color, foreground, parentColor?, onGripMouseDown?,
    *     onBannerClick?, onBannerContextMenu?, onClose?, filterIds,
    *     dashboardHintFor?, hideStatusBadges?, scopeId, containerBlockId,
@@ -859,7 +859,7 @@ export interface ExtensionAPI {
     ColorPicker: unknown;
     DragGrip: unknown;
     DropGhost: unknown;
-    ContainerRow: unknown;
+    SidebarBanner: unknown;
     PathStatusLine: unknown;
   };
 

--- a/src/extensions/diff-viewer/index.ts
+++ b/src/extensions/diff-viewer/index.ts
@@ -113,7 +113,7 @@ export function registerDiffViewerExtension(api: ExtensionAPI): void {
  * Materialize a Diff dashboard workspace for `workspace`. The dashboard
  * owns a single `diff-viewer:diff` surface pointed at the workspace's
  * repository; the `Uncommitted Changes` name mirrors the surface the
- * old container-banner diff link used to spawn. Surface props match
+ * old sidebar-banner diff link used to spawn. Surface props match
  * the `show-uncommitted` command so the rendered diff is identical.
  */
 async function createDiffDashboardWorkspace(

--- a/src/lib/bootstrap/init-workspaces.ts
+++ b/src/lib/bootstrap/init-workspaces.ts
@@ -42,7 +42,7 @@ import GearIcon from "../icons/GearIcon.svelte";
 import GridIcon from "../icons/GridIcon.svelte";
 import WorkspacesWidget from "../components/WorkspacesWidget.svelte";
 import { registerMarkdownComponent } from "../services/markdown-component-registry";
-import type { WorkspaceRecord as Workspace } from "../stores/workspace";
+import type { RootWorkspace as Workspace } from "../stores/workspace";
 import {
   pendingCreateResolver,
   createDialogPrefill,

--- a/src/lib/bootstrap/init-workspaces.ts
+++ b/src/lib/bootstrap/init-workspaces.ts
@@ -239,8 +239,8 @@ export async function initWorkspaces(): Promise<void> {
   // from the canonical tag on each load.
   reclaimBranchedWorkspaces();
 
-  // Root-row renderer for "workspace" kind. ContainerRow inside
-  // the renderer owns the grip/banner/child-list chrome; the rail
+  // Root-row renderer for "workspace" kind. SidebarBanner inside
+  // the renderer owns the grip/bar/child-list chrome; the rail
   // color + label resolvers let the outer list paint the grip in the
   // workspace's color and show its name in the drag overlay.
   registerRootRowRenderer({

--- a/src/lib/bootstrap/restore-workspaces.test.ts
+++ b/src/lib/bootstrap/restore-workspaces.test.ts
@@ -103,7 +103,7 @@ describe("restoreWorkspaces — owned dashboards survive restart", () => {
     expect(dash?.dashboardContributionId).toBe("group");
 
     // Regression: root-shaped Workspaces must own a (possibly empty)
-    // `branchedWorkspaceIds` array. WorkspaceRecord's contract requires
+    // `branchedWorkspaceIds` array. RootWorkspace's contract requires
     // it; consumers like WorkspaceSectionContent crash if it's undefined.
     const root = restored.find((w) => w.id === "root-1");
     expect(Array.isArray(root?.branchedWorkspaceIds)).toBe(true);

--- a/src/lib/components/ArchiveZone.svelte
+++ b/src/lib/components/ArchiveZone.svelte
@@ -215,7 +215,6 @@
     position: absolute;
     inset: 0;
     border: 3px solid;
-    border-left-width: 6px;
     border-radius: 6px;
     opacity: 0.35;
     pointer-events: none;

--- a/src/lib/components/ContainerRow.svelte
+++ b/src/lib/components/ContainerRow.svelte
@@ -88,6 +88,12 @@
    */
   export let workspaceListViewComponent: Component | unknown | undefined =
     undefined;
+  /**
+   * True while this root row's collapsed-mode popover is open. Forwarded
+   * to the SidebarRail so the rail stays full-width while the banner is
+   * being shown, even after the cursor has left the rail itself.
+   */
+  export let popoverActive: boolean = false;
 
   let bannerHovered = false;
 
@@ -204,6 +210,8 @@
         canDrag={true}
         {locked}
         hasActiveStripe={hasActiveChild && collapsed}
+        isActive={hasActiveChild}
+        {popoverActive}
         {onGripMouseDown}
         {onClose}
         closeTooltip="Delete Workspace"

--- a/src/lib/components/ContainerRow.svelte
+++ b/src/lib/components/ContainerRow.svelte
@@ -213,6 +213,7 @@
         isActive={hasActiveChild}
         {popoverActive}
         {onGripMouseDown}
+        onClick={onBannerClick}
         {onClose}
         closeTooltip="Delete Workspace"
       />

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -49,7 +49,7 @@
   /** When set, renders this label in the close/lock slot during meta-hold (shortcutHintsActive). */
   export let shortcutLabel: string | undefined = undefined;
   /**
-   * Renders the rail stripe at the slim 6px width instead of the full
+   * Renders the rail stripe at the slim 4px width instead of the full
    * 8px. Callers set this in collapsed sidebar mode for inactive,
    * non-hovered rows whose popover/banner isn't open, so the rail reads
    * as a thin accent that expands back to 8px the moment any of those
@@ -85,7 +85,7 @@
   $: fritBackgroundRepeat = "repeat";
   $: showDots = visible && alwaysShowDots;
   $: showRailStripe = !visible;
-  $: railStripeWidth = narrowRail ? "6px" : "8px";
+  $: railStripeWidth = narrowRail ? "4px" : "8px";
 </script>
 
 <div

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -48,6 +48,15 @@
   export let locked: boolean = false;
   /** When set, renders this label in the close/lock slot during meta-hold (shortcutHintsActive). */
   export let shortcutLabel: string | undefined = undefined;
+  /**
+   * Renders the rail stripe at the slim 6px width instead of the full
+   * 8px. Callers set this in collapsed sidebar mode for inactive,
+   * non-hovered rows whose popover/banner isn't open, so the rail reads
+   * as a thin accent that expands back to 8px the moment any of those
+   * conditions flips. The grip wrapper itself stays 8px wide so row
+   * layout is unaffected.
+   */
+  export let narrowRail: boolean = false;
 
   let closeButtonHovered = false;
   // shortcutLabel takes priority over close/lock when meta-hold is active.
@@ -69,6 +78,7 @@
   $: fritBackgroundRepeat = "repeat";
   $: showDots = visible && alwaysShowDots;
   $: showRailStripe = !visible;
+  $: railStripeWidth = narrowRail ? "6px" : "8px";
 </script>
 
 <div
@@ -93,9 +103,10 @@
       style="
         position: absolute;
         left: 0; top: 0; bottom: 0;
-        width: 8px;
+        width: {railStripeWidth};
         background: {effectiveColor};
         opacity: {railOpacity};
+        transition: width 0.1s;
       "
     ></div>
   {/if}

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -57,6 +57,13 @@
    * layout is unaffected.
    */
   export let narrowRail: boolean = false;
+  /**
+   * When true, the grip's primary action is a click (activate the row)
+   * rather than a drag — so the cursor reads `pointer` instead of
+   * `grab`. Callers set this in collapsed sidebar mode where the rail
+   * is the row's main interaction target.
+   */
+  export let primaryClickable: boolean = false;
 
   let closeButtonHovered = false;
   // shortcutLabel takes priority over close/lock when meta-hold is active.
@@ -90,7 +97,13 @@
     align-self: stretch;
     position: relative;
     width: 8px;
-    cursor: {locked ? 'not-allowed' : visible ? 'grab' : 'default'};
+    cursor: {locked
+    ? 'not-allowed'
+    : primaryClickable
+      ? 'pointer'
+      : visible
+        ? 'grab'
+        : 'default'};
     overflow: hidden;
   "
 >

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -83,8 +83,12 @@
   $: fritBackgroundSize = "5px 5px";
   $: fritBackgroundPosition = "0 0, 2.5px 2.5px";
   $: fritBackgroundRepeat = "repeat";
-  $: showDots = visible && alwaysShowDots;
-  $: showRailStripe = !visible;
+  // In narrow-rail mode the painted color stays at 4px even when the
+  // rail is hovered — so the stripe renders regardless of `visible`,
+  // and the hover dot pattern is suppressed (it would otherwise paint
+  // 8px wide and contradict the 4px policy).
+  $: showDots = visible && alwaysShowDots && !narrowRail;
+  $: showRailStripe = !visible || narrowRail;
   $: railStripeWidth = narrowRail ? "4px" : "8px";
 </script>
 

--- a/src/lib/components/PaneView.svelte
+++ b/src/lib/components/PaneView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { theme } from "../stores/theme";
+  import { sidebarVisible } from "../stores/ui";
   import { workspaces } from "../stores/workspace";
   import { commandStore } from "../services/command-registry";
   import TabBar from "./TabBar.svelte";
@@ -219,8 +220,13 @@
     position: relative;
     --notify: {$theme.notify};
     --notify-glow: {$theme.notifyGlow};
-    border: 1px solid {paneHasUnread ? $theme.notify : $theme.border};
-    border-radius: 4px; overflow: hidden;
+    border-top: 1px solid {paneHasUnread ? $theme.notify : $theme.border};
+    border-right: 1px solid {paneHasUnread ? $theme.notify : $theme.border};
+    border-bottom: 1px solid {paneHasUnread ? $theme.notify : $theme.border};
+    border-left: {$sidebarVisible
+    ? `1px solid ${paneHasUnread ? $theme.notify : $theme.border}`
+    : 'none'};
+    border-radius: {$sidebarVisible ? '4px' : '0 4px 4px 0'}; overflow: hidden;
     {paneHasUnread
     ? `box-shadow: 0 0 0 1px ${$theme.notifyGlow}, 0 0 14px 1px ${$theme.notifyGlow};`
     : ''}

--- a/src/lib/components/PseudoWorkspaceRow.svelte
+++ b/src/lib/components/PseudoWorkspaceRow.svelte
@@ -119,6 +119,7 @@
       railOpacity={1}
       alwaysShowDots={true}
       {narrowRail}
+      primaryClickable={!$sidebarVisible}
     />
     <div
       aria-hidden="true"

--- a/src/lib/components/PseudoWorkspaceRow.svelte
+++ b/src/lib/components/PseudoWorkspaceRow.svelte
@@ -12,7 +12,7 @@
    * calls onClose() so the registrar can wire up a reopen affordance.
    */
   import { theme } from "../stores/theme";
-  import { canSidebarDrag } from "../stores/ui";
+  import { canSidebarDrag, sidebarVisible } from "../stores/ui";
   import { activePseudoWorkspaceId } from "../stores/workspace";
   import { activeWorkspaceId } from "../stores/workspace";
   import DragGrip from "./DragGrip.svelte";
@@ -33,6 +33,12 @@
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
   /** Sidebar position index for the ⌘N shortcut hint. */
   export let shortcutIdx: number | undefined = undefined;
+  /**
+   * True while this row's collapsed-mode popover/banner is open. Keeps
+   * the rail at full width while the banner is showing, even after the
+   * cursor has left the rail itself.
+   */
+  export let popoverActive: boolean = false;
 
   $: rowBodyApi = pseudo.rowBody
     ? getExtensionApiById(pseudo.source)
@@ -60,6 +66,11 @@
 
   $: isActive = $activePseudoWorkspaceId === pseudo.id;
   $: gripVisible = rowHovered && $canSidebarDrag;
+  // Mirror SidebarRail's collapsed-mode rail-width policy: thin when
+  // inactive, not currently hovered, AND the popover isn't open.
+  // Expanded mode keeps 8px.
+  $: narrowRail =
+    !$sidebarVisible && !isActive && !rowHovered && !popoverActive;
 
   function handleClose(): void {
     unregisterPseudoWorkspace(pseudo.id);
@@ -107,6 +118,7 @@
       railColor={bannerBackground}
       railOpacity={1}
       alwaysShowDots={true}
+      {narrowRail}
     />
     <div
       aria-hidden="true"

--- a/src/lib/components/PseudoWorkspaceRow.svelte
+++ b/src/lib/components/PseudoWorkspaceRow.svelte
@@ -12,7 +12,7 @@
    * calls onClose() so the registrar can wire up a reopen affordance.
    */
   import { theme } from "../stores/theme";
-  import { reorderContext } from "../stores/ui";
+  import { canSidebarDrag } from "../stores/ui";
   import { activePseudoWorkspaceId } from "../stores/workspace";
   import { activeWorkspaceId } from "../stores/workspace";
   import DragGrip from "./DragGrip.svelte";
@@ -59,7 +59,7 @@
   }
 
   $: isActive = $activePseudoWorkspaceId === pseudo.id;
-  $: gripVisible = rowHovered && $reorderContext === null;
+  $: gripVisible = rowHovered && $canSidebarDrag;
 
   function handleClose(): void {
     unregisterPseudoWorkspace(pseudo.id);

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -59,9 +59,8 @@
 <!-- Collapsed mode: the sidebar is absolutely positioned so it overlays
      the main column rather than sitting next to it as a flex sibling.
      The main column applies padding-left equal to RAIL_WIDTH_PX so its
-     content scoots out from under the overlay. This avoids any visual
-     seam at the rail/terminal edge. Expanded mode keeps the historical
-     flex-sibling layout. -->
+     content scoots out from under the overlay. Expanded mode keeps the
+     historical flex-sibling layout. -->
 <div
   id="sidebar"
   class:collapsed={!$sidebarVisible}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -102,9 +102,9 @@
   role="presentation"
   style="
     width: {$sidebarVisible ? `${$sidebarWidth}px` : `${RAIL_WIDTH_PX}px`};
-    background: {$theme.sidebarBg};
+    background: {$sidebarVisible ? $theme.sidebarBg : 'transparent'};
     display: flex;
-    overflow: {!$sidebarVisible && overlayActive ? 'visible' : 'hidden'};
+    overflow: hidden;
     font-size: 13px;
     flex-shrink: 0;
     position: relative;
@@ -122,11 +122,9 @@
       width: {$sidebarVisible ? '100%' : `${$sidebarWidth}px`};
       height: 100%;
       display: flex;
-      background: {$theme.sidebarBg};
+      background: {$sidebarVisible ? $theme.sidebarBg : 'transparent'};
       transition: box-shadow 120ms ease;
-      {$sidebarVisible
-      ? ''
-      : `position: absolute; left: 0; top: 0; z-index: 100; ${overlayActive ? 'box-shadow: 0 0 24px rgba(0, 0, 0, 0.45);' : ''}`}
+      {$sidebarVisible ? '' : 'position: absolute; left: 0; top: 0;'}
     "
   >
     <div

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -56,18 +56,24 @@
   }
 </script>
 
+<!-- Collapsed mode: the sidebar is absolutely positioned so it overlays
+     the main column rather than sitting next to it as a flex sibling.
+     The main column applies padding-left equal to RAIL_WIDTH_PX so its
+     content scoots out from under the overlay. This avoids any visual
+     seam at the rail/terminal edge. Expanded mode keeps the historical
+     flex-sibling layout. -->
 <div
   id="sidebar"
   class:collapsed={!$sidebarVisible}
   role="presentation"
   style="
-    width: {$sidebarVisible ? `${$sidebarWidth}px` : `${RAIL_WIDTH_PX}px`};
+    {$sidebarVisible
+    ? `position: relative; width: ${$sidebarWidth}px; flex-shrink: 0;`
+    : `position: absolute; left: 0; top: 0; bottom: 0; width: ${RAIL_WIDTH_PX}px; z-index: 2;`}
     background: {$sidebarVisible ? $theme.sidebarBg : $theme.bg};
     display: flex;
     overflow: hidden;
     font-size: 13px;
-    flex-shrink: 0;
-    position: relative;
   "
 >
   <!-- In collapsed mode the wrapper is a 12px rail strip clipped via

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -189,7 +189,9 @@
         {/each}
       </div>
 
-      <ArchiveZone />
+      {#if $sidebarVisible}
+        <ArchiveZone />
+      {/if}
     </div>
     {#if $sidebarVisible}
       <SidebarResizeHandle

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -62,7 +62,7 @@
   role="presentation"
   style="
     width: {$sidebarVisible ? `${$sidebarWidth}px` : `${RAIL_WIDTH_PX}px`};
-    background: {$sidebarVisible ? $theme.sidebarBg : 'transparent'};
+    background: {$sidebarVisible ? $theme.sidebarBg : $theme.bg};
     display: flex;
     overflow: hidden;
     font-size: 13px;
@@ -81,7 +81,7 @@
       width: {$sidebarVisible ? '100%' : `${$sidebarWidth}px`};
       height: 100%;
       display: flex;
-      background: {$sidebarVisible ? $theme.sidebarBg : 'transparent'};
+      background: {$sidebarVisible ? $theme.sidebarBg : $theme.bg};
       transition: box-shadow 120ms ease;
       {$sidebarVisible ? '' : 'position: absolute; left: 0; top: 0;'}
     "

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -11,7 +11,6 @@
    * render below it in their declared order but aren't reorderable
    * at the top level either.
    */
-  import { onDestroy } from "svelte";
   import { theme } from "../stores/theme";
   import { sidebarVisible, sidebarWidth } from "../stores/ui";
   import { sidebarSectionStore } from "../services/sidebar-section-registry";
@@ -25,49 +24,13 @@
   import SidebarResizeHandle from "./SidebarResizeHandle.svelte";
   import NewWorkspaceSplitButton from "./NewWorkspaceSplitButton.svelte";
 
-  // Brief grace period so users can drift off the slot for a moment
-  // (e.g. catching the OS scrollbar) without the overlay flashing shut.
-  const HOVER_CLOSE_DELAY_MS = 150;
-
   // Width of the rail-only slot when the sidebar is collapsed. The
-  // workspace banner's grip rail is 8px (DragGrip frit pattern); show
-  // it plus a few pixels of banner past the rail so the colour stripe
-  // is visible without revealing row content.
+  // wrapper paints a 12px-wide rail strip via overflow:hidden; each
+  // row inside renders at its natural width but is clipped here so
+  // only the leftmost rail edge shows. Per-row hover popovers (owned
+  // by WorkspaceListBlock) escape this clip via position:fixed so
+  // they appear at the row's y-coordinate at full sidebar width.
   const RAIL_WIDTH_PX = 12;
-
-  let overlayActive = false;
-  let closeTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function clearCloseTimer() {
-    if (closeTimer) {
-      clearTimeout(closeTimer);
-      closeTimer = null;
-    }
-  }
-
-  function handleSlotEnter() {
-    if ($sidebarVisible) return;
-    clearCloseTimer();
-    overlayActive = true;
-  }
-
-  function handleSlotLeave() {
-    if ($sidebarVisible) return;
-    clearCloseTimer();
-    closeTimer = setTimeout(() => {
-      overlayActive = false;
-      closeTimer = null;
-    }, HOVER_CLOSE_DELAY_MS);
-  }
-
-  // Reset overlay state whenever the sidebar expands so the overlay
-  // doesn't linger after the user toggles it back open.
-  $: if ($sidebarVisible) {
-    clearCloseTimer();
-    overlayActive = false;
-  }
-
-  onDestroy(clearCloseTimer);
 
   const iconSvgMap: Record<string, string> = {
     plus: `<line x1="8" y1="3" x2="8" y2="13" /><line x1="3" y1="8" x2="13" y2="8" />`,
@@ -96,9 +59,6 @@
 <div
   id="sidebar"
   class:collapsed={!$sidebarVisible}
-  class:overlay-active={!$sidebarVisible && overlayActive}
-  on:mouseenter={handleSlotEnter}
-  on:mouseleave={handleSlotLeave}
   role="presentation"
   style="
     width: {$sidebarVisible ? `${$sidebarWidth}px` : `${RAIL_WIDTH_PX}px`};
@@ -110,12 +70,11 @@
     position: relative;
   "
 >
-  <!-- In collapsed mode the inner content is absolutely positioned at
-       its full natural width but clipped by the rail slot's
-       overflow: hidden — exposing only the leftmost RAIL_WIDTH_PX
-       pixels of each row, which is where the workspace grip rail and
-       a sliver of the banner colour live. Hovering lifts the clip so
-       the full sidebar opens over the terminal. -->
+  <!-- In collapsed mode the wrapper is a 12px rail strip clipped via
+       overflow:hidden. Each row inside renders at its natural width
+       (clipped at the wrapper) — only the leftmost rail is visible.
+       Per-row hover popovers (rendered by WorkspaceListBlock) escape
+       this clip via position:fixed so they appear at the row's y. -->
   <div
     class="sidebar-content"
     style="

--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
   /**
-   * ContainerRow — shared root-row chrome for "container workspaces" in
-   * the Workspaces sidebar section (Workspaces, agent orchestrators).
+   * SidebarBanner — root-row chrome for a Workspace banner in the
+   * primary sidebar. Per `docs/ontology.md`, a "banner" is the sidebar
+   * block rendered for a `kind: "workspace"` entry in `rootRowOrder`,
+   * showing the Root Workspace's name, color, git status, and its
+   * nested Branch list. This component owns that whole block —
+   * grip + visible bar + nested list — and is the unit reused for
+   * banners hosted inside other banners (e.g. an Agentic Dashboard
+   * row inside its Workspace banner).
    *
-   * The banner is **inert**: callers cannot register a click handler.
-   * Interaction lives in the child rows inside the nested list (e.g. the
-   * Dashboard workspace item) or in the context menu. Internal buttons
-   * and links in `banner-end` stop their own propagation.
+   * The visible bar is **inert**: callers cannot register a click
+   * handler on it directly. Interaction lives in the child rows
+   * inside the nested list (e.g. the Dashboard workspace item) or
+   * in the context menu. Internal buttons and links in `banner-end`
+   * stop their own propagation.
    *
    * Visual variants:
-   *   - `parentColor` unset → root mode: grip + banner + nested list
+   *   - `parentColor` unset → root mode: grip + bar + nested list
    *     stretch together with the shared rail color.
-   *   - `parentColor` set → nested-inside-another-container mode: banner
-   *     only, no outer grip, with the orchestrator/Workspace color
-   *     painting the banner background and a small accent strip on the
-   *     right.
+   *   - `parentColor` set → nested-inside-another-banner mode: bar
+   *     only, no outer grip, with the host banner's color painting
+   *     the bar background and a small accent strip on the right.
    */
   import { type Component } from "svelte";
   import { slide } from "svelte/transition";
@@ -28,9 +34,9 @@
   /** Banner + rail color. Required. */
   export let color: string;
   /**
-   * When set, render the nested variant: banner only (no grip), painted
-   * with `color` as background. Used when this container is nested
-   * inside another container (e.g. a dashboard under a Workspace).
+   * When set, render the nested variant: bar only (no grip), painted
+   * with `color` as background. Used when this banner is nested
+   * inside another banner (e.g. a dashboard under a Workspace).
    */
   export let parentColor: string | undefined = undefined;
   /**
@@ -42,13 +48,13 @@
   export let onBannerContextMenu: ((e: MouseEvent) => void) | undefined =
     undefined;
   /**
-   * Banner body left-click — fires for clicks anywhere in the banner
-   * row (including the git-status subtitle area). Interactive children
-   * inside the banner (SplitButton chips, PR/diff links) call
+   * Banner body left-click — fires for clicks anywhere in the bar
+   * (including the git-status subtitle area). Interactive children
+   * inside the bar (SplitButton chips, PR/diff links) call
    * `stopPropagation` so they don't bubble into this handler.
    */
   export let onBannerClick: (() => void) | undefined = undefined;
-  /** Optional close/delete handler. When provided, a × button appears on banner hover. */
+  /** Optional close/delete handler. When provided, a × button appears on bar hover. */
   export let onClose: (() => void) | undefined = undefined;
   /** When true, shows a lock chip on the grip instead of the close button. */
   export let locked: boolean = false;
@@ -61,24 +67,24 @@
         ws: Workspace,
       ) => { id: string; color?: string; onClick: () => void } | undefined)
     | undefined = undefined;
-  /** Forwarded: suppress per-row status badges when the container aggregates. */
+  /** Forwarded: suppress per-row status badges when the banner aggregates. */
   export let hideStatusBadges: boolean = false;
   /**
-   * When true, a child workspace inside this container is the active
-   * workspace. The banner swaps its idle `$theme.border` stroke for the
-   * container's `color` so the active state ties the workspace banner
+   * When true, a child workspace inside this banner is the active
+   * workspace. The bar swaps its idle `$theme.border` stroke for the
+   * banner's `color` so the active state ties the workspace banner
    * to its active child visually.
    */
   export let hasActiveChild: boolean = false;
-  /** Drag scope id (container id). */
+  /** Drag scope id (banner id). */
   export let scopeId: string;
-  /** Sidebar block id the container belongs to (for drag context). */
+  /** Sidebar block id the banner belongs to (for drag context). */
   export let containerBlockId: string = "__workspaces__";
   /** Human-readable label surfaced in the nested list's context menu. */
   export let containerLabel: string = "";
   /**
    * Optional data attribute for identifying the row in tests / DOM.
-   * Defaults to `data-container-row` without a value.
+   * Defaults to `data-sidebar-banner` without a value.
    */
   export let testId: string | undefined = undefined;
   /**
@@ -89,9 +95,9 @@
   export let workspaceListViewComponent: Component | unknown | undefined =
     undefined;
   /**
-   * True while this root row's collapsed-mode popover is open. Forwarded
-   * to the SidebarRail so the rail stays full-width while the banner is
-   * being shown, even after the cursor has left the rail itself.
+   * True while this banner's collapsed-mode popover is open. Forwarded
+   * to the SidebarRail so the rail stays full-width while the popover
+   * is being shown, even after the cursor has left the rail itself.
    */
   export let popoverActive: boolean = false;
 
@@ -118,20 +124,20 @@
     DefaultWorkspaceListView) as Component;
 </script>
 
-<!-- The banner banner sits flush with the viewport's left edge. When the
+<!-- The banner sits flush with the viewport's left edge. When the
      cursor exits through that edge fast (or out the top into the title
      bar on Linux/WebKitGTK), the row's own `mouseleave` can be skipped,
-     leaving the banner stuck in its hovered state. A body-level
-     mouseleave is the authoritative "cursor left the app" signal — when
-     it fires we know no DOM element should be considered hovered. -->
+     leaving the bar stuck in its hovered state. A body-level
+     mouseleave is the authoritative "cursor left the app" signal —
+     when it fires we know no DOM element should be considered hovered. -->
 <svelte:body on:mouseleave={() => (bannerHovered = false)} />
 
 {#if parentColor}
-  <!-- Child-inside-parent variant — banner only, with left-edge
-       colored accent. Uses SidebarElement for unified styling. -->
+  <!-- Nested variant — bar only, with left-edge colored accent. Uses
+       SidebarElement for unified styling. -->
   <div
-    data-container-row={testId ?? ""}
-    data-container-mode="child"
+    data-sidebar-banner={testId ?? ""}
+    data-sidebar-banner-mode="child"
     style="position: relative;"
   >
     <SidebarElement
@@ -147,7 +153,7 @@
       onContextMenu={onBannerContextMenu}
     >
       <div
-        data-container-banner-body
+        data-sidebar-banner-row-body
         style="padding: 4px 8px; display: flex; flex-direction: column; gap: 2px; min-height: 32px; justify-content: center; flex: 1; min-width: 0;"
       >
         <div
@@ -159,7 +165,7 @@
         </div>
         <slot name="banner-subtitle" {collapsed} />
         {#if $$slots["btn-row"]}
-          <div class="container-btn-row">
+          <div class="sidebar-banner-btn-row">
             <slot
               name="btn-row"
               {collapsed}
@@ -172,7 +178,7 @@
     </SidebarElement>
     {#if !collapsed && nonDashboardCount > 0}
       <div
-        data-container-children={scopeId}
+        data-sidebar-banner-children={scopeId}
         data-children-count={nonDashboardCount}
         style="display: flex; flex-direction: column;"
         transition:slide={{ duration: 200 }}
@@ -192,15 +198,15 @@
   </div>
 {:else}
   <!-- Root variant — the colored grip column lives at the outer flex
-       level so it stretches the full workspace height (a continuous rail
-       connecting the banner to the children). A light border
-       (matching the inactive dashboard-tile stroke) wraps only the
-       banner row; the child workspace list renders below the border
-       so children carry their own chrome. -->
+       level so it stretches the full banner height (a continuous rail
+       connecting the bar to the children). A light border (matching
+       the inactive dashboard-tile stroke) wraps only the bar; the
+       child workspace list renders below the border so children carry
+       their own chrome. -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    data-container-row={testId ?? ""}
-    data-container-mode="root"
+    data-sidebar-banner={testId ?? ""}
+    data-sidebar-banner-mode="root"
     style="display: flex; position: relative; align-items: stretch;"
   >
     {#if onGripMouseDown}
@@ -227,7 +233,7 @@
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
-        data-container-banner
+        data-sidebar-banner-row
         style="
           position: relative;
           padding: 4px 6px 4px 0;
@@ -257,7 +263,7 @@
         on:mouseleave={() => (bannerHovered = false)}
       >
         <div
-          data-container-banner-body
+          data-sidebar-banner-row-body
           style="padding-left: 8px; padding-right: 0; display: flex; flex-direction: column; gap: 2px; min-height: 32px; justify-content: center;"
         >
           <div
@@ -269,7 +275,7 @@
           </div>
           <slot name="banner-subtitle" {bannerHovered} {collapsed} />
           {#if $$slots["btn-row"]}
-            <div class="container-btn-row">
+            <div class="sidebar-banner-btn-row">
               <slot
                 name="btn-row"
                 {collapsed}
@@ -282,7 +288,7 @@
       </div>
       {#if !collapsed && nonDashboardCount > 0}
         <div
-          data-container-children={scopeId}
+          data-sidebar-banner-children={scopeId}
           data-children-count={nonDashboardCount}
           style="display: flex; flex-direction: column; margin-left: -2px; margin-top: -2px;"
           transition:slide={{ duration: 200 }}
@@ -304,13 +310,13 @@
 {/if}
 
 <style>
-  .container-btn-row {
+  .sidebar-banner-btn-row {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
     margin: 4px 0 2px;
   }
-  :global([data-container-mode="root"] button) {
+  :global([data-sidebar-banner-mode="root"] button) {
     cursor: pointer;
   }
 </style>

--- a/src/lib/components/SidebarElement.svelte
+++ b/src/lib/components/SidebarElement.svelte
@@ -5,8 +5,8 @@
    * sidebar.
    *
    * Used by WorkspaceItem (Branch rows, including dashboard rows)
-   * and by ContainerRow's Branch-inside-Workspace variant. The root
-   * ContainerRow variant builds its own banner because its rail spans
+   * and by SidebarBanner's Branch-inside-Workspace variant. The root
+   * SidebarBanner variant builds its own banner because its rail spans
    * multiple rows; see that file for details.
    *
    * The wrapper itself is intentionally inert — callers that want a
@@ -22,7 +22,7 @@
    * Row variant. Drives chrome (banner gradient, close vs no-close,
    * data-sidebar-element marker) and default density:
    *
-   *   - "parent"    — workspace banner row (ContainerRow). Renders the
+   *   - "parent"    — workspace banner row (SidebarBanner). Renders the
    *                   gradient rail; close/lock affordances are
    *                   suppressed because callers manage closure on the
    *                   banner itself.

--- a/src/lib/components/SidebarElement.svelte
+++ b/src/lib/components/SidebarElement.svelte
@@ -74,6 +74,13 @@
   /** Callback when drag grip is pressed */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
 
+  /**
+   * Callback when the rail itself is clicked. Lets the colored rail
+   * stripe act as an activation target alongside the slot content's own
+   * click handler. Pass-through to SidebarRail.
+   */
+  export let onRailClick: (() => void) | undefined = undefined;
+
   /** Callback when close button is clicked */
   export let onClose: (() => void) | undefined = undefined;
 
@@ -146,6 +153,7 @@
     {isActive}
     {popoverActive}
     {onGripMouseDown}
+    onClick={onRailClick}
   />
   {#if isParent}
     <!-- Workspace banner rail gradient -->

--- a/src/lib/components/SidebarElement.svelte
+++ b/src/lib/components/SidebarElement.svelte
@@ -49,6 +49,13 @@
   /** Whether this element is currently active */
   export let isActive: boolean = false;
 
+  /**
+   * True while the row's collapsed-mode hover banner is open. Forwarded
+   * to SidebarRail so the rail stays at full width while the banner is
+   * shown, even after the cursor has left the rail itself.
+   */
+  export let popoverActive: boolean = false;
+
   /** Whether this element is locked (shows lock icon instead of close) */
   export let isLocked: boolean = false;
 
@@ -136,6 +143,8 @@
     {canDrag}
     locked={isLocked}
     {isDragging}
+    {isActive}
+    {popoverActive}
     {onGripMouseDown}
   />
   {#if isParent}

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -2,8 +2,8 @@
   /**
    * SidebarRail — shared drag rail (DragGrip + hover scoping + lock /
    * close handling) used by both SidebarElement (single-row rail)
-   * and ContainerRow's root variant (multi-row rail that stretches the
-   * full container height).
+   * and SidebarBanner's root variant (multi-row rail that stretches the
+   * full banner height).
    *
    * Modes:
    *   - "row":       1-row rail. No external border. Close button is

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -123,6 +123,7 @@
     {closeTooltip}
     {locked}
     {narrowRail}
+    primaryClickable={!$sidebarVisible && !!onClick}
   />
   {#if mode === "container" && hasActiveStripe}
     <div

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -13,7 +13,7 @@
    *                  hosts the close button inside the grip.
    */
   import { theme } from "../stores/theme";
-  import { anyReorderActive } from "../stores/ui";
+  import { anyReorderActive, sidebarVisible } from "../stores/ui";
   import DragGrip from "./DragGrip.svelte";
 
   export let mode: "row" | "container" = "row";
@@ -72,7 +72,7 @@
     position: relative;
     {mode === 'container'
     ? `flex-shrink: 0; align-self: stretch; box-sizing: border-box;
-         border-left: 1px solid ${railBorderColor};
+         ${$sidebarVisible ? `border-left: 1px solid ${railBorderColor};` : ''}
          border-top: 1px solid ${color};
          border-bottom: 1px solid ${color};`
     : ''}

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -33,6 +33,23 @@
   /** Container mode: paint a 1px accent stripe at the rail's left edge. */
   export let hasActiveStripe: boolean = false;
 
+  /**
+   * Whether the owning row/container represents the active workspace (or
+   * has an active descendant in container mode). Drives rail-width in
+   * collapsed sidebar mode: active rails stay 8px so the active row
+   * remains visually anchored, inactive rails shrink to 6px and expand
+   * back to 8px on hover. Has no effect when the sidebar is expanded.
+   */
+  export let isActive: boolean = false;
+
+  /**
+   * True while the row's hover banner/popover is open. Treated like a
+   * hover signal for rail width: the rail stays at 8px while the popover
+   * is showing, even if the cursor has left the rail itself for the
+   * popover body. Has no effect when the sidebar is expanded.
+   */
+  export let popoverActive: boolean = false;
+
   /** Mousedown handler for drag start. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
 
@@ -47,6 +64,15 @@
   $: effectiveCanDrag = canDrag && $canSidebarDrag;
   $: visible = isDragging || (effectiveCanDrag && railHovered && !locked);
   $: railBorderColor = $theme.border ?? "transparent";
+  // Collapsed mode rail-width policy: thin (6px) when inactive, not
+  // currently hovered/dragged, AND the row's popover/banner isn't open.
+  // Expanded mode keeps the historical 8px rail regardless of state.
+  $: narrowRail =
+    !$sidebarVisible &&
+    !isActive &&
+    !railHovered &&
+    !isDragging &&
+    !popoverActive;
 </script>
 
 <!-- The rail occupies the leftmost 8px of the row, flush with the
@@ -87,6 +113,7 @@
     onClose={mode === "container" && !locked ? onClose : undefined}
     {closeTooltip}
     {locked}
+    {narrowRail}
   />
   {#if mode === "container" && hasActiveStripe}
     <div

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -53,6 +53,14 @@
   /** Mousedown handler for drag start. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
 
+  /**
+   * Click handler for the rail itself. Lets the rail behave as an
+   * activation target — clicking the colored stripe activates the row /
+   * container that owns it. The grip's internal close button stops
+   * propagation, so closing never doubles as an activate.
+   */
+  export let onClick: (() => void) | undefined = undefined;
+
   /** Container mode: rail-mounted close button. */
   export let onClose: (() => void) | undefined = undefined;
 
@@ -93,6 +101,7 @@
       onGripMouseDown(e);
     }
   }}
+  on:click={() => onClick?.()}
   style="
     display: flex;
     position: relative;

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -72,15 +72,14 @@
   $: effectiveCanDrag = canDrag && $canSidebarDrag;
   $: visible = isDragging || (effectiveCanDrag && railHovered && !locked);
   $: railBorderColor = $theme.border ?? "transparent";
-  // Collapsed mode rail-width policy: thin (4px) when inactive, not
-  // currently hovered/dragged, AND the row's popover/banner isn't open.
-  // Expanded mode keeps the historical 8px rail regardless of state.
+  // Collapsed mode rail-width policy: thin (4px) when inactive and the
+  // row isn't being dragged or showing a popover. Hovering the rail no
+  // longer widens the painted color — the 8px wrapper still catches the
+  // hover for popover triggering, but the rendered stripe stays at 4px
+  // so hover doesn't visually overlap the active-rail width. Expanded
+  // mode keeps the historical 8px rail regardless of state.
   $: narrowRail =
-    !$sidebarVisible &&
-    !isActive &&
-    !railHovered &&
-    !isDragging &&
-    !popoverActive;
+    !$sidebarVisible && !isActive && !isDragging && !popoverActive;
 </script>
 
 <!-- The rail occupies the leftmost 8px of the row, flush with the
@@ -108,8 +107,8 @@
     {mode === 'container'
     ? `flex-shrink: 0; align-self: stretch; box-sizing: border-box;
          ${$sidebarVisible ? `border-left: 1px solid ${railBorderColor};` : ''}
-         border-top: 1px solid ${color};
-         border-bottom: 1px solid ${color};`
+         border-top: 1px solid ${isActive ? color : railBorderColor};
+         border-bottom: 1px solid ${isActive ? color : railBorderColor};`
     : ''}
   "
 >

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -13,7 +13,7 @@
    *                  hosts the close button inside the grip.
    */
   import { theme } from "../stores/theme";
-  import { anyReorderActive, sidebarVisible } from "../stores/ui";
+  import { sidebarVisible, canSidebarDrag } from "../stores/ui";
   import DragGrip from "./DragGrip.svelte";
 
   export let mode: "row" | "container" = "row";
@@ -44,8 +44,8 @@
 
   let railHovered = false;
 
-  $: visible =
-    isDragging || (canDrag && railHovered && !$anyReorderActive && !locked);
+  $: effectiveCanDrag = canDrag && $canSidebarDrag;
+  $: visible = isDragging || (effectiveCanDrag && railHovered && !locked);
   $: railBorderColor = $theme.border ?? "transparent";
 </script>
 
@@ -63,7 +63,7 @@
   on:mouseenter={() => (railHovered = true)}
   on:mouseleave={() => (railHovered = false)}
   on:mousedown={(e) => {
-    if (railHovered && onGripMouseDown) {
+    if (railHovered && effectiveCanDrag && onGripMouseDown) {
       onGripMouseDown(e);
     }
   }}

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -37,7 +37,7 @@
    * Whether the owning row/container represents the active workspace (or
    * has an active descendant in container mode). Drives rail-width in
    * collapsed sidebar mode: active rails stay 8px so the active row
-   * remains visually anchored, inactive rails shrink to 6px and expand
+   * remains visually anchored, inactive rails shrink to 4px and expand
    * back to 8px on hover. Has no effect when the sidebar is expanded.
    */
   export let isActive: boolean = false;
@@ -72,7 +72,7 @@
   $: effectiveCanDrag = canDrag && $canSidebarDrag;
   $: visible = isDragging || (effectiveCanDrag && railHovered && !locked);
   $: railBorderColor = $theme.border ?? "transparent";
-  // Collapsed mode rail-width policy: thin (6px) when inactive, not
+  // Collapsed mode rail-width policy: thin (4px) when inactive, not
   // currently hovered/dragged, AND the row's popover/banner isn't open.
   // Expanded mode keeps the historical 8px rail regardless of state.
   $: narrowRail =

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -95,7 +95,7 @@
   // layout — suppress it in that context.
   $: isInsideWorkspace = typeof workspace.rootWorkspaceId === "string";
   // Surface the root Workspace's path-missing flag on every Branch row
-  // inside it. The Workspace banner (ContainerRow) currently has no
+  // inside it. The Workspace banner (SidebarBanner) currently has no
   // affordance for this state — flagging it on the row makes the
   // condition discoverable from anywhere the Branch renders.
   $: rootWorkspacePathMissing = (() => {

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -143,6 +143,12 @@
   export let dragActive = false;
   /** Mousedown handler fired when the drag grip is pressed. Drag origin, not row body. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
+  /**
+   * True while this row's collapsed-mode popover/banner is open.
+   * Forwarded to SidebarElement so the rail stays full-width while the
+   * banner is showing.
+   */
+  export let popoverActive: boolean = false;
 </script>
 
 <SidebarElement
@@ -150,6 +156,7 @@
   compact={isChild}
   name={workspace.name}
   {isActive}
+  {popoverActive}
   {isLocked}
   isDragging={dragActive}
   canDrag={!!onGripMouseDown}

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -169,6 +169,7 @@
     ? `${modLabel}${shortcutIdx + 1}`
     : undefined}
   {onGripMouseDown}
+  onRailClick={onSelect}
   {onClose}
   onContextMenu={(e) => {
     // Dashboards are non-interactive surfaces; right-click is a no-op.

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -16,9 +16,16 @@
    * WorkspaceListView.
    */
   import { derived } from "svelte/store";
+  import { onDestroy } from "svelte";
   import { theme } from "../stores/theme";
   import { workspaces } from "../stores/workspace";
-  import { reorderContext, canSidebarDrag } from "../stores/ui";
+  import {
+    reorderContext,
+    canSidebarDrag,
+    sidebarVisible,
+    sidebarWidth,
+    hoveredRootRowKey,
+  } from "../stores/ui";
   import {
     rootRowOrder,
     moveRootRow,
@@ -161,6 +168,59 @@
     },
   );
   $: renderedRows = $renderedRowsStore;
+
+  // --- Per-row popover (collapsed sidebar only) ---
+  //
+  // When the sidebar is collapsed, hovering an individual row's rail
+  // surfaces THAT row's full banner as an absolutely-positioned popover
+  // anchored at the row's y-coordinate. Other rails stay 12px-clipped.
+  // The hovered row's key drives both the popover render here AND the
+  // shared `hoveredRootRowKey` store so peer chrome (status badges, etc.)
+  // can react.
+  const POPOVER_GRACE_MS = 150;
+
+  let popoverRow: { key: string; top: number; height: number } | null = null;
+  let popoverGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPopoverGraceTimer() {
+    if (popoverGraceTimer) {
+      clearTimeout(popoverGraceTimer);
+      popoverGraceTimer = null;
+    }
+  }
+
+  function setPopoverFromEvent(e: MouseEvent, key: string) {
+    if ($sidebarVisible) return;
+    clearPopoverGraceTimer();
+    const target = e.currentTarget as HTMLElement | null;
+    if (!target) return;
+    const rect = target.getBoundingClientRect();
+    popoverRow = { key, top: rect.top, height: rect.height };
+    hoveredRootRowKey.set(key);
+  }
+
+  function clearPopoverWithGrace() {
+    if ($sidebarVisible) return;
+    clearPopoverGraceTimer();
+    popoverGraceTimer = setTimeout(() => {
+      popoverRow = null;
+      hoveredRootRowKey.set(null);
+      popoverGraceTimer = null;
+    }, POPOVER_GRACE_MS);
+  }
+
+  // Drop the popover whenever the sidebar expands so it doesn't linger
+  // after the user toggles state mid-hover.
+  $: if ($sidebarVisible) {
+    clearPopoverGraceTimer();
+    popoverRow = null;
+    if ($hoveredRootRowKey !== null) hoveredRootRowKey.set(null);
+  }
+
+  onDestroy(() => {
+    clearPopoverGraceTimer();
+    if ($hoveredRootRowKey !== null) hoveredRootRowKey.set(null);
+  });
 
   // --- Unified drag pipeline for the root list ---
   //
@@ -316,6 +376,47 @@
      moved up into Sidebar's top row so it aligns with the
      other title-row buttons. -->
 
+{#snippet rowBody(entry: RenderedRow)}
+  {#if entry.row.kind === "pseudo-workspace" && entry.pseudoWorkspace}
+    <PseudoWorkspaceRow
+      pseudo={entry.pseudoWorkspace}
+      onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
+    />
+  {:else if entry.standaloneDashboardWs}
+    {@const ws = entry.standaloneDashboardWs}
+    {@const globalIdx = $workspaces.findIndex((w) => w.id === ws.id)}
+    <WorkspaceItem
+      workspace={ws}
+      index={globalIdx}
+      isActive={globalIdx === $activeWorkspaceIdx}
+      onSelect={() => {
+        if (globalIdx >= 0) switchWorkspace(globalIdx);
+      }}
+      onClose={() => {
+        if (globalIdx >= 0) closeWorkspace(globalIdx);
+      }}
+      onRename={() => {}}
+      onContextMenu={() => {}}
+      onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
+      dragActive={false}
+      shortcutIdx={entry.workspaceOnlyIdx}
+    />
+  {:else if entry.rendererComponent && entry.rendererSource}
+    {@const extApi = getExtensionApiById(entry.rendererSource)}
+    {#if extApi}
+      <ExtensionWrapper
+        api={extApi}
+        component={entry.rendererComponent}
+        props={{
+          id: entry.row.id,
+          onGripMouseDown: (e: MouseEvent) => startRootRowDrag(e, entry.idx),
+          shortcutIdx: entry.workspaceOnlyIdx,
+        }}
+      />
+    {/if}
+  {/if}
+{/snippet}
+
 <!-- Root rows: Workspaces and pinned extension blocks interleaved per
      $rootRowOrder. Each row is shelled with a core-drawn DragGrip
      (left) + content (right). Non-source rows during a drag get a
@@ -355,51 +456,14 @@
   {#if !isSource}
     <div class="root-row" data-root-row-container={entry.idx}>
       <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div data-root-row-idx={entry.idx} style="position: relative;">
-        <!-- Row content — the renderer draws its OWN grip (via
-             onGripMouseDown) so the row looks self-contained (no gap
-             between active workspace bg and its rail). Core still owns
-             the drag pipeline — the renderer's grip just calls back
-             into startRootRowDrag. -->
-        {#if entry.row.kind === "pseudo-workspace" && entry.pseudoWorkspace}
-          <PseudoWorkspaceRow
-            pseudo={entry.pseudoWorkspace}
-            onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
-          />
-        {:else if entry.standaloneDashboardWs}
-          {@const ws = entry.standaloneDashboardWs}
-          {@const globalIdx = $workspaces.findIndex((w) => w.id === ws.id)}
-          <WorkspaceItem
-            workspace={ws}
-            index={globalIdx}
-            isActive={globalIdx === $activeWorkspaceIdx}
-            onSelect={() => {
-              if (globalIdx >= 0) switchWorkspace(globalIdx);
-            }}
-            onClose={() => {
-              if (globalIdx >= 0) closeWorkspace(globalIdx);
-            }}
-            onRename={() => {}}
-            onContextMenu={() => {}}
-            onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
-            dragActive={isSource}
-            shortcutIdx={entry.workspaceOnlyIdx}
-          />
-        {:else if entry.rendererComponent && entry.rendererSource}
-          {@const extApi = getExtensionApiById(entry.rendererSource)}
-          {#if extApi}
-            <ExtensionWrapper
-              api={extApi}
-              component={entry.rendererComponent}
-              props={{
-                id: entry.row.id,
-                onGripMouseDown: (e: MouseEvent) =>
-                  startRootRowDrag(e, entry.idx),
-                shortcutIdx: entry.workspaceOnlyIdx,
-              }}
-            />
-          {/if}
-        {/if}
+      <div
+        data-root-row-idx={entry.idx}
+        data-root-row-key={entry.key}
+        style="position: relative;"
+        on:mouseenter={(e) => setPopoverFromEvent(e, entry.key)}
+        on:mouseleave={clearPopoverWithGrace}
+      >
+        {@render rowBody(entry)}
       </div>
     </div>
   {/if}
@@ -414,6 +478,30 @@
     </div>
   {/if}
 {/each}
+
+{#if !$sidebarVisible && popoverRow}
+  {@const popoverEntry = renderedRows.find((r) => r.key === popoverRow!.key)}
+  {#if popoverEntry}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="root-row-popover"
+      data-root-row-popover={popoverEntry.key}
+      style="
+        position: fixed;
+        top: {popoverRow.top}px;
+        left: 0;
+        width: {$sidebarWidth}px;
+        z-index: 200;
+        pointer-events: auto;
+        background: transparent;
+      "
+      on:mouseenter={clearPopoverGraceTimer}
+      on:mouseleave={clearPopoverWithGrace}
+    >
+      {@render rowBody(popoverEntry)}
+    </div>
+  {/if}
+{/if}
 
 <style>
   /* Inter-row gap — matches the child workspace inter-row gap

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -100,7 +100,7 @@
      * button — Settings, Claude Settings, etc.). These have
      * `isDashboard: true`, `dashboardContributionId`, and no
      * `rootWorkspaceId`. The registered "workspace" renderer (built for
-     * `WorkspaceRecord` rows with paths and branches) can't draw them, so
+     * `RootWorkspace` rows with paths and branches) can't draw them, so
      * the block routes them through `WorkspaceItem` directly.
      */
     standaloneDashboardWs?: Workspace;

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -18,7 +18,7 @@
   import { derived } from "svelte/store";
   import { theme } from "../stores/theme";
   import { workspaces } from "../stores/workspace";
-  import { reorderContext, anyReorderActive } from "../stores/ui";
+  import { reorderContext, canSidebarDrag } from "../stores/ui";
   import {
     rootRowOrder,
     moveRootRow,
@@ -187,7 +187,7 @@
       background: "transparent",
       border: `1px solid ${$theme.border ?? "transparent"}`,
     }),
-    canStart: () => !$anyReorderActive,
+    canStart: () => $canSidebarDrag,
     onDrop: (from, to) => moveRootRow(from, to),
     onMove: (x, y, ghostEl) => {
       const fromIdx = rootDrag.getState().sourceIdx;

--- a/src/lib/components/WorkspaceListBlock.svelte
+++ b/src/lib/components/WorkspaceListBlock.svelte
@@ -377,10 +377,12 @@
      other title-row buttons. -->
 
 {#snippet rowBody(entry: RenderedRow)}
+  {@const popoverActive = popoverRow?.key === entry.key}
   {#if entry.row.kind === "pseudo-workspace" && entry.pseudoWorkspace}
     <PseudoWorkspaceRow
       pseudo={entry.pseudoWorkspace}
       onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
+      {popoverActive}
     />
   {:else if entry.standaloneDashboardWs}
     {@const ws = entry.standaloneDashboardWs}
@@ -400,6 +402,7 @@
       onGripMouseDown={(e) => startRootRowDrag(e, entry.idx)}
       dragActive={false}
       shortcutIdx={entry.workspaceOnlyIdx}
+      {popoverActive}
     />
   {:else if entry.rendererComponent && entry.rendererSource}
     {@const extApi = getExtensionApiById(entry.rendererSource)}
@@ -411,6 +414,7 @@
           id: entry.row.id,
           onGripMouseDown: (e: MouseEvent) => startRootRowDrag(e, entry.idx),
           shortcutIdx: entry.workspaceOnlyIdx,
+          popoverActive,
         }}
       />
     {/if}
@@ -482,6 +486,11 @@
 {#if !$sidebarVisible && popoverRow}
   {@const popoverEntry = renderedRows.find((r) => r.key === popoverRow!.key)}
   {#if popoverEntry}
+    <!-- Popover anchors at left:4px so the row's rail lines up with the
+         4px gutter painted by the sidebar wrapper's padding-left:4px in
+         expanded mode (and matches the wrapper's collapsed rail
+         placement). Width subtracts the gutter so the right edge stays
+         flush at viewport x = sidebarWidth. -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="root-row-popover"
@@ -489,8 +498,8 @@
       style="
         position: fixed;
         top: {popoverRow.top}px;
-        left: 0;
-        width: {$sidebarWidth}px;
+        left: 4px;
+        width: {$sidebarWidth - 4}px;
         z-index: 200;
         pointer-events: auto;
         background: transparent;

--- a/src/lib/components/WorkspaceRowBody.svelte
+++ b/src/lib/components/WorkspaceRowBody.svelte
@@ -3,8 +3,8 @@
    * WorkspaceRowBody — root-row renderer registered under the
    * "workspace" kind (see `bootstrap/init-workspaces.ts`).
    * Thin pass-through to WorkspaceSectionContent — the shared
-   * <ContainerRow> primitive (mounted inside the section content) owns
-   * the grip + banner + nested-list chrome. This component exists as
+   * <SidebarBanner> primitive (mounted inside the section content) owns
+   * the grip + bar + nested-list chrome. This component exists as
    * the registry entry point and to forward the grip handle.
    *
    * The registry invokes the component with `{ id, onGripMouseDown }`.
@@ -12,7 +12,7 @@
   import WorkspaceSectionContent from "./WorkspaceSectionContent.svelte";
 
   export let id: string;
-  /** Forwarded to ContainerRow via WorkspaceSectionContent. */
+  /** Forwarded to SidebarBanner via WorkspaceSectionContent. */
   export let onGripMouseDown: (e: MouseEvent) => void = () => {};
   /** Position among workspace-kind rows only, for Cmd+N shortcut label. */
   export let shortcutIdx: number | undefined = undefined;

--- a/src/lib/components/WorkspaceRowBody.svelte
+++ b/src/lib/components/WorkspaceRowBody.svelte
@@ -16,6 +16,11 @@
   export let onGripMouseDown: (e: MouseEvent) => void = () => {};
   /** Position among workspace-kind rows only, for Cmd+N shortcut label. */
   export let shortcutIdx: number | undefined = undefined;
+  /**
+   * True while this root row's collapsed-mode popover/banner is open.
+   * Forwarded down so the rail stays full-width while the banner shows.
+   */
+  export let popoverActive: boolean = false;
 </script>
 
 <WorkspaceSectionContent
@@ -24,4 +29,5 @@
   overlay={null}
   {onGripMouseDown}
   {shortcutIdx}
+  {popoverActive}
 />

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -9,7 +9,7 @@
 
   import { workspaces, activeWorkspaceIdx } from "../stores/workspace";
   import { eventBus, type ExtensionEvent } from "../services/event-bus";
-  import type { WorkspaceRecord } from "../config";
+  import type { RootWorkspace } from "../config";
   import { workspacesStore, getWorkspace } from "../stores/workspace";
   import {
     deleteWorkspace,
@@ -84,7 +84,7 @@
    */
   export let popoverActive: boolean = false;
 
-  let workspace: WorkspaceRecord | undefined;
+  let workspace: RootWorkspace | undefined;
   let stateVersion = 0;
 
   const onWorkspaceStateChanged = () => {
@@ -118,9 +118,9 @@
   // happening in a child Workspace.
   $: filterIds = workspace ? new Set([workspace.id]) : new Set<string>();
 
-  // The Root runtime Workspace shares its id with the Record (ADR-004).
-  // It drives the container row's status dot and renders when the row
-  // is clicked.
+  // The Root runtime Workspace shares its id with its RootWorkspace
+  // entry (ADR-004). It drives the container row's status dot and
+  // renders when the row is clicked.
   $: primaryWs = workspace
     ? $workspaces.find((w) => w.id === workspace!.id)
     : undefined;

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, type Component } from "svelte";
-  import ContainerRow from "./ContainerRow.svelte";
+  import SidebarBanner from "./SidebarBanner.svelte";
   import PathStatusLine from "./PathStatusLine.svelte";
   import WorkspaceDiffPrSubtitle from "./WorkspaceDiffPrSubtitle.svelte";
   import WorkspaceListView from "./WorkspaceListView.svelte";
@@ -57,13 +57,13 @@
   export let rootWorkspaceId: string;
   /**
    * The namespaced sidebar-block id that hosts this workspace — forwarded
-   * to the ContainerRow's child WorkspaceListView so workspace-drag
+   * to the SidebarBanner's child WorkspaceListView so workspace-drag
    * ReorderContext publishes the actual block id.
    */
   export let containerBlockId: string = "";
   /**
    * Forwarded from WorkspaceRowBody — the drag grip is owned by
-   * ContainerRow in root mode.
+   * SidebarBanner in root mode.
    */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
   /**
@@ -79,8 +79,8 @@
   export let shortcutIdx: number | undefined = undefined;
   /**
    * True while this row's collapsed-mode popover/banner is open.
-   * Forwarded to ContainerRow → SidebarRail so the rail stays full-width
-   * while the banner is shown.
+   * Forwarded to SidebarBanner → SidebarRail so the rail stays full-width
+   * while the popover is shown.
    */
   export let popoverActive: boolean = false;
 
@@ -157,14 +157,14 @@
   })();
 
   // True when the primary workspace of this workspace is currently active.
-  // Makes the container row border solid only when the primary workspace
+  // Makes the banner border solid only when the primary workspace
   // is selected (not when a child workspace is selected).
   $: isPrimaryActive = (() => {
     if (!primaryWs) return false;
     return $activeWorkspaceIdx === $workspaces.indexOf(primaryWs);
   })();
 
-  // True when ANY workspace inside this container (the root itself, any
+  // True when ANY workspace inside this banner (the root itself, any
   // branched workspace, or any dashboard child) is the active workspace.
   // Used to keep the collapsed-mode rail at full width while a descendant
   // is active — the rail represents the whole workspace, not just the root.
@@ -388,7 +388,7 @@
       position: relative;
     "
   >
-    <ContainerRow
+    <SidebarBanner
       color={workspaceHex}
       {onGripMouseDown}
       onBannerContextMenu={handleBannerContextMenu}
@@ -608,7 +608,7 @@
           </div>
         {/if}
       </svelte:fragment>
-    </ContainerRow>
+    </SidebarBanner>
 
     {#if overlay}
       <div

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -77,6 +77,12 @@
     | null = null;
   /** Position among workspace-kind rows only (0-indexed), for Cmd+N shortcut label. */
   export let shortcutIdx: number | undefined = undefined;
+  /**
+   * True while this row's collapsed-mode popover/banner is open.
+   * Forwarded to ContainerRow → SidebarRail so the rail stays full-width
+   * while the banner is shown.
+   */
+  export let popoverActive: boolean = false;
 
   let workspace: WorkspaceRecord | undefined;
   let stateVersion = 0;
@@ -376,6 +382,7 @@
       onBannerClick={handleBannerClick}
       filterIds={branchedIds}
       hasActiveChild={isPrimaryActive}
+      {popoverActive}
       dashboardHintFor={hintForWorkspaceDashboardHost}
       scopeId={workspace.id}
       {containerBlockId}

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -164,6 +164,19 @@
     return $activeWorkspaceIdx === $workspaces.indexOf(primaryWs);
   })();
 
+  // True when ANY workspace inside this container (the root itself, any
+  // branched workspace, or any dashboard child) is the active workspace.
+  // Used to keep the collapsed-mode rail at full width while a descendant
+  // is active — the rail represents the whole workspace, not just the root.
+  $: hasActiveDescendant = (() => {
+    if (!workspace) return false;
+    const active = $workspaces[$activeWorkspaceIdx];
+    if (!active) return false;
+    return (
+      active.id === workspace.id || active.rootWorkspaceId === workspace.id
+    );
+  })();
+
   // Re-evaluate contributed children when contributors register/unregister.
   // The `$childRowContributorStore` reference is what makes this statement
   // reactive — `getChildRowsFor` reads the store via `get()` and wouldn't
@@ -381,7 +394,7 @@
       onBannerContextMenu={handleBannerContextMenu}
       onBannerClick={handleBannerClick}
       filterIds={branchedIds}
-      hasActiveChild={isPrimaryActive}
+      hasActiveChild={hasActiveDescendant}
       {popoverActive}
       dashboardHintFor={hintForWorkspaceDashboardHost}
       scopeId={workspace.id}

--- a/src/lib/components/WorkspaceView.svelte
+++ b/src/lib/components/WorkspaceView.svelte
@@ -15,9 +15,9 @@
 </script>
 
 <div
-  style="flex: 1; display: flex; min-height: 0; min-width: 0; {visible
-    ? ''
-    : 'display: none;'}"
+  style="flex: 1; {visible
+    ? 'display: flex'
+    : 'display: none'}; min-height: 0; min-width: 0;"
 >
   <SplitNodeView
     node={workspace.paneLayout}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -241,6 +241,9 @@ export interface AppState {
   archivedDefs?: {
     workspaces: Record<string, ArchivedWorkspaceDef>;
   };
+  // Primary sidebar expanded (true) / collapsed (false). See stores/ui.ts
+  // and services/sidebar-persistence-service.ts.
+  sidebarVisible?: boolean;
 }
 
 export interface ArchivedWorkspaceDef {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -187,11 +187,11 @@ export interface AgentsConfig {
 export type { Workspace } from "./types";
 
 /**
- * Re-export WorkspaceRecord from its canonical location so callers
+ * Re-export RootWorkspace from its canonical location so callers
  * that import from this module continue to compile. The canonical
  * definition lives in `./stores/workspaces`.
  */
-export type { WorkspaceRecord } from "./stores/workspace";
+export type { RootWorkspace } from "./stores/workspace";
 
 export interface GnarTermConfig {
   // gnar-term extensions
@@ -244,7 +244,7 @@ export interface AppState {
 }
 
 export interface ArchivedWorkspaceDef {
-  workspace: import("./stores/workspace").WorkspaceRecord;
+  workspace: import("./stores/workspace").RootWorkspace;
   childWorkspaceDefs: (WorkspaceTemplate & { name: string })[];
 }
 

--- a/src/lib/services/__tests__/sidebar-persistence-service.test.ts
+++ b/src/lib/services/__tests__/sidebar-persistence-service.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the sidebar-persistence service.
+ *
+ * Verifies that:
+ *   - `restoreSidebarVisible` applies the persisted boolean to the
+ *     `sidebarVisible` store, and is a no-op when the field is absent
+ *     (so first-run users keep the default expanded state).
+ *   - `persistSidebarVisibleChanges` skips the initial emission (the
+ *     just-restored value) but persists subsequent toggles via
+ *     `saveState({ sidebarVisible })`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+const saveStateMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../config", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../config")>("../../config");
+  return {
+    ...actual,
+    saveState: (...args: unknown[]) => saveStateMock(...args),
+  };
+});
+
+import { sidebarVisible } from "../../stores/ui";
+import {
+  restoreSidebarVisible,
+  persistSidebarVisibleChanges,
+} from "../sidebar-persistence-service";
+
+describe("sidebar-persistence-service", () => {
+  beforeEach(() => {
+    saveStateMock.mockClear();
+    sidebarVisible.set(true);
+  });
+
+  describe("restoreSidebarVisible", () => {
+    it("applies a persisted true to the store", () => {
+      sidebarVisible.set(false);
+      restoreSidebarVisible({ sidebarVisible: true });
+      expect(get(sidebarVisible)).toBe(true);
+    });
+
+    it("applies a persisted false to the store", () => {
+      sidebarVisible.set(true);
+      restoreSidebarVisible({ sidebarVisible: false });
+      expect(get(sidebarVisible)).toBe(false);
+    });
+
+    it("is a no-op when sidebarVisible is absent", () => {
+      sidebarVisible.set(true);
+      restoreSidebarVisible({});
+      expect(get(sidebarVisible)).toBe(true);
+    });
+
+    it("is a no-op when sidebarVisible is a non-boolean", () => {
+      sidebarVisible.set(true);
+      // Caller could pass a malformed AppState — guard rejects it.
+      restoreSidebarVisible({ sidebarVisible: "yes" } as unknown as Parameters<
+        typeof restoreSidebarVisible
+      >[0]);
+      expect(get(sidebarVisible)).toBe(true);
+    });
+  });
+
+  describe("persistSidebarVisibleChanges", () => {
+    it("skips the first emission (the restored value)", () => {
+      sidebarVisible.set(false);
+      const unsubscribe = persistSidebarVisibleChanges();
+      expect(saveStateMock).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("persists subsequent toggles via saveState", () => {
+      sidebarVisible.set(true);
+      const unsubscribe = persistSidebarVisibleChanges();
+
+      sidebarVisible.set(false);
+      expect(saveStateMock).toHaveBeenCalledTimes(1);
+      expect(saveStateMock).toHaveBeenLastCalledWith({ sidebarVisible: false });
+
+      sidebarVisible.set(true);
+      expect(saveStateMock).toHaveBeenCalledTimes(2);
+      expect(saveStateMock).toHaveBeenLastCalledWith({ sidebarVisible: true });
+
+      unsubscribe();
+    });
+
+    it("stops persisting after unsubscribe", () => {
+      const unsubscribe = persistSidebarVisibleChanges();
+      sidebarVisible.set(false);
+      expect(saveStateMock).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+
+      sidebarVisible.set(true);
+      expect(saveStateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/services/__tests__/workspace-restore.test.ts
+++ b/src/lib/services/__tests__/workspace-restore.test.ts
@@ -5,11 +5,11 @@
  *   1. switchWorkspace records lastActiveBranchedWorkspaceId on Workspace
  *   2. switchWorkspace does NOT record when child has no rootWorkspaceId
  *   3. activateWorkspace lands on the Workspace's own Root (the runtime
- *      workspace whose id matches the Record id) even when
+ *      workspace whose id matches the RootWorkspace id) even when
  *      lastActiveBranchedWorkspaceId points at a sibling Branch. lastActive
  *      is preserved as a tracking field but does NOT route row activations.
  *   4. activateWorkspace materializes a Root runtime workspace at the
- *      Record's id when none exists yet (lazy materialization on click).
+ *      RootWorkspace's id when none exists yet (lazy materialization on click).
  *
  * S9 tests:
  *   5. autoRunRestoreCommands=true → startupCommand set directly (not pendingRestoreCommand)
@@ -27,7 +27,7 @@ import { activateWorkspace, addWorkspace } from "../workspace-service";
 import { resetWorkspacesForTest, getWorkspace } from "../../stores/workspace";
 import { rootRowOrder } from "../../stores/root-row-order";
 import type { Workspace } from "../../types";
-import type { WorkspaceRecord } from "../../config";
+import type { RootWorkspace } from "../../config";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
@@ -77,8 +77,8 @@ function makeChild(id: string, rootWorkspaceId?: string): Workspace {
 
 function makeWorkspace(
   id: string,
-  overrides: Partial<WorkspaceRecord> = {},
-): WorkspaceRecord {
+  overrides: Partial<RootWorkspace> = {},
+): RootWorkspace {
   return {
     id,
     name: `Workspace ${id}`,

--- a/src/lib/services/__tests__/workspace-service.test.ts
+++ b/src/lib/services/__tests__/workspace-service.test.ts
@@ -24,7 +24,7 @@ import { eventBus } from "../event-bus";
 import { rootRowOrder } from "../../stores/root-row-order";
 import { workspaces, activeWorkspaceIdx } from "../../stores/workspace";
 import type { Workspace } from "../../types";
-import type { WorkspaceRecord } from "../../config";
+import type { RootWorkspace } from "../../config";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
@@ -32,8 +32,8 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 function makeWorkspace(
   id: string,
-  overrides: Partial<WorkspaceRecord> = {},
-): WorkspaceRecord {
+  overrides: Partial<RootWorkspace> = {},
+): RootWorkspace {
   return {
     id,
     name: `Workspace ${id}`,

--- a/src/lib/services/agents-sidebar.ts
+++ b/src/lib/services/agents-sidebar.ts
@@ -7,7 +7,7 @@
  */
 import type { DetectedAgent } from "./agent-detection-service";
 import type { Workspace } from "../types";
-import type { WorkspaceRecord } from "../config";
+import type { RootWorkspace } from "../config";
 
 export interface AgentRow extends DetectedAgent {
   /** Display name of the Branch the agent lives in. */
@@ -26,7 +26,7 @@ export interface AgentRow extends DetectedAgent {
 export function buildAgentRows(
   agents: DetectedAgent[],
   branchedWsList: Workspace[],
-  workspaces: WorkspaceRecord[],
+  workspaces: RootWorkspace[],
 ): AgentRow[] {
   return agents
     .filter((a) => a.status !== "closed")

--- a/src/lib/services/dashboard-contribution-registry.ts
+++ b/src/lib/services/dashboard-contribution-registry.ts
@@ -7,7 +7,7 @@
  */
 import { get, type Readable } from "svelte/store";
 import { createRegistry } from "./create-registry";
-import type { WorkspaceRecord as Workspace } from "../config";
+import type { RootWorkspace as Workspace } from "../config";
 
 /**
  * Stable persisted id for the built-in Workspace overview dashboard.

--- a/src/lib/services/extension-api.ts
+++ b/src/lib/services/extension-api.ts
@@ -61,7 +61,7 @@ import {
   sendNotification as notifSend,
 } from "@tauri-apps/plugin-notification";
 import WorkspaceListView from "../components/WorkspaceListView.svelte";
-import ContainerRow from "../components/ContainerRow.svelte";
+import SidebarBanner from "../components/SidebarBanner.svelte";
 import PathStatusLine from "../components/PathStatusLine.svelte";
 import SplitButton from "../components/SplitButton.svelte";
 import ColorPicker from "../components/ColorPicker.svelte";
@@ -523,7 +523,7 @@ export function createExtensionAPI(
         ColorPicker,
         DragGrip,
         DropGhost,
-        ContainerRow,
+        SidebarBanner,
         PathStatusLine,
       };
     },

--- a/src/lib/services/sidebar-persistence-service.ts
+++ b/src/lib/services/sidebar-persistence-service.ts
@@ -1,0 +1,42 @@
+/**
+ * Sidebar persistence — restores the primary sidebar's expanded /
+ * collapsed state on launch and writes it back whenever the user toggles
+ * it.
+ *
+ * Backed by `AppState.sidebarVisible` (config.ts). Without this service
+ * the store always boots to `true` and the user's collapsed choice is
+ * forgotten across launches.
+ */
+import { sidebarVisible } from "../stores/ui";
+import { saveState, type AppState } from "../config";
+
+/**
+ * Apply the persisted boolean (if any) to the `sidebarVisible` store.
+ * No-op when the field is absent so the store keeps its default of
+ * `true` (expanded) for first-run users.
+ */
+export function restoreSidebarVisible(state: AppState): void {
+  if (typeof state.sidebarVisible === "boolean") {
+    sidebarVisible.set(state.sidebarVisible);
+  }
+}
+
+/**
+ * Subscribe to `sidebarVisible` and persist changes via `saveState`. The
+ * very first emission (the current value at subscribe time) is skipped
+ * so the just-restored value is not round-tripped back to disk. Returns
+ * the unsubscribe function.
+ *
+ * Call AFTER `restoreSidebarVisible` so the skipped first emission is
+ * the restored value, not the store's default.
+ */
+export function persistSidebarVisibleChanges(): () => void {
+  let initialized = false;
+  return sidebarVisible.subscribe((value) => {
+    if (!initialized) {
+      initialized = true;
+      return;
+    }
+    void saveState({ sidebarVisible: value });
+  });
+}

--- a/src/lib/services/workspace-runtime-service.ts
+++ b/src/lib/services/workspace-runtime-service.ts
@@ -246,7 +246,7 @@ export async function createWorkspaceFromDef(
     );
     // Branches (have rootWorkspaceId) live nested inside their root and
     // never get a row of their own. Roots get a `kind: "workspace"` row
-    // here; the matching WorkspaceRecord append (via `addWorkspace`)
+    // here; the matching RootWorkspace append (via `addWorkspace`)
     // is idempotent on the same id+kind.
     if (typeof ws.rootWorkspaceId !== "string") {
       appendRootRow({ kind: "workspace", id: ws.id });

--- a/src/lib/services/workspace-runtime-service.ts
+++ b/src/lib/services/workspace-runtime-service.ts
@@ -222,7 +222,11 @@ export async function createWorkspaceFromDef(
   // A runtime workspace whose id matches an existing root entry IS the
   // Workspace's own Root tab surface — merge the runtime fields onto
   // the existing record-shaped entry rather than appending a duplicate
-  // row. Otherwise append as a new entry.
+  // row. Otherwise append as a new entry, but guard against re-appending
+  // a Branch or Dashboard whose id is already in the store (getWorkspace
+  // only sees root-shaped entries, so duplicate Branches/Dashboards
+  // would otherwise slip past the merge above and land as duplicate
+  // keys in the keyed each that renders WorkspaceView).
   const isWorkspaceOwnRoot = getWorkspace(ws.id) !== undefined;
   if (isWorkspaceOwnRoot) {
     workspaces.update((list) =>
@@ -237,7 +241,9 @@ export async function createWorkspaceFromDef(
       ),
     );
   } else {
-    workspaces.update((list) => [...list, ws]);
+    workspaces.update((list) =>
+      list.some((w) => w.id === ws.id) ? list : [...list, ws],
+    );
     // Branches (have rootWorkspaceId) live nested inside their root and
     // never get a row of their own. Roots get a `kind: "workspace"` row
     // here; the matching WorkspaceRecord append (via `addWorkspace`)

--- a/src/lib/services/workspace-service.ts
+++ b/src/lib/services/workspace-service.ts
@@ -11,7 +11,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { get } from "svelte/store";
 import type { SurfaceDef } from "../config";
-import type { WorkspaceRecord } from "../stores/workspace";
+import type { RootWorkspace } from "../stores/workspace";
 import { WORKSPACE_COLOR_SLOTS } from "../../extensions/api";
 import { appendRootRow, removeRootRow } from "../stores/root-row-order";
 import { workspaces } from "../stores/workspace";
@@ -46,13 +46,13 @@ function emitStateChanged(metadata: Record<string, unknown> = {}): void {
   });
 }
 
-export function addWorkspace(workspace: WorkspaceRecord): void {
+export function addWorkspace(workspace: RootWorkspace): void {
   // Every entry in the unified store is a `Workspace`, so even a
   // record-shaped row needs a paneLayout. When the caller hasn't
   // materialized a tab surface yet, mint a placeholder empty pane —
   // `createWorkspaceFromDef` will overwrite paneLayout / activePaneId
   // when the matching runtime workspace is created.
-  const ensured: WorkspaceRecord = {
+  const ensured: RootWorkspace = {
     ...workspace,
     paneLayout: workspace.paneLayout ?? {
       type: "pane",
@@ -72,7 +72,7 @@ export function addWorkspace(workspace: WorkspaceRecord): void {
 
 export function updateWorkspace(
   id: string,
-  patch: Partial<Omit<WorkspaceRecord, "id">>,
+  patch: Partial<Omit<RootWorkspace, "id">>,
 ): void {
   const next = getWorkspaces().map((w) =>
     w.id === id ? { ...w, ...patch } : w,
@@ -193,7 +193,7 @@ export function workspaceDashboardPath(workspacePath: string): string {
   return `${workspacePath.replace(/\/+$/, "")}/.gnar-term/workspace-dashboard.md`;
 }
 
-function buildWorkspaceDashboardMarkdown(workspace: WorkspaceRecord): string {
+function buildWorkspaceDashboardMarkdown(workspace: RootWorkspace): string {
   // The Workspace Dashboard is the generic, agent-agnostic landing page for
   // a Workspace. It surfaces GitHub work-tracker context — open
   // issues + open PRs — side by side, as a passive read-only browse
@@ -234,7 +234,7 @@ children:
  * workspace never trampling user customizations.
  */
 async function writeWorkspaceDashboardTemplate(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
   path: string,
   options: { force?: boolean } = {},
 ): Promise<void> {
@@ -259,7 +259,7 @@ async function writeWorkspaceDashboardTemplate(
  * needing the workspace to be closed/recreated.
  */
 export async function regenerateWorkspaceDashboardTemplate(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
 ): Promise<void> {
   await writeWorkspaceDashboardTemplate(
     workspace,
@@ -271,7 +271,7 @@ export async function regenerateWorkspaceDashboardTemplate(
 }
 
 function createDashboardWorkspaceFromDef(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
   name: string,
   contribId: string,
   surfaces: SurfaceDef[],
@@ -292,7 +292,7 @@ function createDashboardWorkspaceFromDef(
  * link to it.
  */
 export async function createWorkspaceDashboard(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
 ): Promise<string> {
   const path = workspaceDashboardPath(workspace.path);
   try {
@@ -319,7 +319,7 @@ export async function createWorkspaceDashboard(
  * contributions.
  */
 export function createSettingsDashboardWorkspace(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
 ): Promise<string> {
   return createDashboardWorkspaceFromDef(workspace, "Settings", "settings", []);
 }
@@ -379,7 +379,7 @@ function hasDashboardWorkspace(
  * caller has already built the snapshot (e.g. `reconcileWorkspaceDashboards`).
  */
 export async function provisionAutoDashboardsForWorkspace(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
   existingContribIds?: ReadonlySet<string>,
 ): Promise<void> {
   for (const c of getDashboardContributions()) {
@@ -444,7 +444,7 @@ export function closeDashboardForWorkspace(
  * eagerly on workspace creation, so this is a pure activation call.
  * Returns true on success.
  */
-export function openWorkspaceDashboard(workspace: WorkspaceRecord): boolean {
+export function openWorkspaceDashboard(workspace: RootWorkspace): boolean {
   const targetId = workspace.dashboardWorkspaceId;
   if (!targetId) return false;
   const idx = get(workspaces).findIndex((w) => w.id === targetId);
@@ -506,7 +506,7 @@ export async function activateWorkspace(workspaceId: string): Promise<void> {
  * workspaces store and ripples to `$activeWorkspaceIdx`.
  */
 async function reconcileDashboardsForWorkspace(
-  workspace: WorkspaceRecord,
+  workspace: RootWorkspace,
   dashboardIndex: Map<string, Map<string, Workspace[]>>,
 ): Promise<void> {
   const byContrib = dashboardIndex.get(workspace.id);
@@ -632,9 +632,10 @@ export function reclaimBranchedWorkspaces(): void {
 
 /**
  * Promote every standalone runtime Workspace to a Root by creating a
- * matching WorkspaceRecord with the same id (Root and Record share an
- * id). A "standalone" runtime workspace is one that:
- *   - has no matching Record (no row in the sidebar yet)
+ * matching RootWorkspace with the same id (the Root runtime workspace
+ * and its RootWorkspace entry share an id). A "standalone" runtime
+ * workspace is one that:
+ *   - has no matching RootWorkspace (no row in the sidebar yet)
  *   - is not a Branch (`rootWorkspaceId` unset). Branches are Branches
  *     for life — even orphan Branches (rootWorkspaceId points at a
  *     missing Workspace) are never promoted to Roots
@@ -662,7 +663,7 @@ function materializeStandaloneRoots(): void {
 
     const path = ws.path && ws.path.length > 0 ? ws.path : "~";
 
-    const workspace: WorkspaceRecord = {
+    const workspace: RootWorkspace = {
       id: ws.id,
       name: ws.name,
       path,
@@ -679,7 +680,7 @@ function materializeStandaloneRoots(): void {
 /**
  * Startup reconciliation — called after workspaces are restored.
  * Promotes every standalone runtime Workspace to a Root by creating a
- * matching WorkspaceRecord (shared id). Branch status is derived
+ * matching RootWorkspace (shared id). Branch status is derived
  * directly from `Workspace.rootWorkspaceId`, so no parallel membership
  * registry needs rehydrating at startup.
  *

--- a/src/lib/services/workspace-switcher-filter.ts
+++ b/src/lib/services/workspace-switcher-filter.ts
@@ -71,30 +71,30 @@ export function filterWorkspaces(
 
   for (let idx = 0; idx < workspaces.length; idx++) {
     const ws = workspaces[idx]!;
-    // A workspace belongs to a Root group if it points at one (branches +
+    // A workspace nests under a Root if it points at one (branches +
     // dashboards) or if it IS the Root itself (the runtime entry shares
     // its id with the Record per ADR-004).
-    const parentRootId = ws.rootWorkspaceId;
+    const rootRef = ws.rootWorkspaceId;
     const isOwnRoot = rootIds.has(ws.id);
-    const groupRootId = isOwnRoot
+    const bucketRootId = isOwnRoot
       ? ws.id
-      : parentRootId && rootIds.has(parentRootId)
-        ? parentRootId
+      : rootRef && rootIds.has(rootRef)
+        ? rootRef
         : undefined;
-    const root = groupRootId ? rootMap.get(groupRootId) : undefined;
+    const root = bucketRootId ? rootMap.get(bucketRootId) : undefined;
 
     const row: SwitcherRow = {
       ws,
       idx,
       rootLabel: root?.name ?? "",
       kind: "branch",
-      depth: groupRootId ? 1 : 0,
+      depth: bucketRootId ? 1 : 0,
     };
 
-    if (groupRootId) {
-      const bucket = byRoot.get(groupRootId) ?? [];
+    if (bucketRootId) {
+      const bucket = byRoot.get(bucketRootId) ?? [];
       bucket.push(row);
-      byRoot.set(groupRootId, bucket);
+      byRoot.set(bucketRootId, bucket);
     } else {
       standaloneRows.push(row);
     }

--- a/src/lib/services/workspace-switcher-filter.ts
+++ b/src/lib/services/workspace-switcher-filter.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from "../types";
-import type { WorkspaceRecord } from "../config";
+import type { RootWorkspace } from "../config";
 
 export interface SwitcherRow {
   ws: Workspace;
@@ -34,9 +34,9 @@ export interface SwitcherRow {
  */
 export function filterWorkspaces(
   workspaces: Workspace[],
-  rootMap: Map<string, WorkspaceRecord>,
+  rootMap: Map<string, RootWorkspace>,
   query: string,
-  rootWorkspaces: WorkspaceRecord[] = [],
+  rootWorkspaces: RootWorkspace[] = [],
 ): SwitcherRow[] {
   const q = query.trim().toLowerCase();
 
@@ -73,7 +73,7 @@ export function filterWorkspaces(
     const ws = workspaces[idx]!;
     // A workspace nests under a Root if it points at one (branches +
     // dashboards) or if it IS the Root itself (the runtime entry shares
-    // its id with the Record per ADR-004).
+    // its id with the RootWorkspace per ADR-004).
     const rootRef = ws.rootWorkspaceId;
     const isOwnRoot = rootIds.has(ws.id);
     const bucketRootId = isOwnRoot
@@ -146,7 +146,7 @@ function wsTypeOrder(ws: Workspace): number {
   return 2; // dashboards last
 }
 
-function makeRootRow(root: WorkspaceRecord): SwitcherRow {
+function makeRootRow(root: RootWorkspace): SwitcherRow {
   // The ws field on root rows holds a minimal Workspace-shaped object.
   // Consumers must check kind === "root" before treating it as a real branch workspace.
   return {

--- a/src/lib/services/workspace-switcher-filter.ts
+++ b/src/lib/services/workspace-switcher-filter.ts
@@ -71,22 +71,30 @@ export function filterWorkspaces(
 
   for (let idx = 0; idx < workspaces.length; idx++) {
     const ws = workspaces[idx]!;
-    const rootId = ws.rootWorkspaceId;
-    const isUnderRoot = !!(rootId && rootIds.has(rootId));
-    const root = isUnderRoot ? rootMap.get(rootId!) : undefined;
+    // A workspace belongs to a Root group if it points at one (branches +
+    // dashboards) or if it IS the Root itself (the runtime entry shares
+    // its id with the Record per ADR-004).
+    const parentRootId = ws.rootWorkspaceId;
+    const isOwnRoot = rootIds.has(ws.id);
+    const groupRootId = isOwnRoot
+      ? ws.id
+      : parentRootId && rootIds.has(parentRootId)
+        ? parentRootId
+        : undefined;
+    const root = groupRootId ? rootMap.get(groupRootId) : undefined;
 
     const row: SwitcherRow = {
       ws,
       idx,
       rootLabel: root?.name ?? "",
       kind: "branch",
-      depth: isUnderRoot ? 1 : 0,
+      depth: groupRootId ? 1 : 0,
     };
 
-    if (isUnderRoot && rootId) {
-      const bucket = byRoot.get(rootId) ?? [];
+    if (groupRootId) {
+      const bucket = byRoot.get(groupRootId) ?? [];
       bucket.push(row);
-      byRoot.set(rootId, bucket);
+      byRoot.set(groupRootId, bucket);
     } else {
       standaloneRows.push(row);
     }

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -5,12 +5,13 @@ export const isFullscreen = writable<boolean>(false);
 
 /**
  * Primary sidebar expanded/collapsed state. Persisted in AppState as
- * `sidebarVisible.primary`.
+ * `sidebarVisible` (boolean) by `sidebar-persistence-service` so the
+ * user's choice survives across launches.
  *
  *   true  — expanded: full-width sidebar takes layout space.
- *   false — collapsed: 8px rail-only slot; full sidebar appears as
- *           a hover-triggered overlay over the terminal area, and
- *           the "+ New" split button moves to the TitleBar.
+ *   false — collapsed: 4px rail-only slot; full sidebar appears as
+ *           a per-row popover over the terminal area, and the
+ *           "+ New" split button moves to the TitleBar.
  *
  * The boolean keeps its historical name (and persisted key) for
  * AppState migration — pre-existing `false` values now read as

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -57,6 +57,17 @@ export const anyReorderActive = derived(
 );
 
 /**
+ * True when the sidebar is in a state where banner drag is allowed:
+ * sidebar expanded AND no reorder already in flight. While the sidebar
+ * is collapsed the rails act as a visual index only — drag is disabled
+ * to keep the rail strip stable while the cursor hovers it.
+ */
+export const canSidebarDrag = derived(
+  [sidebarVisible, anyReorderActive],
+  ([$visible, $reordering]) => $visible && !$reordering,
+);
+
+/**
  * True while a within-block (row-level) reorder is in progress. Derived —
  * do not write directly; update `reorderContext` instead.
  */

--- a/src/lib/stores/workspace.ts
+++ b/src/lib/stores/workspace.ts
@@ -168,7 +168,7 @@ export const activeSurface = derived([activePane], ([$pane]) => {
 });
 
 // Persistence is owned by `workspace-runtime-service.persistWorkspaces`,
-// which serializes this store and merges in WorkspaceRecord entries to
+// which serializes this store and merges in RootWorkspace entries to
 // produce the single canonical `state.workspaces[]` writer.
 
 // ---------------------------------------------------------------------------
@@ -317,7 +317,7 @@ export function serializeWorkspace(ws: Workspace): WorkspaceDef {
 // ===========================================================================
 
 /**
- * `WorkspaceRecord` narrows `Workspace` to the fields a root workspace
+ * `RootWorkspace` narrows `Workspace` to the fields a root workspace
  * is guaranteed to own at runtime (path, color, branchedWorkspaceIds,
  * isGit, createdAt). Structural fields (`paneLayout`, `activePaneId`)
  * stay optional so the creation flow can construct an entry before its
@@ -326,9 +326,9 @@ export function serializeWorkspace(ws: Workspace): WorkspaceDef {
  * runtime workspace materializes.
  *
  * This is a typed view over `Workspace` rows in the unified
- * `_workspaces` store — there is no separate "Record" store.
+ * `_workspaces` store — there is no separate root-only store.
  */
-export type WorkspaceRecord = Omit<Workspace, "paneLayout" | "activePaneId"> & {
+export type RootWorkspace = Omit<Workspace, "paneLayout" | "activePaneId"> & {
   path: string;
   color: string;
   branchedWorkspaceIds: string[];
@@ -358,7 +358,7 @@ function isRootWorkspace(ws: Workspace): boolean {
  * focused tab belonged to one of its Branches. Set by
  * `setActiveWorkspaceId()` and read by `workspace-persist.ts`.
  */
-const _activeWorkspaceRecordId = writable<string | null>(null);
+const _activeRootWorkspaceId = writable<string | null>(null);
 
 /**
  * Public root-workspaces store. Read-only projection of `_workspaces`
@@ -366,12 +366,12 @@ const _activeWorkspaceRecordId = writable<string | null>(null);
  * helpers (`addWorkspace`, `setWorkspaces`, ...) which preserve
  * children/dashboards by editing the array in place.
  */
-export const workspacesStore: Readable<WorkspaceRecord[]> = derived(
+export const workspacesStore: Readable<RootWorkspace[]> = derived(
   _workspaces,
-  ($ws) => $ws.filter(isRootWorkspace) as WorkspaceRecord[],
+  ($ws) => $ws.filter(isRootWorkspace) as RootWorkspace[],
 );
 
-let _workspaceRecordsLoaded = false;
+let _rootWorkspacesLoaded = false;
 
 /**
  * Read state from disk and seed the active root-workspace id. The
@@ -383,20 +383,20 @@ let _workspaceRecordsLoaded = false;
  * the initializer.
  */
 export async function loadWorkspaces(): Promise<void> {
-  if (_workspaceRecordsLoaded) return;
-  _workspaceRecordsLoaded = true;
+  if (_rootWorkspacesLoaded) return;
+  _rootWorkspacesLoaded = true;
 
   const state = await loadState();
   if (typeof state.activeWorkspaceId === "string") {
-    _activeWorkspaceRecordId.set(state.activeWorkspaceId);
+    _activeRootWorkspaceId.set(state.activeWorkspaceId);
   }
 }
 
-export function getWorkspaces(): WorkspaceRecord[] {
-  return get(_workspaces).filter(isRootWorkspace) as WorkspaceRecord[];
+export function getWorkspaces(): RootWorkspace[] {
+  return get(_workspaces).filter(isRootWorkspace) as RootWorkspace[];
 }
 
-export function getWorkspace(id: string): WorkspaceRecord | undefined {
+export function getWorkspace(id: string): RootWorkspace | undefined {
   return getWorkspaces().find((w) => w.id === id);
 }
 
@@ -407,7 +407,7 @@ export function getWorkspace(id: string): WorkspaceRecord | undefined {
  * keep their original order, with non-root entries that originally
  * appeared before any root retained at the front.
  */
-export function setWorkspaces(next: readonly WorkspaceRecord[]): void {
+export function setWorkspaces(next: readonly RootWorkspace[]): void {
   _workspaces.update((current) => {
     const merged: Workspace[] = [];
     let nextIdx = 0;
@@ -430,16 +430,16 @@ export function setWorkspaces(next: readonly WorkspaceRecord[]): void {
 }
 
 export function getActiveWorkspaceId(): string | null {
-  return get(_activeWorkspaceRecordId);
+  return get(_activeRootWorkspaceId);
 }
 
 export function setActiveWorkspaceId(id: string | null): void {
-  _activeWorkspaceRecordId.set(id);
+  _activeRootWorkspaceId.set(id);
 }
 
 /** Test hook — reset in-memory state so tests start clean. */
 export function resetWorkspacesForTest(): void {
   _workspaces.set([]);
-  _activeWorkspaceRecordId.set(null);
-  _workspaceRecordsLoaded = false;
+  _activeRootWorkspaceId.set(null);
+  _rootWorkspacesLoaded = false;
 }


### PR DESCRIPTION
## Summary

Cleanup pass on the primary sidebar's collapsed state and the workspace switcher.

- **Collapsed sidebar**: per-row popover replaces the whole-sidebar hover overlay; rail itself becomes a clickable activate target with width tiers (4px idle / 8px active/hover/popover); collapsed sidebar overlays the terminal seamlessly (transparent bg, no left border, no pane border-left); archive zone hidden and banner drag disabled while collapsed.
- **Sidebar persistence**: expanded/collapsed choice now survives quit/relaunch (\`AppState.sidebarVisible\`).
- **Switcher**: Root Workspace nests under its own header above dashboards.
- **Runtime correctness**: dedupe workspaces by id when re-creating Branches/Dashboards to prevent duplicate-id rows.
- **Renames**: \`ContainerRow\` → \`SidebarBanner\` and \`WorkspaceRecord\` → \`RootWorkspace\` to align with \`docs/ontology.md\`.
- **Tests**: regression coverage for all of the above (rail width, click, cursor, collapsed border/bg, archive collapsed, drag-disabled, row popover, switcher filter, workspace-runtime dedup, drag grip, sidebar persistence).

## Test plan

- [ ] Collapse the primary sidebar; the rail is 4px and the terminal extends flush under it (no seam, no left border).
- [ ] Hover a workspace rail — width grows to 8px, cursor becomes pointer; click activates that workspace.
- [ ] Hover a row while collapsed — only that row's popover appears (no whole-sidebar overlay).
- [ ] While collapsed, the archive zone is hidden and banner drag is disabled.
- [ ] Active descendant keeps its parent workspace's rail full-width.
- [ ] Open the workspace switcher: Root Workspace appears under its own Root Workspace section, above Dashboards.
- [ ] Trigger a Branches/Dashboards re-create cycle; no duplicate rows by id.
- [ ] Collapse the sidebar, quit the app, relaunch — sidebar reopens collapsed. Expand, quit, relaunch — sidebar reopens expanded.
- [ ] \`npm test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)