### PR TITLE
fix(sidebar): subtitle layout, banner border, collapsed-popover clickability

### DIFF
--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -75,12 +75,19 @@
   /** Forwarded: suppress per-row status badges when the banner aggregates. */
   export let hideStatusBadges: boolean = false;
   /**
-   * When true, a child workspace inside this banner is the active
-   * workspace. The bar swaps its idle `$theme.border` stroke for the
-   * banner's `color` so the active state ties the workspace banner
-   * to its active child visually.
+   * When true, any descendant of this banner (the root workspace itself,
+   * a branched workspace, or a dashboard child) is the active workspace.
+   * Drives the rail's collapsed-mode width and the active-stripe accent
+   * — both represent "this banner contains the active workspace".
    */
   export let hasActiveChild: boolean = false;
+  /**
+   * When true, the root workspace this banner represents is itself the
+   * active workspace (not a child of it). Drives the bar's border stroke
+   * — the border lights up only when the root is selected, not when a
+   * child branch is, since branches own their own row chrome.
+   */
+  export let isPrimaryActive: boolean = false;
   /** Drag scope id (banner id). */
   export let scopeId: string;
   /** Sidebar block id the banner belongs to (for drag context). */
@@ -115,6 +122,21 @@
   export let dashboardCount: number = 0;
 
   let bannerHovered = false;
+
+  // Wrapper-level click for the banner body. The visible bar, the
+  // banner-subtitle slots, and any empty space in the row should all
+  // count as activating the workspace — especially in collapsed mode,
+  // where the popover spans more area than the bar alone. Clicks that
+  // originate inside a self-handling descendant (the rail, which fires
+  // `onBannerClick` itself, or a nested SidebarElement row that owns
+  // its own activation) are ignored so they don't double-fire.
+  function handleWrapperClick(e: MouseEvent) {
+    const t = e.target as HTMLElement | null;
+    if (!t) return;
+    if (t.closest("[data-sidebar-rail]")) return;
+    if (t.closest("[data-sidebar-element]")) return;
+    onBannerClick?.();
+  }
 
   // Non-dashboard count: dashboards don't count as real child workspaces for
   // the purposes of showing the toggle button and auto-expand/collapse.
@@ -166,20 +188,25 @@
 {#if parentColor}
   <!-- Nested variant — bar only, with left-edge colored accent. Uses
        SidebarElement for unified styling. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     data-sidebar-banner={testId ?? ""}
     data-sidebar-banner-mode="child"
     style="position: relative;"
+    on:click|stopPropagation={handleWrapperClick}
   >
     <SidebarElement
       kind="parent"
       name={containerLabel}
-      isActive={false}
+      isActive={isPrimaryActive}
       isLocked={locked}
       isDragging={false}
       canDrag={false}
       canClose={!!onClose}
       {color}
+      {popoverActive}
+      onRailClick={onBannerClick}
       {onClose}
       onContextMenu={onBannerContextMenu}
     >
@@ -238,11 +265,13 @@
        the inactive dashboard-tile stroke) wraps only the bar; the
        child workspace list renders below the border so children carry
        their own chrome. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     data-sidebar-banner={testId ?? ""}
     data-sidebar-banner-mode="root"
-    style="display: flex; position: relative; align-items: stretch;"
+    style="display: flex; position: relative; align-items: stretch; cursor: pointer;"
+    on:click|stopPropagation={handleWrapperClick}
   >
     {#if onGripMouseDown}
       <SidebarRail
@@ -265,7 +294,6 @@
         min-width: 0;
       "
     >
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         data-sidebar-banner-row
@@ -278,13 +306,13 @@
           ? ($theme.bgHighlight ?? 'transparent')
           : ($theme.bgSurface ?? 'transparent')};
           color: {$theme.fg};
-          border-top: 1px solid {hasActiveChild
+          border-top: 1px solid {isPrimaryActive
           ? color
           : ($theme.border ?? 'transparent')};
-          border-right: 1px solid {hasActiveChild
+          border-right: 1px solid {isPrimaryActive
           ? color
           : ($theme.border ?? 'transparent')};
-          border-bottom: 1px solid {hasActiveChild
+          border-bottom: 1px solid {isPrimaryActive
           ? color
           : ($theme.border ?? 'transparent')};
           border-left: none;
@@ -293,7 +321,6 @@
           transition: background 0.15s;
         "
         on:contextmenu={onBannerContextMenu}
-        on:click={onBannerClick}
         on:mouseenter={() => (bannerHovered = true)}
         on:mouseleave={() => (bannerHovered = false)}
       >

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -353,9 +353,9 @@
     {/if}
 
     {#if !isDashboardWorkspaceRow && subtitleComponents.length > 0}
-      <SidebarSubtitleRow color={$theme.fgMuted}>
-        {#each subtitleComponents as sub (sub.id)}
-          {@const subApi = getExtensionApiById(sub.source)}
+      {#each subtitleComponents as sub (sub.id)}
+        {@const subApi = getExtensionApiById(sub.source)}
+        <SidebarSubtitleRow color={$theme.fgMuted}>
           {#if subApi}
             <ExtensionWrapper
               api={subApi}
@@ -369,8 +369,8 @@
               accentColor={railColor}
             />
           {/if}
-        {/each}
-      </SidebarSubtitleRow>
+        </SidebarSubtitleRow>
+      {/each}
     {/if}
 
     {#if latestNotification && !hideStatusBadges && !isInsideWorkspace && agentBadges.length === 0}

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -416,6 +416,7 @@
       onBannerClick={handleBannerClick}
       filterIds={branchedIds}
       hasActiveChild={hasActiveDescendant}
+      {isPrimaryActive}
       {popoverActive}
       scopeId={workspace.id}
       {containerBlockId}


### PR DESCRIPTION
## Summary
- Branch row subtitles now render on individual rows so git status, diff, PR, and other workspace-subtitle contributions stack vertically instead of squeezing into one line.
- The root workspace banner's border lights up only when the root itself is the active workspace; descendant activity (branches, dashboards) still drives the rail width via `hasActiveChild`.
- Whole banner body is clickable in collapsed-mode popovers — fixes dead-zones for both standalone root workspaces and rootspaces nested inside another workspace. Self-handling descendants (rails, child `SidebarElement` rows, chip buttons) keep their existing click behavior, so Settings, ×, lock, expand toggle, and tile actions all continue to work in the popover.

## Test plan
- [ ] Open a workspace with diff + PR + path subtitles; confirm each renders on its own row in the branch list.
- [ ] Activate a branch under a root workspace; verify the root banner does *not* gain the active border, but the rail stripe is still 8px wide.
- [ ] Activate the root workspace itself; verify the root banner border lights up in the workspace color.
- [ ] Collapse the sidebar; hover a standalone root workspace row to open the popover; click in the empty body area (not on a button); verify the workspace activates.
- [ ] Collapse the sidebar; hover a workspace whose `after-children` includes a nested rootspace; click the nested rootspace's body in the popover; verify only the nested rootspace activates (not the parent).
- [ ] In collapsed-mode popover, click the Settings chip, × close button, lock chip, expand caret, and any tile-action chip; verify each fires its own action without also activating the workspace.
- [ ] Open a PR link from the banner subtitle while collapsed; verify the URL opens (existing behavior preserved).
- [ ] `npm test` and `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)