### PR TITLE
fix(sidebar): inline expand chip + matching archive chevron

### DIFF
--- a/src/lib/components/ArchiveZone.svelte
+++ b/src/lib/components/ArchiveZone.svelte
@@ -127,28 +127,33 @@
       style="border-color: {$theme.fgDim};"
     ></div>
     <div class="archive-banner-body">
+      <span class="archive-label">Archive</span>
       <span
         aria-hidden="true"
-        class="chevron"
-        style="transform: rotate({expanded ? 90 : 0}deg);"
+        class="expand-chip"
+        style="background: {$theme.bgSurface ?? 'transparent'};"
       >
+        {#if totalCount > 0 && !expanded}
+          <span class="expand-count" style="color: {$theme.fgDim};"
+            >{totalCount}</span
+          >
+        {/if}
         <svg
-          width="10"
-          height="10"
-          viewBox="0 0 12 12"
+          width="12"
+          height="8"
+          viewBox="0 0 12 8"
           fill="none"
-          stroke="currentColor"
+          stroke={$theme.fgDim}
           stroke-width="1.5"
           stroke-linecap="round"
           stroke-linejoin="round"
+          style="transition: transform 0.2s ease; transform: rotate({expanded
+            ? 0
+            : 180}deg);"
         >
-          <polyline points="3,2 8,6 3,10" />
+          <polyline points="1,1 6,7 11,1" />
         </svg>
       </span>
-      <span class="archive-label">Archive</span>
-      {#if totalCount > 0}
-        <span class="count-chip">{totalCount}</span>
-      {/if}
     </div>
   </button>
 
@@ -230,16 +235,6 @@
     padding: 4px 6px;
   }
 
-  .chevron {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 12px;
-    color: inherit;
-    transition: transform 0.15s ease;
-    flex-shrink: 0;
-  }
-
   .archive-label {
     flex: 1;
     text-align: left;
@@ -248,14 +243,23 @@
     white-space: nowrap;
   }
 
-  .count-chip {
-    background: rgba(255, 255, 255, 0.06);
-    color: rgba(255, 255, 255, 0.55);
-    border-radius: 3px;
-    padding: 1px 5px;
-    font-size: 10px;
+  .expand-chip {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 24px;
+    min-width: 28px;
+    padding: 0 6px;
+    border-radius: 5px;
+  }
+
+  .expand-count {
+    font-size: 11px;
     font-weight: 600;
-    flex-shrink: 0;
+    line-height: 1;
+    pointer-events: none;
   }
 
   .archive-list {

--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -221,17 +221,25 @@
           <slot />
           <slot name="banner-end" />
         </div>
-        <slot name="banner-subtitle" {collapsed} />
-        {#if $$slots["btn-row"]}
-          <div class="sidebar-banner-btn-row">
-            <slot
-              name="btn-row"
-              {collapsed}
-              toggle={toggleCollapsed}
-              showToggle={expandable}
-            />
+        <div
+          style="display: flex; align-items: flex-end; gap: 6px; min-width: 0;"
+        >
+          <div
+            style="flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px;"
+          >
+            <slot name="banner-subtitle" {collapsed} />
           </div>
-        {/if}
+          {#if $$slots["btn-row"]}
+            <div class="sidebar-banner-btn-row">
+              <slot
+                name="btn-row"
+                {collapsed}
+                toggle={toggleCollapsed}
+                showToggle={expandable}
+              />
+            </div>
+          {/if}
+        </div>
       </div>
     </SidebarElement>
     {#if !collapsed && expandable}
@@ -335,17 +343,25 @@
             <slot {bannerHovered} />
             <slot name="banner-end" {bannerHovered} {collapsed} />
           </div>
-          <slot name="banner-subtitle" {bannerHovered} {collapsed} />
-          {#if $$slots["btn-row"]}
-            <div class="sidebar-banner-btn-row">
-              <slot
-                name="btn-row"
-                {collapsed}
-                toggle={toggleCollapsed}
-                showToggle={expandable}
-              />
+          <div
+            style="display: flex; align-items: flex-end; gap: 6px; min-width: 0;"
+          >
+            <div
+              style="flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px;"
+            >
+              <slot name="banner-subtitle" {bannerHovered} {collapsed} />
             </div>
-          {/if}
+            {#if $$slots["btn-row"]}
+              <div class="sidebar-banner-btn-row">
+                <slot
+                  name="btn-row"
+                  {collapsed}
+                  toggle={toggleCollapsed}
+                  showToggle={expandable}
+                />
+              </div>
+            {/if}
+          </div>
         </div>
       </div>
       {#if !collapsed && expandable}
@@ -387,9 +403,9 @@
 <style>
   .sidebar-banner-btn-row {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
     gap: 4px;
-    margin: 4px 0 2px;
+    flex-shrink: 0;
   }
   :global([data-sidebar-banner-mode="root"] button) {
     cursor: pointer;

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -570,8 +570,7 @@
             aria-label={collapsed ? "Expand workspace" : "Collapse workspace"}
             title={collapsed ? "Expand workspace" : "Collapse workspace"}
             style="background: {$theme.bgSurface ??
-              'transparent'}; border: 1px solid {$theme.border ??
-              'transparent'}; gap: 6px;"
+              'transparent'}; border: none; gap: 6px;"
           >
             {#if collapsed && branchedIds.size > 0}
               <span
@@ -694,9 +693,10 @@
     -webkit-app-region: no-drag;
   }
   .dash-btn-expand {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     width: auto;
     min-width: 28px;
+    padding: 0 6px;
   }
   .dash-btn:hover {
     filter: brightness(1.1);


### PR DESCRIPTION
## Summary
- Move the workspace banner's expand chevron out of a full-width row and into a compact chip aligned to the bottom-right, beside the path/branch subtitle rows.
- Restyle the archive header's expand affordance to match: count + chevron grouped, with the same down-when-collapsed / up-when-expanded rotation.
- Drop the 1px border on both chips so they read as inline glyphs rather than buttons.

## Test plan
- [ ] Open a workspace banner with branched workspaces collapsed → verify the expand chip sits at the bottom-right of the banner (not on its own row), shows the branch count + down-chevron, and clicking it expands the children list.
- [ ] Expand a workspace banner → chevron rotates to point up, count disappears.
- [ ] Workspace banner with no children → expand chip is hidden (no btn-row rendered).
- [ ] Archive section collapsed with N archived workspaces → header shows "Archive" label on the left and a chevron+count chip on the right, no border around the chip.
- [ ] Click the archive header → chevron rotates up, count disappears, archived items list shows below.
- [ ] Drag-to-archive still works (drop target unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)