### PR TITLE
fix(pane): dismiss on last pane spawns fresh terminal instead of closing workspace

### DIFF
--- a/src/__tests__/shell-relaunch.test.ts
+++ b/src/__tests__/shell-relaunch.test.ts
@@ -363,6 +363,43 @@ describe("S-RELAUNCH: dismissPane", () => {
     dismissPane("p1");
     expect(getAllPanes(get(workspaces)[0].paneLayout)).toHaveLength(1);
   });
+
+  it("spawns a fresh terminal instead of closing the workspace when dismissing the only pane", async () => {
+    // Single-pane workspace — dismissing would normally collapse the only
+    // pane and remove the workspace entirely. New behavior: spawn a fresh
+    // terminal in place so the workspace stays open (matches manual
+    // close-last-tab).
+    const pane: Pane = {
+      id: "p1",
+      surfaces: [],
+      activeSurfaceId: null,
+      exitedSurface: { code: 0 },
+    };
+    const ws: Workspace = {
+      id: "ws1",
+      name: "Test",
+      paneLayout: { type: "pane", pane },
+      activePaneId: "p1",
+      path: "/tmp/test-ws",
+    };
+    workspaces.set([ws]);
+    activeWorkspaceIdx.set(0);
+
+    dismissPane("p1");
+    // Allow the awaited createTerminalSurface microtask to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Workspace still exists, pane still exists, exitedSurface cleared,
+    // and a fresh surface is attached.
+    const wsList = get(workspaces);
+    expect(wsList).toHaveLength(1);
+    expect(wsList[0].id).toBe("ws1");
+    const panes = getAllPanes(wsList[0].paneLayout);
+    expect(panes).toHaveLength(1);
+    expect(panes[0].exitedSurface).toBeUndefined();
+    expect(panes[0].surfaces).toHaveLength(1);
+  });
 });
 
 describe("S-RELAUNCH: relaunchPane", () => {

--- a/src/lib/services/pane-service.ts
+++ b/src/lib/services/pane-service.ts
@@ -175,6 +175,30 @@ export function dismissPane(paneId: string): void {
   const pane = getAllPanes(ws.paneLayout).find((p) => p.id === paneId);
   if (!pane) return;
   pane.exitedSurface = undefined;
+  // Last pane in a non-dashboard workspace: spawn a fresh terminal in
+  // place rather than removing the pane (which would close the whole
+  // workspace). Mirrors removeSurface's last-tab behavior.
+  const paneCount = getAllPanes(ws.paneLayout).length;
+  if (paneCount === 1 && ws.isDashboard !== true) {
+    pane.activeSurfaceId = null;
+    workspaces.update((l) => [...l]);
+    void (async () => {
+      const cwd =
+        (ws as { worktreePath?: string }).worktreePath ?? ws.path ?? undefined;
+      const surface = await createTerminalSurface(pane, cwd);
+      pane.activeSurfaceId = surface.id;
+      workspaces.update((l) => [...l]);
+      eventBus.emit({
+        type: "surface:created",
+        id: surface.id,
+        paneId: pane.id,
+        kind: "terminal",
+      });
+      void safeFocus(surface);
+      schedulePersist();
+    })();
+    return;
+  }
   removePane(ws, pane);
   schedulePersist();
 }


### PR DESCRIPTION
## Summary
- `dismissPane` previously called `removePane` unconditionally, which closes the entire workspace when the dismissed pane is the only one — surprising behavior given that manually closing the last tab spawns a replacement terminal.
- Mirror `removeSurface`'s last-tab behavior in `dismissPane`: if this is the only pane in a non-dashboard workspace, spawn a fresh terminal in place (cwd from `worktreePath` / `path`) so the workspace stays open. Multi-pane and dashboard cases are unchanged.
- Added a regression test in `shell-relaunch.test.ts` covering the new last-pane case.

## Test plan
- [ ] Open a workspace with a single terminal tab. Run `exit`. On the "Shell exited" screen, click **Dismiss** → workspace stays open with a fresh terminal in place.
- [ ] Same as above but press **Esc** / **D** → workspace stays open with a fresh terminal in place.
- [ ] Open a workspace with two split panes. Exit one shell → click **Dismiss** → that pane collapses, workspace and other pane remain (existing behavior preserved).
- [ ] Open a workspace, exit the only tab, click **Relaunch** → fresh terminal in place (existing behavior preserved).
- [ ] Open a Dashboard workspace, trigger dismiss flow → workspace closes (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)