### PR TITLE
feat(rail): waiting-attention hat on collapsed Root rails

### DIFF
--- a/src/__tests__/rail-attention.test.ts
+++ b/src/__tests__/rail-attention.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for rootNeedsRailAttention — pure aggregator that decides
+ * whether a Root workspace's collapsed-mode rail should paint the
+ * "needs attention" hat.
+ */
+import { describe, it, expect } from "vitest";
+import { rootNeedsRailAttention } from "../lib/services/rail-attention";
+import type { DetectedAgent } from "../lib/services/agent-detection-service";
+import type { RootWorkspace } from "../lib/config";
+
+function makeAgent(overrides: Partial<DetectedAgent> = {}): DetectedAgent {
+  const now = new Date().toISOString();
+  return {
+    agentId: "agent-1",
+    agentName: "Claude Code",
+    surfaceId: "surface-1",
+    workspaceId: "ws-1",
+    status: "running",
+    createdAt: now,
+    lastStatusChange: now,
+    ...overrides,
+  };
+}
+
+function makeRoot(
+  id: string,
+  branchedWorkspaceIds: string[] = [],
+): RootWorkspace {
+  return {
+    id,
+    name: id,
+    color: "#aaa",
+    path: "/tmp",
+    branchedWorkspaceIds,
+    isGit: false,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+describe("rootNeedsRailAttention", () => {
+  it("returns false when there are no agents", () => {
+    const root = makeRoot("root-1");
+    expect(rootNeedsRailAttention(root, [])).toBe(false);
+  });
+
+  it("returns false when no agent is in this Root or its branches", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [makeAgent({ workspaceId: "other", status: "waiting" })];
+    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+  });
+
+  it("returns true when the Root itself has a waiting agent", () => {
+    const root = makeRoot("root-1");
+    const agents = [makeAgent({ workspaceId: "root-1", status: "waiting" })];
+    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+  });
+
+  it("returns true when a branch has a waiting agent", () => {
+    const root = makeRoot("root-1", ["br-1", "br-2"]);
+    const agents = [makeAgent({ workspaceId: "br-2", status: "waiting" })];
+    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+  });
+
+  it("returns false when agents are running/idle/active but none waiting", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "running" }),
+      makeAgent({ workspaceId: "br-1", status: "idle" }),
+      makeAgent({ workspaceId: "br-1", status: "active" }),
+    ];
+    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+  });
+
+  it("returns true when at least one agent waits, even if others are running", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "running" }),
+      makeAgent({ workspaceId: "br-1", status: "waiting" }),
+    ];
+    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+  });
+
+  it("ignores closed agents (consistency with buildAgentRows)", () => {
+    const root = makeRoot("root-1");
+    const agents = [makeAgent({ workspaceId: "root-1", status: "closed" })];
+    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+  });
+});

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -64,6 +64,15 @@
    * is the row's main interaction target.
    */
   export let primaryClickable: boolean = false;
+  /**
+   * Collapsed-mode attention signal. When true and the rail is in
+   * narrowRail mode, paints a 10px yellow "hat" at the top of the
+   * rail with a 2px dark divider below it and a gentle pulse glow.
+   * The hat sits flush over the rail stripe; the workspace accent
+   * color shows through below the divider. Ignored when narrowRail
+   * is false (expanded sidebar uses per-row badges instead).
+   */
+  export let needsAttention: boolean = false;
 
   let closeButtonHovered = false;
   // shortcutLabel takes priority over close/lock when meta-hold is active.
@@ -90,6 +99,10 @@
   $: showDots = visible && alwaysShowDots && !narrowRail;
   $: showRailStripe = !visible || narrowRail;
   $: railStripeWidth = narrowRail ? "4px" : "8px";
+  // Hat only renders in collapsed-mode (narrowRail). In expanded
+  // mode the per-row status badges already cover attention, so the
+  // hat would be redundant noise.
+  $: showAttentionHat = narrowRail && needsAttention;
 </script>
 
 <div
@@ -124,6 +137,34 @@
         background: {effectiveColor};
         opacity: {railOpacity};
         transition: width 0.1s;
+      "
+    ></div>
+  {/if}
+  {#if showAttentionHat}
+    <!-- F2 hat overlay: 10px canonical-warning yellow at the top of
+         the rail, a 2px dark divider, then the underlying rail
+         stripe color shows through. Width matches the narrow rail
+         (4px) so the rail does not get visually thicker. The
+         box-shadow keyframe pulses a gentle glow that survives the
+         amber-accent collision case (where the rail color and the
+         hat color match). -->
+    <div
+      aria-hidden="true"
+      class="rail-attention-hat"
+      style="
+        position: absolute;
+        left: 0; top: 0;
+        width: 4px;
+        height: 12px;
+        background: linear-gradient(
+          to bottom,
+          #e8b73a 0,
+          #e8b73a 10px,
+          rgba(0, 0, 0, 0.55) 10px,
+          rgba(0, 0, 0, 0.55) 12px
+        );
+        pointer-events: none;
+        z-index: 2;
       "
     ></div>
   {/if}
@@ -227,3 +268,19 @@
     </div>
   {/if}
 </div>
+
+<style>
+  .rail-attention-hat {
+    animation: rail-hat-glow 1.6s ease-in-out infinite;
+  }
+
+  @keyframes rail-hat-glow {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 rgba(232, 183, 58, 0);
+    }
+    50% {
+      box-shadow: 0 0 4px 1.5px rgba(232, 183, 58, 0.55);
+    }
+  }
+</style>

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -3,6 +3,9 @@
   import { shortcutHintsActive } from "../stores/shortcut-hints";
   import CloseIcon from "../icons/CloseIcon.svelte";
   import LockIcon from "../icons/LockIcon.svelte";
+  import { variantColor } from "../status-colors";
+
+  const warningColor = variantColor("warning");
 
   export let theme: ThemeDef;
   export let visible: boolean = false;
@@ -156,10 +159,11 @@
         left: 0; top: 0;
         width: 4px;
         height: 12px;
+        --rail-attention-glow: {warningColor};
         background: linear-gradient(
           to bottom,
-          #e8b73a 0,
-          #e8b73a 10px,
+          {warningColor} 0,
+          {warningColor} 10px,
           rgba(0, 0, 0, 0.55) 10px,
           rgba(0, 0, 0, 0.55) 12px
         );
@@ -271,16 +275,17 @@
 
 <style>
   .rail-attention-hat {
-    animation: rail-hat-glow 1.6s ease-in-out infinite;
+    animation: dg-rail-hat-glow 1.6s ease-in-out infinite;
   }
 
-  @keyframes rail-hat-glow {
+  @keyframes dg-rail-hat-glow {
     0%,
     100% {
-      box-shadow: 0 0 0 0 rgba(232, 183, 58, 0);
+      box-shadow: 0 0 0 0 transparent;
     }
     50% {
-      box-shadow: 0 0 4px 1.5px rgba(232, 183, 58, 0.55);
+      box-shadow: 0 0 4px 1.5px
+        color-mix(in srgb, var(--rail-attention-glow) 55%, transparent);
     }
   }
 </style>

--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -113,6 +113,13 @@
    */
   export let popoverActive: boolean = false;
   /**
+   * True when any workspace inside this banner's tree (root or any
+   * branched workspace) has an agent with status "waiting". Forwarded
+   * to SidebarRail so the collapsed-mode rail can paint a yellow hat
+   * + pulse to surface the attention without expanding the sidebar.
+   */
+  export let needsAttention: boolean = false;
+  /**
    * Number of dashboard chips this banner will render in its
    * children-leading slot. Combined with `nonDashboardCount` it
    * determines whether the banner is expandable and whether the
@@ -290,6 +297,7 @@
         hasActiveStripe={hasActiveChild && collapsed}
         isActive={hasActiveChild}
         {popoverActive}
+        {needsAttention}
         {onGripMouseDown}
         onClick={onBannerClick}
         {onClose}

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -49,6 +49,13 @@
    * popover body. Has no effect when the sidebar is expanded.
    */
   export let popoverActive: boolean = false;
+  /**
+   * True when any workspace in this Root's tree (root + branched
+   * workspaces) has a waiting agent. Drives the collapsed-mode hat
+   * overlay rendered by DragGrip; ignored when the sidebar is
+   * expanded.
+   */
+  export let needsAttention: boolean = false;
 
   /** Mousedown handler for drag start. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
@@ -122,6 +129,7 @@
     {closeTooltip}
     {locked}
     {narrowRail}
+    {needsAttention}
     primaryClickable={!$sidebarVisible && !!onClick}
   />
   {#if mode === "container" && hasActiveStripe}

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -58,6 +58,7 @@
   } from "../stores/ui";
   import { contrastColor } from "../utils/contrast";
   import { agentsStore } from "../services/agent-detection-service";
+  import { rootNeedsRailAttention } from "../services/rail-attention";
   import { variantColor } from "../status-colors";
   import { shortcutHintsActive } from "../stores/shortcut-hints";
   import { modLabel } from "../terminal-service";
@@ -163,6 +164,15 @@
       return { label: `${idle} idle`, color: variantColor("muted") };
     return null;
   })();
+
+  // Rail attention — collapsed-mode signal for the rail. Scope is
+  // intentionally Root + all branches (worktree AND dashboard branches,
+  // both live in branchedWorkspaceIds). This is the only attention
+  // surface in collapsed mode; banner-level workspaceBotStatus above
+  // stays root-only by design.
+  $: railNeedsAttention = workspace
+    ? rootNeedsRailAttention(workspace, $agentsStore)
+    : false;
 
   // True when the primary workspace of this workspace is currently active.
   // Makes the banner border solid only when the primary workspace
@@ -455,6 +465,7 @@
       hasActiveChild={hasActiveDescendant}
       {isPrimaryActive}
       {popoverActive}
+      needsAttention={railNeedsAttention}
       scopeId={workspace.id}
       {containerBlockId}
       containerLabel={workspace.name}

--- a/src/lib/services/rail-attention.ts
+++ b/src/lib/services/rail-attention.ts
@@ -1,0 +1,18 @@
+/**
+ * Rail attention — pure aggregator that decides whether a Root
+ * workspace's collapsed-mode rail should paint the "needs attention"
+ * hat. Mirrors the buildAgentRows pattern (pure, store-free, vitest-
+ * testable). Scope is intentionally Root + all branches, in contrast
+ * to WorkspaceSectionContent's banner-level workspaceBotStatus, which
+ * is root-only.
+ */
+import type { DetectedAgent } from "./agent-detection-service";
+import type { RootWorkspace } from "../config";
+
+export function rootNeedsRailAttention(
+  root: RootWorkspace,
+  agents: DetectedAgent[],
+): boolean {
+  const ids = new Set([root.id, ...root.branchedWorkspaceIds]);
+  return agents.some((a) => ids.has(a.workspaceId) && a.status === "waiting");
+}


### PR DESCRIPTION
## Summary

When the primary sidebar is collapsed, Root workspace rails now paint a small yellow "hat" with a gentle pulse if any agent in the Root-or-branch tree (worktree or dashboard branches) has `status === "waiting"`. Gives a non-intrusive attention signal without expanding the sidebar.

- New pure aggregator `rootNeedsRailAttention` in `src/lib/services/rail-attention.ts` — Root + `branchedWorkspaceIds`, returns boolean.
- New `needsAttention` prop threaded `WorkspaceSectionContent → SidebarBanner → SidebarRail → DragGrip`. Hat overlay only renders when `narrowRail && needsAttention`.
- Hat uses canonical `variantColor("warning")` token, 2px dark divider for amber-accent collision, scoped keyframe `dg-rail-hat-glow`.
- Existing root-only `workspaceBotStatus` (banner icon) is untouched — the two aggregators are intentionally side-by-side with different scopes.

See `docs/superpowers/specs/2026-05-09-rail-bot-attention-design.md` for the design.

## Test plan

- [ ] Split a Root into a worktree branch. Trigger `agentStatus === 'waiting'` in the branch's terminal. Collapse the sidebar. Confirm Root's rail shows the yellow hat + dark divider + gentle glow pulse.
- [ ] Same flow with a dashboard branch instead of a worktree branch.
- [ ] Resolve the wait. Confirm the hat disappears within one render frame.
- [ ] With a workspace whose accent is amber (`#e8b73a`), trigger a wait in the same Root's tree. Confirm the dark divider keeps the hat visually distinct.
- [ ] Expand the sidebar. Confirm no hat appears (existing per-row badges remain the only attention signal).
- [ ] Make a Root row active and trigger an attention state. Confirm the rail widens to 8px AND shows the hat.
- [ ] Banner bot-status icon regression: confirm banner icon still reflects Root-only state (does not flip to "waiting" because of a branch wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)