### PR TITLE
fix(paste,rail,macos): bracketed paste, universal bot hat, TCC prompts

### DIFF
--- a/src-tauri/Info.dev.plist
+++ b/src-tauri/Info.dev.plist
@@ -10,5 +10,25 @@
   <string>com.gnar.gnarterm.dev</string>
   <key>CFBundleExecutable</key>
   <string>gnar-term</string>
+  <!--
+    Mirror the release Info.plist usage descriptions so dev builds
+    surface the same intelligible TCC prompts (and persist grants)
+    when claude / other in-pane agents stat into protected user-data
+    directories. See src-tauri/Info.plist for the rationale.
+  -->
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>GnarTerm (Dev) and the coding agents running inside it read files in your Documents folder when you point them at projects or ask them to explore.</string>
+  <key>NSDownloadsFolderUsageDescription</key>
+  <string>GnarTerm (Dev) and the coding agents running inside it read files in your Downloads folder when you open or reference them in a workspace.</string>
+  <key>NSDesktopFolderUsageDescription</key>
+  <string>GnarTerm (Dev) and the coding agents running inside it read files on your Desktop when you point them at projects or drop a folder onto a pane.</string>
+  <key>NSAppleMusicUsageDescription</key>
+  <string>GnarTerm (Dev) needs this to walk into your ~/Music tree when an agent enumerates or searches under your home directory; it does not access Apple Music itself.</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>GnarTerm (Dev) needs this to walk into your ~/Pictures tree when an agent enumerates or searches under your home directory; it does not import photos.</string>
+  <key>NSRemovableVolumesUsageDescription</key>
+  <string>GnarTerm (Dev) reads files on removable volumes when you open a workspace whose path lives on one.</string>
+  <key>NSNetworkVolumesUsageDescription</key>
+  <string>GnarTerm (Dev) reads files on network volumes when you open a workspace whose path lives on one.</string>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  GnarTerm runs MCP-driven coding agents (Claude Code) inside its
+  panes. Those agents browse the filesystem on the user's behalf and
+  routinely stat paths that fall under macOS TCC-protected user-data
+  directories. Without these usage-description strings, the resulting
+  prompts are generic ("GnarTerm wants to access files in your
+  Documents folder") with no app-supplied reason, and macOS may
+  refuse to persist the user's grant cleanly across launches.
+
+  Adding the strings does not suppress the first prompt per
+  directory — that's macOS-mandated — but it makes each prompt
+  intelligible and lets the grant stick.
+-->
+<plist version="1.0">
+<dict>
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>GnarTerm and the coding agents running inside it (e.g. Claude Code) read files in your Documents folder when you point them at projects or ask them to explore.</string>
+  <key>NSDownloadsFolderUsageDescription</key>
+  <string>GnarTerm and the coding agents running inside it read files in your Downloads folder when you open or reference them in a workspace.</string>
+  <key>NSDesktopFolderUsageDescription</key>
+  <string>GnarTerm and the coding agents running inside it read files on your Desktop when you point them at projects or drop a folder onto a pane.</string>
+  <key>NSAppleMusicUsageDescription</key>
+  <string>GnarTerm needs this to walk into your ~/Music tree when an agent enumerates or searches under your home directory; it does not access Apple Music itself.</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>GnarTerm needs this to walk into your ~/Pictures tree when an agent enumerates or searches under your home directory; it does not import photos.</string>
+  <key>NSRemovableVolumesUsageDescription</key>
+  <string>GnarTerm reads files on removable volumes when you open a workspace whose path lives on one.</string>
+  <key>NSNetworkVolumesUsageDescription</key>
+  <string>GnarTerm reads files on network volumes when you open a workspace whose path lives on one.</string>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,7 +353,7 @@ pub fn run() {
             // but Cmd+T/Cmd+W/Cmd+N are passed down to JS.
             #[cfg(target_os = "macos")]
             {
-                use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
+                use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
                 let handle = app.handle();
 
                 // GnarTerm Menu
@@ -375,13 +375,16 @@ pub fn run() {
                     ],
                 )?;
 
-                // Edit Menu — Copy/Cut/Paste/Select All are PredefinedMenuItems
-                // which enable native clipboard in the WebView for non-terminal
-                // content (preview surfaces, command palette, etc.).
-                // Terminal surfaces override Cmd+C/V via attachCustomKeyEventHandler.
+                // Edit Menu — Cut/Copy/Select All stay PredefinedMenuItems
+                // (their native NSText actions work fine for both terminal and
+                // non-terminal surfaces). Paste is a custom MenuItem so the
+                // Cmd+V accelerator routes through us — the native paste:
+                // action bypasses xterm.js's bracketed-paste wrapping, which
+                // breaks TUIs (notably Claude Code) that rely on the
+                // `\x1b[200~…\x1b[201~` envelope to recognize a paste.
                 let cut = PredefinedMenuItem::cut(handle, None)?;
                 let copy = PredefinedMenuItem::copy(handle, None)?;
-                let paste = PredefinedMenuItem::paste(handle, None)?;
+                let paste = MenuItem::with_id(handle, "paste", "Paste", true, Some("CmdOrCtrl+V"))?;
                 let select_all = PredefinedMenuItem::select_all(handle, None)?;
 
                 let edit_menu =
@@ -398,7 +401,6 @@ pub fn run() {
                     MenuItem::with_id(handle, "close-tab", "Close Tab", true, Some("CmdOrCtrl+W"))?;
 
                 // View > Theme submenu
-                use tauri::menu::MenuItem;
                 let theme_github = MenuItem::with_id(
                     handle,
                     "theme-github-dark",
@@ -509,6 +511,8 @@ pub fn run() {
                 let _ = app.emit("menu-cmd-palette", ());
             } else if id == "close-tab" {
                 let _ = app.emit("menu-close-tab", ());
+            } else if id == "paste" {
+                let _ = app.emit("menu-paste", ());
             }
         })
         .run(tauri::generate_context!())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -52,6 +52,7 @@
   import { ask, message } from "@tauri-apps/plugin-dialog";
   import { eventBus } from "./lib/services/event-bus";
   import { initDragDropPaneRouter } from "./lib/services/drag-drop-pane-router";
+  import { handleMenuPaste } from "./lib/services/menu-paste-router";
 
   // Extension lifecycle
   import {
@@ -794,6 +795,10 @@
 
     await listen("menu-close-tab", () => {
       closeActiveSurface();
+    });
+
+    await listen("menu-paste", () => {
+      void handleMenuPaste();
     });
 
     // Track fullscreen state for layout adjustments (e.g. traffic light padding)

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -1290,39 +1290,6 @@ describe("WorkspaceItem", () => {
     expect(screen.getByText("Build complete")).toBeTruthy();
   });
 
-  it("renders a status row when an agent is attached but idle", async () => {
-    // Regression: launching claude in a workspace should immediately
-    // show a status row — even before the tracker transitions to
-    // running/waiting. aggregateAgentBadges consumes process items from
-    // the status registry; a muted item means "agent live, no active
-    // work" and must render a visible row.
-    const { setStatusItem, clearAllStatusForWorkspace } =
-      await import("../lib/services/status-registry");
-    const ws = makeChildWorkspace("ws-agent", "Agent WS");
-    setStatusItem("_agent", ws.id, "surface:s1", {
-      category: "process",
-      priority: 0,
-      label: "idle",
-      variant: "muted",
-      metadata: { surfaceId: "s1" },
-    });
-    const { container } = render(WorkspaceItem, {
-      props: {
-        workspace: ws,
-        index: 0,
-        isActive: false,
-        onSelect: noop,
-        onClose: noop,
-        onRename: noop,
-        onContextMenu: noop,
-      },
-    });
-    const row = container.querySelector("[data-harness-title-row]");
-    expect(row).not.toBeNull();
-    expect(row?.getAttribute("title")).toBe("1 idle");
-    clearAllStatusForWorkspace(ws.id);
-  });
-
   it("suppresses the notification row when child of a workspace", () => {
     // Regression: child workspaces render under a workspace's colored
     // banner that already rolls up status; the long blue notification
@@ -2143,7 +2110,7 @@ describe("TerminalSurface", () => {
 // ---------------------------------------------------------------------------
 
 describe("WorkspaceItem — harness sub-row", () => {
-  it("shows sub-row when the active surface has a detected agent", async () => {
+  it("paints a green 'thinking' rail hat for a running agent", async () => {
     const { setStatusItem, clearAllStatusForWorkspace } =
       await import("../lib/services/status-registry");
 
@@ -2171,18 +2138,17 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const harnessEl = container.querySelector("[data-harness-title-row]");
-    expect(harnessEl).not.toBeNull();
-    // When a single tracked agent surface exists, its current task title
-    // is surfaced via the tooltip so the user can see what the agent is
-    // working on without leaving the sidebar.
-    expect(harnessEl?.getAttribute("title")).toBe(
-      "1 running — claude > fixing bug",
-    );
+    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
+    expect(hat).not.toBeNull();
+    // "thinking" hat is static, not pulsing.
+    expect(hat!.classList.contains("pulses")).toBe(false);
     clearAllStatusForWorkspace(ws.id);
   });
 
-  it("shows sub-row when agent is on a non-active surface", async () => {
+  it("paints a muted 'idle' rail hat when an agent is attached but idle", async () => {
+    // Idle agents still warrant a hat — it's the "currently
+    // thinking" presence indicator that survives the BotIcon
+    // removal. Color is muted-grey, no pulse.
     const { setStatusItem, clearAllStatusForWorkspace } =
       await import("../lib/services/status-registry");
 
@@ -2220,13 +2186,13 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const harnessEl = container.querySelector("[data-harness-title-row]");
-    expect(harnessEl).not.toBeNull();
-    expect(harnessEl?.getAttribute("title")).toBe("1 idle — claude");
+    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
+    expect(hat).not.toBeNull();
+    expect(hat!.classList.contains("pulses")).toBe(false);
     clearAllStatusForWorkspace(ws.id);
   });
 
-  it("hides sub-row when hideStatusBadges is true", async () => {
+  it("hides the rail hat when hideStatusBadges is true", async () => {
     const { setStatusItem, clearAllStatusForWorkspace } =
       await import("../lib/services/status-registry");
 
@@ -2255,14 +2221,13 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    expect(container.querySelector("[data-harness-title-row]")).toBeNull();
+    expect(container.querySelector(".rail-bot-hat")).toBeNull();
     clearAllStatusForWorkspace(ws.id);
   });
 
-  it("falls back to the badge count when multiple agent surfaces are tracked", async () => {
-    // With two tracked surfaces in the same workspace, no single title
-    // is dominant; the row reverts to the aggregate "N running" count
-    // rather than picking one task at random.
+  it("paints a single 'thinking' hat regardless of how many agents are running", async () => {
+    // Multiple agents collapse to one hat — the hat is a per-row
+    // signal, not a per-agent one. Color stays the running-green.
     const { setStatusItem, clearAllStatusForWorkspace } =
       await import("../lib/services/status-registry");
 
@@ -2307,9 +2272,42 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const harnessEl = container.querySelector("[data-harness-title-row]");
-    expect(harnessEl).not.toBeNull();
-    expect(harnessEl?.getAttribute("title")).toBe("2 running");
+    const hats = container.querySelectorAll(".rail-bot-hat");
+    expect(hats.length).toBe(1);
+    clearAllStatusForWorkspace(ws.id);
+  });
+
+  it("paints a pulsing 'attention' hat for a waiting agent", async () => {
+    const { setStatusItem, clearAllStatusForWorkspace } =
+      await import("../lib/services/status-registry");
+
+    const surface = makeSurface("s1", { title: "claude" });
+    const pane = makePane("p1", [surface]);
+    const ws = makeChildWorkspace("ws-attn", "Attention WS", pane);
+
+    setStatusItem("_agent", ws.id, "surface:s1", {
+      category: "process",
+      priority: 0,
+      label: "waiting",
+      variant: "warning",
+      metadata: { surfaceId: "s1" },
+    });
+
+    const { container } = render(WorkspaceItem, {
+      props: {
+        workspace: ws,
+        index: 0,
+        isActive: true,
+        onSelect: noop,
+        onClose: noop,
+        onRename: noop,
+        onContextMenu: noop,
+      },
+    });
+
+    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
+    expect(hat).not.toBeNull();
+    expect(hat!.classList.contains("pulses")).toBe(true);
     clearAllStatusForWorkspace(ws.id);
   });
 });

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -74,6 +74,52 @@ describe("DragGrip", () => {
     expect(stripe).not.toBeNull();
     expect(stripe!.style.width).toBe("4px");
   });
+
+  it("renders the bot-status hat in narrow (collapsed) mode", () => {
+    const { container } = render(DragGrip, {
+      props: {
+        theme: stubTheme,
+        visible: false,
+        railColor: "#abcdef",
+        narrowRail: true,
+        botStatus: "thinking",
+      },
+    });
+    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
+    expect(hat).not.toBeNull();
+    expect(hat!.style.width).toBe("4px");
+  });
+
+  it("renders the bot-status hat in expanded (full-width) mode too", () => {
+    // Regression: bot status used to be hidden when the sidebar was
+    // expanded. Now the hat must paint at every rail width so agent
+    // notifications stay visible regardless of sidebar layout.
+    const { container } = render(DragGrip, {
+      props: {
+        theme: stubTheme,
+        visible: false,
+        railColor: "#abcdef",
+        narrowRail: false,
+        botStatus: "attention",
+      },
+    });
+    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
+    expect(hat).not.toBeNull();
+    expect(hat!.style.width).toBe("8px");
+    expect(hat!.classList.contains("pulses")).toBe(true);
+  });
+
+  it("hides the bot-status hat when botStatus is none", () => {
+    const { container } = render(DragGrip, {
+      props: {
+        theme: stubTheme,
+        visible: false,
+        railColor: "#abcdef",
+        botStatus: "none",
+      },
+    });
+    expect(container.querySelector(".rail-bot-hat")).toBeNull();
+  });
 });
 
 const SOURCE = readFileSync(

--- a/src/__tests__/menu-paste-router.test.ts
+++ b/src/__tests__/menu-paste-router.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the menu-paste router. The native Edit > Paste accelerator
+ * preempts the in-terminal keydown handler, so paste must route through
+ * this dispatcher to preserve xterm bracketed-paste wrapping for TUIs
+ * (Claude Code, vim) while still working in DOM inputs.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const clipboardText = vi.fn<[], Promise<string>>();
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: () => clipboardText(),
+}));
+
+const workspacesValue: Array<{ paneLayout: unknown }> = [];
+vi.mock("../lib/stores/workspace", () => ({
+  workspaces: { subscribe: vi.fn() },
+}));
+vi.mock("svelte/store", async () => {
+  const actual =
+    await vi.importActual<typeof import("svelte/store")>("svelte/store");
+  return { ...actual, get: () => workspacesValue };
+});
+
+import { handleMenuPaste } from "../lib/services/menu-paste-router";
+
+function makeTerminalSurface(termElement: HTMLElement, ptyId = 1) {
+  const paste = vi.fn();
+  return {
+    paste,
+    surface: {
+      kind: "terminal" as const,
+      id: "s1",
+      terminal: { paste } as unknown as { paste: typeof paste },
+      fitAddon: {} as never,
+      searchAddon: {} as never,
+      termElement,
+      ptyId,
+      title: "t",
+      hasUnread: false,
+      opened: true,
+    },
+  };
+}
+
+function setActiveLayout(surfaces: unknown[]) {
+  workspacesValue.length = 0;
+  workspacesValue.push({
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p1", surfaces, activeSurfaceId: null },
+    },
+  });
+}
+
+function clearBody(): void {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+}
+
+beforeEach(() => {
+  clearBody();
+  workspacesValue.length = 0;
+  clipboardText.mockResolvedValue("hello world");
+});
+
+describe("handleMenuPaste", () => {
+  it("routes to terminal.paste() when focus is inside a terminal surface", async () => {
+    const termEl = document.createElement("div");
+    const innerXterm = document.createElement("textarea");
+    termEl.appendChild(innerXterm);
+    document.body.appendChild(termEl);
+    const { paste, surface } = makeTerminalSurface(termEl);
+    setActiveLayout([surface]);
+
+    innerXterm.focus();
+    await handleMenuPaste();
+
+    expect(paste).toHaveBeenCalledWith("hello world");
+  });
+
+  it("does not paste when terminal ptyId is -1 (unspawned)", async () => {
+    const termEl = document.createElement("div");
+    document.body.appendChild(termEl);
+    const { paste, surface } = makeTerminalSurface(termEl, -1);
+    setActiveLayout([surface]);
+    termEl.tabIndex = -1;
+    termEl.focus();
+
+    await handleMenuPaste();
+    expect(paste).not.toHaveBeenCalled();
+  });
+
+  it("splices text into a focused HTML input at the selection", async () => {
+    const input = document.createElement("input");
+    input.value = "abcdef";
+    document.body.appendChild(input);
+    input.focus();
+    input.setSelectionRange(2, 4); // select "cd"
+
+    const handler = vi.fn();
+    input.addEventListener("input", handler);
+
+    await handleMenuPaste();
+
+    expect(input.value).toBe("ab" + "hello world" + "ef");
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it("splices text into a focused textarea at the selection", async () => {
+    const ta = document.createElement("textarea");
+    ta.value = "12345";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.setSelectionRange(5, 5);
+
+    await handleMenuPaste();
+    expect(ta.value).toBe("12345hello world");
+  });
+
+  it("delegates to execCommand for contenteditable", async () => {
+    const div = document.createElement("div");
+    div.contentEditable = "true";
+    div.tabIndex = 0;
+    document.body.appendChild(div);
+    div.focus();
+    expect(document.activeElement).toBe(div);
+
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      writable: true,
+      value: exec,
+    });
+
+    await handleMenuPaste();
+    expect(exec).toHaveBeenCalledWith("insertText", false, "hello world");
+  });
+
+  it("is a no-op when clipboard is empty", async () => {
+    clipboardText.mockResolvedValueOnce("");
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    const handler = vi.fn();
+    input.addEventListener("input", handler);
+
+    await handleMenuPaste();
+    expect(handler).not.toHaveBeenCalled();
+    expect(input.value).toBe("");
+  });
+
+  it("swallows clipboard errors without throwing", async () => {
+    clipboardText.mockRejectedValueOnce(new Error("denied"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(handleMenuPaste()).resolves.toBeUndefined();
+    warn.mockRestore();
+  });
+});

--- a/src/__tests__/rail-attention.test.ts
+++ b/src/__tests__/rail-attention.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for rootRailBotStatus — pure aggregator that decides which
- * collapsed-mode rail hat (none / thinking / attention) a Root
- * workspace's rail should paint.
+ * rail hat (none / thinking / attention) a Root workspace's rail
+ * should paint. The hat renders at every sidebar width.
  */
 import { describe, it, expect } from "vitest";
 import { rootRailBotStatus } from "../lib/services/rail-attention";
@@ -81,13 +81,39 @@ describe("rootRailBotStatus", () => {
     expect(rootRailBotStatus(root, agents)).toBe("attention");
   });
 
-  it("returns 'none' when every agent is idle/done/closed", () => {
+  it("returns 'idle' when every present agent is idle/done", () => {
     const root = makeRoot("root-1", ["br-1"]);
     const agents = [
       makeAgent({ workspaceId: "root-1", status: "idle" }),
       makeAgent({ workspaceId: "br-1", status: "done" }),
+    ];
+    expect(rootRailBotStatus(root, agents)).toBe("idle");
+  });
+
+  it("ignores 'closed' agents (the process is gone, no hat)", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "closed" }),
       makeAgent({ workspaceId: "br-1", status: "closed" }),
     ];
     expect(rootRailBotStatus(root, agents)).toBe("none");
+  });
+
+  it("returns 'idle' over 'none' when at least one agent is still attached", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "idle" }),
+      makeAgent({ workspaceId: "br-1", status: "closed" }),
+    ];
+    expect(rootRailBotStatus(root, agents)).toBe("idle");
+  });
+
+  it("'thinking' wins over 'idle' co-presence", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "idle" }),
+      makeAgent({ workspaceId: "br-1", status: "running" }),
+    ];
+    expect(rootRailBotStatus(root, agents)).toBe("thinking");
   });
 });

--- a/src/__tests__/rail-attention.test.ts
+++ b/src/__tests__/rail-attention.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for rootNeedsRailAttention — pure aggregator that decides
- * whether a Root workspace's collapsed-mode rail should paint the
- * "needs attention" hat.
+ * Tests for rootRailBotStatus — pure aggregator that decides which
+ * collapsed-mode rail hat (none / thinking / attention) a Root
+ * workspace's rail should paint.
  */
 import { describe, it, expect } from "vitest";
-import { rootNeedsRailAttention } from "../lib/services/rail-attention";
+import { rootRailBotStatus } from "../lib/services/rail-attention";
 import type { DetectedAgent } from "../lib/services/agent-detection-service";
 import type { RootWorkspace } from "../lib/config";
 
@@ -37,52 +37,57 @@ function makeRoot(
   };
 }
 
-describe("rootNeedsRailAttention", () => {
-  it("returns false when there are no agents", () => {
-    const root = makeRoot("root-1");
-    expect(rootNeedsRailAttention(root, [])).toBe(false);
+describe("rootRailBotStatus", () => {
+  it("returns 'none' when there are no agents", () => {
+    expect(rootRailBotStatus(makeRoot("root-1"), [])).toBe("none");
   });
 
-  it("returns false when no agent is in this Root or its branches", () => {
+  it("returns 'none' when no agent is in this Root or its branches", () => {
     const root = makeRoot("root-1", ["br-1"]);
     const agents = [makeAgent({ workspaceId: "other", status: "waiting" })];
-    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+    expect(rootRailBotStatus(root, agents)).toBe("none");
   });
 
-  it("returns true when the Root itself has a waiting agent", () => {
+  it("returns 'attention' when the Root itself has a waiting agent", () => {
     const root = makeRoot("root-1");
     const agents = [makeAgent({ workspaceId: "root-1", status: "waiting" })];
-    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+    expect(rootRailBotStatus(root, agents)).toBe("attention");
   });
 
-  it("returns true when a branch has a waiting agent", () => {
+  it("returns 'attention' when a branch has a waiting agent", () => {
     const root = makeRoot("root-1", ["br-1", "br-2"]);
     const agents = [makeAgent({ workspaceId: "br-2", status: "waiting" })];
-    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+    expect(rootRailBotStatus(root, agents)).toBe("attention");
   });
 
-  it("returns false when agents are running/idle/active but none waiting", () => {
+  it("returns 'thinking' when an agent is running but none is waiting", () => {
     const root = makeRoot("root-1", ["br-1"]);
-    const agents = [
-      makeAgent({ workspaceId: "root-1", status: "running" }),
-      makeAgent({ workspaceId: "br-1", status: "idle" }),
-      makeAgent({ workspaceId: "br-1", status: "active" }),
-    ];
-    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+    const agents = [makeAgent({ workspaceId: "root-1", status: "running" })];
+    expect(rootRailBotStatus(root, agents)).toBe("thinking");
   });
 
-  it("returns true when at least one agent waits, even if others are running", () => {
+  it("returns 'thinking' when an agent is active but none is waiting", () => {
+    const root = makeRoot("root-1");
+    const agents = [makeAgent({ workspaceId: "root-1", status: "active" })];
+    expect(rootRailBotStatus(root, agents)).toBe("thinking");
+  });
+
+  it("returns 'attention' when at least one waits, even alongside running", () => {
     const root = makeRoot("root-1", ["br-1"]);
     const agents = [
       makeAgent({ workspaceId: "root-1", status: "running" }),
       makeAgent({ workspaceId: "br-1", status: "waiting" }),
     ];
-    expect(rootNeedsRailAttention(root, agents)).toBe(true);
+    expect(rootRailBotStatus(root, agents)).toBe("attention");
   });
 
-  it("ignores closed agents (consistency with buildAgentRows)", () => {
-    const root = makeRoot("root-1");
-    const agents = [makeAgent({ workspaceId: "root-1", status: "closed" })];
-    expect(rootNeedsRailAttention(root, agents)).toBe(false);
+  it("returns 'none' when every agent is idle/done/closed", () => {
+    const root = makeRoot("root-1", ["br-1"]);
+    const agents = [
+      makeAgent({ workspaceId: "root-1", status: "idle" }),
+      makeAgent({ workspaceId: "br-1", status: "done" }),
+      makeAgent({ workspaceId: "br-1", status: "closed" }),
+    ];
+    expect(rootRailBotStatus(root, agents)).toBe("none");
   });
 });

--- a/src/__tests__/workspace-diff-pr-subtitle.test.ts
+++ b/src/__tests__/workspace-diff-pr-subtitle.test.ts
@@ -178,4 +178,67 @@ describe("WorkspaceDiffPrSubtitle", () => {
     expect(container.querySelector("[data-pr-row]")).not.toBeNull();
     expect(container.textContent).toMatch(/#42/);
   });
+
+  it("never paints the previous row's PR after the workspaceId prop changes", async () => {
+    // Regression: the collapsed-rail popover reuses one subtitle
+    // instance with a changing `workspaceId` prop. Imperatively-set
+    // `pr` would briefly show row A's PR after switching to row B,
+    // until the `repoRoot` reactive chain caught up. The fix derives
+    // `pr` from `(repoRoot, prCacheStore)` so the displayed PR can
+    // never be from a different repo root than the one we're
+    // currently rendering.
+    const { invoke } = await import("@tauri-apps/api/core");
+    const invokeMock = vi.mocked(invoke);
+
+    const prA = {
+      number: 11,
+      title: "PR A",
+      state: "OPEN",
+      url: "https://example.com/pr/11",
+      headRefName: "feat-a",
+      isDraft: false,
+      ciStatus: "SUCCESS",
+    };
+    const prB = {
+      number: 22,
+      title: "PR B",
+      state: "OPEN",
+      url: "https://example.com/pr/22",
+      headRefName: "feat-b",
+      isDraft: false,
+      ciStatus: "SUCCESS",
+    };
+    invokeMock.mockImplementation(async (cmd: string, args?: unknown) => {
+      if (cmd !== "gh_view_pr") return null;
+      const path = (args as { repoPath: string }).repoPath;
+      if (path === "/repos/A") return prA;
+      if (path === "/repos/B") return prB;
+      return null;
+    });
+
+    workspaces.set([makeRootWorkspace("ws-A"), makeRootWorkspace("ws-B")]);
+    setBranch("ws-A", "/repos/A");
+    setBranch("ws-B", "/repos/B");
+
+    const view = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-A" },
+    });
+    // Drain enough microtasks for invoke + reactive flush so #11 lands.
+    await tick();
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    await tick();
+    expect(view.container.textContent).toMatch(/#11/);
+
+    // Switch the prop without remounting — same instance, new row.
+    await view.rerender({ workspaceId: "ws-B" });
+    await tick();
+    // At this exact moment, the displayed PR must NOT be A's #11.
+    // It can be a placeholder, B's #22 from a fresh-cache hit, or
+    // null while pending — anything but A's PR data.
+    expect(view.container.textContent).not.toMatch(/#11/);
+
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    await tick();
+    expect(view.container.textContent).toMatch(/#22/);
+  });
 });

--- a/src/__tests__/workspace-diff-pr-subtitle.test.ts
+++ b/src/__tests__/workspace-diff-pr-subtitle.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(null),
@@ -21,6 +22,23 @@ import {
   statusRegistry,
 } from "../lib/services/status-registry";
 import { GIT_STATUS_SOURCE } from "../lib/services/git-status-service";
+import { workspaces } from "../lib/stores/workspace";
+import type { Workspace } from "../lib/types";
+
+function makeRootWorkspace(id: string): Workspace {
+  return {
+    id,
+    name: id,
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p1", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: null,
+    path: "/repos/project",
+    color: "#aaa",
+    isGit: true,
+  };
+}
 
 function setDirty(workspaceId: string, label = "M3 A1") {
   setStatusItem(GIT_STATUS_SOURCE, workspaceId, "dirty", {
@@ -80,5 +98,84 @@ describe("WorkspaceDiffPrSubtitle", () => {
         (args as Record<string, unknown>).repoPath === "/repos/project",
     );
     expect(called).toBe(true);
+  });
+
+  it("renders a hidden placeholder PR row while the initial fetch is pending", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const invokeMock = vi.mocked(invoke);
+    // Never resolve, so prInitialResolved stays false.
+    invokeMock.mockImplementation(() => new Promise(() => {}));
+
+    workspaces.set([makeRootWorkspace("ws-1")]);
+    setBranch("ws-1", "/repos/placeholder-test");
+
+    const { container } = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(container.querySelector("[data-pr-row-placeholder]")).not.toBeNull();
+    // Real PR row should not be present yet.
+    expect(container.querySelector("[data-pr-row]")).toBeNull();
+  });
+
+  it("paints the real PR row synchronously on a second mount via the module-level cache", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const invokeMock = vi.mocked(invoke);
+
+    const fakePr = {
+      number: 42,
+      title: "Cached PR",
+      state: "OPEN",
+      url: "https://example.com/pr/42",
+      headRefName: "feat-x",
+      isDraft: false,
+      ciStatus: "SUCCESS",
+    };
+    invokeMock.mockImplementation(async (cmd: string) =>
+      cmd === "gh_view_pr" ? fakePr : null,
+    );
+
+    workspaces.set([makeRootWorkspace("ws-1")]);
+    setBranch("ws-1", "/repos/cache-hit-test");
+
+    // First mount: trigger fetch and let the module-level cache fill.
+    const first = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+    // Drain enough microtasks for invoke promise + .then handlers + reactive
+    // statements to flush before unmounting.
+    await tick();
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+    await tick();
+
+    // Sanity check: gh_view_pr fired at least once on first mount and the
+    // first call resolved with our fake PR (proving the cache should be
+    // populated by now).
+    expect(
+      invokeMock.mock.calls.some(
+        ([cmd, args]) =>
+          cmd === "gh_view_pr" &&
+          (args as Record<string, unknown>).repoPath ===
+            "/repos/cache-hit-test",
+      ),
+    ).toBe(true);
+    expect(first.container.textContent).toMatch(/#42/);
+
+    first.unmount();
+    cleanup();
+
+    // Second mount: cache hit should paint the real PR row immediately, with
+    // no placeholder reservation. Workspaces store survives across mounts.
+    const { container } = render(WorkspaceDiffPrSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+    await tick();
+
+    expect(container.querySelector("[data-pr-row-placeholder]")).toBeNull();
+    expect(container.querySelector("[data-pr-row]")).not.toBeNull();
+    expect(container.textContent).toMatch(/#42/);
   });
 });

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -6,6 +6,7 @@
   import { variantColor } from "../status-colors";
 
   const warningColor = variantColor("warning");
+  const successColor = variantColor("success");
 
   export let theme: ThemeDef;
   export let visible: boolean = false;
@@ -68,14 +69,19 @@
    */
   export let primaryClickable: boolean = false;
   /**
-   * Collapsed-mode attention signal. When true and the rail is in
-   * narrowRail mode, paints a 10px yellow "hat" at the top of the
-   * rail with a 2px dark divider below it and a gentle pulse glow.
-   * The hat sits flush over the rail stripe; the workspace accent
-   * color shows through below the divider. Ignored when narrowRail
-   * is false (expanded sidebar uses per-row badges instead).
+   * Collapsed-mode bot status signal. Drives the rail "hat":
+   *   - "none":       no hat painted.
+   *   - "thinking":   green static hat — at least one agent in the
+   *                   tree is running/active but none waiting.
+   *   - "attention":  yellow pulsing hat — at least one agent is
+   *                   waiting on user input. Highest priority and
+   *                   supersedes "thinking".
+   *
+   * Hats only render when the rail is in `narrowRail` (collapsed
+   * sidebar) mode — expanded mode uses per-row badges instead so
+   * a hat would be redundant noise.
    */
-  export let needsAttention: boolean = false;
+  export let botStatus: "none" | "thinking" | "attention" = "none";
 
   let closeButtonHovered = false;
   // shortcutLabel takes priority over close/lock when meta-hold is active.
@@ -103,9 +109,11 @@
   $: showRailStripe = !visible || narrowRail;
   $: railStripeWidth = narrowRail ? "4px" : "8px";
   // Hat only renders in collapsed-mode (narrowRail). In expanded
-  // mode the per-row status badges already cover attention, so the
+  // mode the per-row status badges already cover bot status, so the
   // hat would be redundant noise.
-  $: showAttentionHat = narrowRail && needsAttention;
+  $: showHat = narrowRail && botStatus !== "none";
+  $: hatColor = botStatus === "attention" ? warningColor : successColor;
+  $: hatPulses = botStatus === "attention";
 </script>
 
 <div
@@ -143,27 +151,29 @@
       "
     ></div>
   {/if}
-  {#if showAttentionHat}
-    <!-- F2 hat overlay: 10px canonical-warning yellow at the top of
-         the rail, a 2px dark divider, then the underlying rail
-         stripe color shows through. Width matches the narrow rail
-         (4px) so the rail does not get visually thicker. The
-         box-shadow keyframe pulses a gentle glow that survives the
-         amber-accent collision case (where the rail color and the
-         hat color match). -->
+  {#if showHat}
+    <!-- Bot-status hat overlay: 10px solid color at the top of the
+         rail, a 2px dark divider, then the underlying rail stripe
+         color shows through. Width matches the narrow rail (4px) so
+         the rail does not get visually thicker. The "attention"
+         variant pulses via box-shadow; the "thinking" variant is
+         static green. The pulse glow survives the rare case where
+         the rail color and hat color match (e.g. amber accent +
+         yellow attention). -->
     <div
       aria-hidden="true"
-      class="rail-attention-hat"
+      class="rail-bot-hat"
+      class:pulses={hatPulses}
       style="
         position: absolute;
         left: 0; top: 0;
         width: 4px;
         height: 12px;
-        --rail-attention-glow: {warningColor};
+        --rail-hat-glow: {hatColor};
         background: linear-gradient(
           to bottom,
-          {warningColor} 0,
-          {warningColor} 10px,
+          {hatColor} 0,
+          {hatColor} 10px,
           rgba(0, 0, 0, 0.55) 10px,
           rgba(0, 0, 0, 0.55) 12px
         );
@@ -274,7 +284,7 @@
 </div>
 
 <style>
-  .rail-attention-hat {
+  .rail-bot-hat.pulses {
     animation: dg-rail-hat-glow 1.6s ease-in-out infinite;
   }
 
@@ -285,7 +295,7 @@
     }
     50% {
       box-shadow: 0 0 4px 1.5px
-        color-mix(in srgb, var(--rail-attention-glow) 55%, transparent);
+        color-mix(in srgb, var(--rail-hat-glow) 55%, transparent);
     }
   }
 </style>

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -7,6 +7,7 @@
 
   const warningColor = variantColor("warning");
   const successColor = variantColor("success");
+  const mutedColor = variantColor("muted");
 
   export let theme: ThemeDef;
   export let visible: boolean = false;
@@ -69,19 +70,25 @@
    */
   export let primaryClickable: boolean = false;
   /**
-   * Collapsed-mode bot status signal. Drives the rail "hat":
-   *   - "none":       no hat painted.
-   *   - "thinking":   green static hat — at least one agent in the
-   *                   tree is running/active but none waiting.
-   *   - "attention":  yellow pulsing hat — at least one agent is
-   *                   waiting on user input. Highest priority and
-   *                   supersedes "thinking".
+   * Bot-status signal. Drives the rail "hat" (a 4–8px colored cap
+   * at the top of the rail). Highest precedence first:
+   *   - "attention":   yellow pulsing hat — at least one agent is
+   *                    waiting on user input. Supersedes everything.
+   *   - "thinking":    green static hat — at least one agent is
+   *                    actively running/working but none waiting.
+   *   - "idle":        muted-grey static hat — agent is attached
+   *                    and "currently thinking" (idle / done /
+   *                    detected-but-not-active). Lowest visual
+   *                    weight, but still surfaces presence so the
+   *                    bot's existence is never invisible.
+   *   - "none":        no hat painted. Only when no agent is
+   *                    detected at all.
    *
-   * Hats only render when the rail is in `narrowRail` (collapsed
-   * sidebar) mode — expanded mode uses per-row badges instead so
-   * a hat would be redundant noise.
+   * Renders in BOTH collapsed (narrowRail) and expanded sidebar
+   * modes — bot status is the only universal signal we surface on
+   * the rail itself, so it stays visible at every width.
    */
-  export let botStatus: "none" | "thinking" | "attention" = "none";
+  export let botStatus: "none" | "thinking" | "attention" | "idle" = "none";
 
   let closeButtonHovered = false;
   // shortcutLabel takes priority over close/lock when meta-hold is active.
@@ -108,12 +115,20 @@
   $: showDots = visible && alwaysShowDots && !narrowRail;
   $: showRailStripe = !visible || narrowRail;
   $: railStripeWidth = narrowRail ? "4px" : "8px";
-  // Hat only renders in collapsed-mode (narrowRail). In expanded
-  // mode the per-row status badges already cover bot status, so the
-  // hat would be redundant noise.
-  $: showHat = narrowRail && botStatus !== "none";
-  $: hatColor = botStatus === "attention" ? warningColor : successColor;
+  // Hat renders at every rail width — bot status is the one signal
+  // we always surface on the rail itself so notification visibility
+  // doesn't depend on whether the sidebar is collapsed.
+  $: showHat = botStatus !== "none";
+  $: hatColor =
+    botStatus === "attention"
+      ? warningColor
+      : botStatus === "thinking"
+        ? successColor
+        : mutedColor;
   $: hatPulses = botStatus === "attention";
+  // Hat matches the rail's painted width so it caps the rail cleanly
+  // in both collapsed (4px) and expanded (8px) modes.
+  $: hatWidth = railStripeWidth;
 </script>
 
 <div
@@ -154,12 +169,13 @@
   {#if showHat}
     <!-- Bot-status hat overlay: 10px solid color at the top of the
          rail, a 2px dark divider, then the underlying rail stripe
-         color shows through. Width matches the narrow rail (4px) so
-         the rail does not get visually thicker. The "attention"
-         variant pulses via box-shadow; the "thinking" variant is
-         static green. The pulse glow survives the rare case where
-         the rail color and hat color match (e.g. amber accent +
-         yellow attention). -->
+         color shows through. Width tracks the rail stripe (4px in
+         collapsed mode, 8px in expanded) so the hat caps the rail
+         cleanly without ever appearing thicker than the rail itself.
+         The "attention" variant pulses via box-shadow; the
+         "thinking" variant is static green. The pulse glow survives
+         the rare case where the rail color and hat color match
+         (e.g. amber accent + yellow attention). -->
     <div
       aria-hidden="true"
       class="rail-bot-hat"
@@ -167,7 +183,7 @@
       style="
         position: absolute;
         left: 0; top: 0;
-        width: 4px;
+        width: {hatWidth};
         height: 12px;
         --rail-hat-glow: {hatColor};
         background: linear-gradient(

--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -114,11 +114,13 @@
   export let popoverActive: boolean = false;
   /**
    * Aggregated bot status across this banner's tree (root + branches).
-   * Forwarded to SidebarRail so the collapsed-mode rail paints the
-   * appropriate hat: green ("thinking") for any active agent, pulsing
-   * yellow ("attention") when one needs input, nothing for "none".
+   * Forwarded to SidebarRail so the rail paints the appropriate hat at
+   * every sidebar width: pulsing yellow ("attention") when one needs
+   * input, green ("thinking") for any actively-working agent, muted
+   * grey ("idle") when an agent is attached but quiet, nothing for
+   * "none".
    */
-  export let botStatus: "none" | "thinking" | "attention" = "none";
+  export let botStatus: "none" | "thinking" | "attention" | "idle" = "none";
   /**
    * Number of dashboard chips this banner will render in its
    * children-leading slot. Combined with `nonDashboardCount` it

--- a/src/lib/components/SidebarBanner.svelte
+++ b/src/lib/components/SidebarBanner.svelte
@@ -113,12 +113,12 @@
    */
   export let popoverActive: boolean = false;
   /**
-   * True when any workspace inside this banner's tree (root or any
-   * branched workspace) has an agent with status "waiting". Forwarded
-   * to SidebarRail so the collapsed-mode rail can paint a yellow hat
-   * + pulse to surface the attention without expanding the sidebar.
+   * Aggregated bot status across this banner's tree (root + branches).
+   * Forwarded to SidebarRail so the collapsed-mode rail paints the
+   * appropriate hat: green ("thinking") for any active agent, pulsing
+   * yellow ("attention") when one needs input, nothing for "none".
    */
-  export let needsAttention: boolean = false;
+  export let botStatus: "none" | "thinking" | "attention" = "none";
   /**
    * Number of dashboard chips this banner will render in its
    * children-leading slot. Combined with `nonDashboardCount` it
@@ -297,7 +297,7 @@
         hasActiveStripe={hasActiveChild && collapsed}
         isActive={hasActiveChild}
         {popoverActive}
-        {needsAttention}
+        {botStatus}
         {onGripMouseDown}
         onClick={onBannerClick}
         {onClose}

--- a/src/lib/components/SidebarElement.svelte
+++ b/src/lib/components/SidebarElement.svelte
@@ -95,6 +95,16 @@
   /** Floating ⌘N hint label shown when shortcut hints are active. */
   export let shortcutLabel: string | undefined = undefined;
 
+  /**
+   * Bot status for this row. Forwarded to SidebarRail / DragGrip,
+   * which paints the colored "hat" at the top of the rail at every
+   * sidebar width. "attention" pulses yellow (waiting on user),
+   * "thinking" is green (active agent), "idle" is muted-grey
+   * (agent attached but not actively working), "none" hides the
+   * hat entirely.
+   */
+  export let botStatus: "none" | "thinking" | "attention" | "idle" = "none";
+
   let isHovered = false;
 
   $: effectiveColor = color || $theme.accent;
@@ -152,6 +162,7 @@
     {isDragging}
     {isActive}
     {popoverActive}
+    {botStatus}
     {onGripMouseDown}
     onClick={onRailClick}
   />

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -50,12 +50,12 @@
    */
   export let popoverActive: boolean = false;
   /**
-   * True when any workspace in this Root's tree (root + branched
-   * workspaces) has a waiting agent. Drives the collapsed-mode hat
-   * overlay rendered by DragGrip; ignored when the sidebar is
-   * expanded.
+   * Aggregated bot status across this Root's tree (root + branched
+   * workspaces). Drives the collapsed-mode hat overlay rendered by
+   * DragGrip — green for "thinking", pulsing yellow for "attention",
+   * nothing for "none". Ignored when the sidebar is expanded.
    */
-  export let needsAttention: boolean = false;
+  export let botStatus: "none" | "thinking" | "attention" = "none";
 
   /** Mousedown handler for drag start. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
@@ -129,7 +129,7 @@
     {closeTooltip}
     {locked}
     {narrowRail}
-    {needsAttention}
+    {botStatus}
     primaryClickable={!$sidebarVisible && !!onClick}
   />
   {#if mode === "container" && hasActiveStripe}

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -50,12 +50,13 @@
    */
   export let popoverActive: boolean = false;
   /**
-   * Aggregated bot status across this Root's tree (root + branched
-   * workspaces). Drives the collapsed-mode hat overlay rendered by
-   * DragGrip — green for "thinking", pulsing yellow for "attention",
-   * nothing for "none". Ignored when the sidebar is expanded.
+   * Bot status for the row this rail belongs to. Drives the hat
+   * overlay rendered by DragGrip — pulsing yellow for "attention",
+   * green for "thinking", muted-grey for "idle", nothing for
+   * "none". Renders at every sidebar width so bot presence stays
+   * visible whether the sidebar is collapsed or expanded.
    */
-  export let botStatus: "none" | "thinking" | "attention" = "none";
+  export let botStatus: "none" | "thinking" | "attention" | "idle" = "none";
 
   /** Mousedown handler for drag start. */
   export let onGripMouseDown: ((e: MouseEvent) => void) | undefined = undefined;

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -1,3 +1,26 @@
+<script context="module" lang="ts">
+  // Module-level PR cache keyed by repoRoot. The collapsed-mode hover
+  // popover mounts a fresh subtitle on every hover, so without a cache
+  // each hover would re-fetch from `gh_view_pr` and re-paint from
+  // `pr = null` → loaded, causing the popover height to jump as the PR
+  // row appears. Seeding from the cache on mount paints the loaded
+  // state instantly on every hover after the first.
+  //
+  // MUST live in `<script context="module">` — vars in the per-instance
+  // `<script>` are scoped per component instance, not shared across
+  // mounts, so an in-instance cache would defeat the purpose.
+  export interface GhPrView {
+    number: number;
+    title: string;
+    state: string;
+    url: string;
+    headRefName: string;
+    isDraft: boolean;
+    ciStatus: string;
+  }
+  const prCache = new Map<string, GhPrView | null>();
+</script>
+
 <script lang="ts">
   /**
    * WorkspaceDiffPrSubtitle — compact diff + PR statusline for individual
@@ -98,16 +121,6 @@
       ].filter(Boolean)
     : [];
 
-  interface GhPrView {
-    number: number;
-    title: string;
-    state: string;
-    url: string;
-    headRefName: string;
-    isDraft: boolean;
-    ciStatus: string;
-  }
-
   function ciColor(status: string, fallback: string): string {
     if (status === "SUCCESS") return "#4ec957";
     if (status === "FAILURE") return "#e85454";
@@ -118,6 +131,11 @@
   let pr: GhPrView | null = null;
   let prTimer: ReturnType<typeof setInterval> | null = null;
   let lastRepoRoot: string | null = null;
+  // True once we have any answer for the current repoRoot — either a
+  // cache hit on mount, or the initial fetch resolved. Drives the
+  // skeleton-placeholder reservation so the popover height stays
+  // stable through the very first ever load too.
+  let prInitialResolved = false;
 
   const PR_REFRESH_MS = 5_000;
 
@@ -127,14 +145,27 @@
         repoPath: root,
       });
       pr = result ?? null;
+      prCache.set(root, pr);
     } catch {
-      pr = null;
+      // Transient failure: don't clobber the cache (so a network blip
+      // doesn't flush a known-good PR row), but mark resolved so we
+      // stop reserving placeholder space.
+      pr = prCache.get(root) ?? null;
+    } finally {
+      prInitialResolved = true;
     }
   }
 
   function startPrPolling(root: string): void {
     if (prTimer) clearInterval(prTimer);
     lastRepoRoot = root;
+    if (prCache.has(root)) {
+      pr = prCache.get(root) ?? null;
+      prInitialResolved = true;
+    } else {
+      pr = null;
+      prInitialResolved = false;
+    }
     void refreshPr(root);
     prTimer = setInterval(() => void refreshPr(root), PR_REFRESH_MS);
   }
@@ -152,6 +183,7 @@
   $: if (!repoRoot && lastRepoRoot) {
     stopPrPolling();
     pr = null;
+    prInitialResolved = false;
     lastRepoRoot = null;
   }
 
@@ -161,6 +193,11 @@
     isRootWorkspace &&
     pr !== null &&
     (pr.state === "OPEN" || pr.state === "open");
+  // True for root workspaces whose PR fetch hasn't returned yet.
+  // Drives a hidden-but-spaced placeholder so the popover paints at
+  // its final height from the start instead of jumping when the PR
+  // row appears.
+  $: prLoading = isRootWorkspace && !!repoRoot && !prInitialResolved;
   $: isDraft = pr?.isDraft ?? false;
   $: prColor = pr
     ? isDraft
@@ -169,7 +206,7 @@
     : fgMuted;
 </script>
 
-{#if showDiff || showPr || showRemote}
+{#if showDiff || showPr || showRemote || prLoading}
   <div
     style="display: flex; flex-direction: column; gap: 1px; padding: 0 12px 0 6px; overflow: hidden;"
   >
@@ -253,6 +290,7 @@
 
     {#if showPr && pr}
       <div
+        data-pr-row
         style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden;"
         title="#{pr.number} {pr.title}{isDraft ? ' (draft)' : ''}"
       >
@@ -282,6 +320,28 @@
         >
           #{pr.number}{isDraft ? " draft" : ""}
         </span>
+      </div>
+    {:else if prLoading}
+      <!-- Skeleton placeholder: same structure and dimensions as the
+           real PR row but invisible. Reserves vertical space so the
+           hover popover paints at its loaded height even on the very
+           first hover, before `gh_view_pr` resolves. -->
+      <div
+        data-pr-row-placeholder
+        aria-hidden="true"
+        style="display: flex; align-items: center; gap: 4px; min-width: 0; overflow: hidden; visibility: hidden;"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="transparent"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="18" r="3" />
+        </svg>
+        <span style="font-size: 10px;">#0</span>
       </div>
     {/if}
   </div>

--- a/src/lib/components/WorkspaceDiffPrSubtitle.svelte
+++ b/src/lib/components/WorkspaceDiffPrSubtitle.svelte
@@ -1,10 +1,19 @@
 <script context="module" lang="ts">
+  import { writable } from "svelte/store";
+
   // Module-level PR cache keyed by repoRoot. The collapsed-mode hover
-  // popover mounts a fresh subtitle on every hover, so without a cache
-  // each hover would re-fetch from `gh_view_pr` and re-paint from
-  // `pr = null` → loaded, causing the popover height to jump as the PR
-  // row appears. Seeding from the cache on mount paints the loaded
-  // state instantly on every hover after the first.
+  // popover reuses the same subtitle instance with a changing
+  // `workspaceId` prop, so without a cache each hover would re-fetch
+  // from `gh_view_pr` and re-paint from `pr = null` → loaded, making
+  // the popover height jump as the PR row appears.
+  //
+  // Backing the cache with a writable store (and reassigning the Map
+  // on every update) means subscribers re-derive their displayed PR
+  // whenever any row's data lands. Combined with deriving `pr` from
+  // `(repoRoot, $prCacheStore)` rather than imperatively setting it,
+  // this rules out the prior "floating PR" race where the displayed
+  // value briefly held the previous row's PR after the prop changed
+  // but before the new fetch resolved.
   //
   // MUST live in `<script context="module">` — vars in the per-instance
   // `<script>` are scoped per component instance, not shared across
@@ -18,7 +27,14 @@
     isDraft: boolean;
     ciStatus: string;
   }
-  const prCache = new Map<string, GhPrView | null>();
+  const prCacheStore = writable(new Map<string, GhPrView | null>());
+  function setPrCache(root: string, value: GhPrView | null): void {
+    prCacheStore.update((m) => {
+      const next = new Map(m);
+      next.set(root, value);
+      return next;
+    });
+  }
 </script>
 
 <script lang="ts">
@@ -128,44 +144,42 @@
     return fallback;
   }
 
-  let pr: GhPrView | null = null;
   let prTimer: ReturnType<typeof setInterval> | null = null;
   let lastRepoRoot: string | null = null;
-  // True once we have any answer for the current repoRoot — either a
-  // cache hit on mount, or the initial fetch resolved. Drives the
-  // skeleton-placeholder reservation so the popover height stays
-  // stable through the very first ever load too.
-  let prInitialResolved = false;
 
   const PR_REFRESH_MS = 5_000;
+
+  // Derive both `pr` and `prInitialResolved` directly from the
+  // current `repoRoot` and the cache store. Imperative assignment
+  // would let `pr` lag behind a `repoRoot` change long enough to
+  // briefly paint the previous row's PR — exactly the "floating PR"
+  // bug. Derived state ties the displayed PR to the row identity by
+  // construction.
+  $: pr = repoRoot ? ($prCacheStore.get(repoRoot) ?? null) : null;
+  $: prInitialResolved = repoRoot ? $prCacheStore.has(repoRoot) : true;
 
   async function refreshPr(root: string): Promise<void> {
     try {
       const result = await invoke<GhPrView | null>("gh_view_pr", {
         repoPath: root,
       });
-      pr = result ?? null;
-      prCache.set(root, pr);
+      setPrCache(root, result ?? null);
     } catch {
-      // Transient failure: don't clobber the cache (so a network blip
-      // doesn't flush a known-good PR row), but mark resolved so we
-      // stop reserving placeholder space.
-      pr = prCache.get(root) ?? null;
-    } finally {
-      prInitialResolved = true;
+      // Transient failure: don't clobber a known-good cache entry,
+      // but seed `null` if we have no prior answer so the placeholder
+      // reservation can clear.
+      prCacheStore.update((m) => {
+        if (m.has(root)) return m;
+        const next = new Map(m);
+        next.set(root, null);
+        return next;
+      });
     }
   }
 
   function startPrPolling(root: string): void {
     if (prTimer) clearInterval(prTimer);
     lastRepoRoot = root;
-    if (prCache.has(root)) {
-      pr = prCache.get(root) ?? null;
-      prInitialResolved = true;
-    } else {
-      pr = null;
-      prInitialResolved = false;
-    }
     void refreshPr(root);
     prTimer = setInterval(() => void refreshPr(root), PR_REFRESH_MS);
   }
@@ -182,8 +196,6 @@
   }
   $: if (!repoRoot && lastRepoRoot) {
     stopPrPolling();
-    pr = null;
-    prInitialResolved = false;
     lastRepoRoot = null;
   }
 

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -119,21 +119,23 @@
   $: processStatusStore = getWorkspaceStatusByCategory(workspace.id, "process");
   $: processItems = $processStatusStore;
   $: agentBadges = aggregateAgentBadges(processItems);
-  // OSC-detectable agents (Claude/Codex/Aider) re-title their PTY to the
-  // active task — "Strategic opportunity assessment for Vellum". When a
-  // single tracked agent surface dominates, surface its current title in
-  // the banner so the user can see what the agent is working on without
-  // switching to that tab.
-  $: agentTaskTitle = (() => {
-    if (processItems.length !== 1) return null;
-    const item = processItems[0];
-    const sid = item?.metadata?.surfaceId;
-    if (typeof sid !== "string") return null;
-    const surface = allSurfaces.find((s) => s.id === sid);
-    const title = surface && "title" in surface ? surface.title : null;
-    return typeof title === "string" && title.length > 0 ? title : null;
+  // Per-row bot status for the rail hat. Precedence (highest first):
+  //   attention (waiting) → thinking (running) → idle (any other
+  //   tracked process item like muted/done) → none.
+  // A waiting agent always wins so the pulse can't be hidden by a
+  // co-resident running or idle agent. Mirrors rootRailBotStatus.
+  $: rowBotStatus = (() => {
+    let sawThinking = false;
+    let sawIdle = false;
+    for (const item of processItems) {
+      if (item.variant === "warning") return "attention" as const;
+      if (item.variant === "success") sawThinking = true;
+      else sawIdle = true;
+    }
+    if (sawThinking) return "thinking" as const;
+    if (sawIdle) return "idle" as const;
+    return "none" as const;
   })();
-
   $: subtitleComponents = $workspaceSubtitleStore;
 
   export async function startRename(): Promise<void> {
@@ -168,6 +170,7 @@
   shortcutLabel={shortcutIdx !== undefined && shortcutIdx < 9
     ? `${modLabel}${shortcutIdx + 1}`
     : undefined}
+  botStatus={hideStatusBadges ? "none" : rowBotStatus}
   {onGripMouseDown}
   onRailClick={onSelect}
   {onClose}
@@ -297,20 +300,6 @@
             padding: 2px 4px; margin-left: -4px; border-radius: 4px;
           "
         />
-        {#if !hideStatusBadges && agentBadges.length > 0 && agentBadges[0]}
-          {@const badge = agentBadges[0]}
-          {@const isWaiting = badge.variant === "warning"}
-          <span
-            data-harness-title-row
-            title={agentTaskTitle
-              ? `${badge.label} — ${agentTaskTitle}`
-              : badge.label}
-            class:pulse={isWaiting}
-            style="display: inline-flex; align-items: center; flex-shrink: 0; color: {badge.color};"
-          >
-            <BotIcon size={13} />
-          </span>
-        {/if}
       </div>
 
       {#if !hideStatusBadges && hasUnread && agentBadges.length === 0}
@@ -382,20 +371,3 @@
     {/if}
   </div>
 </SidebarElement>
-
-<style>
-  .pulse {
-    animation: pulse 1.4s ease-in-out infinite;
-  }
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 0.5;
-      transform: scale(1.25);
-    }
-  }
-</style>

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -58,7 +58,7 @@
   } from "../stores/ui";
   import { contrastColor } from "../utils/contrast";
   import { agentsStore } from "../services/agent-detection-service";
-  import { rootNeedsRailAttention } from "../services/rail-attention";
+  import { rootRailBotStatus } from "../services/rail-attention";
   import { variantColor } from "../status-colors";
   import { shortcutHintsActive } from "../stores/shortcut-hints";
   import { modLabel } from "../terminal-service";
@@ -165,14 +165,14 @@
     return null;
   })();
 
-  // Rail attention — collapsed-mode signal for the rail. Scope is
+  // Rail bot status — collapsed-mode signal for the rail. Scope is
   // intentionally Root + all branches (worktree AND dashboard branches,
-  // both live in branchedWorkspaceIds). This is the only attention
+  // both live in branchedWorkspaceIds). This is the only bot-status
   // surface in collapsed mode; banner-level workspaceBotStatus above
   // stays root-only by design.
-  $: railNeedsAttention = workspace
-    ? rootNeedsRailAttention(workspace, $agentsStore)
-    : false;
+  $: railBotStatus = workspace
+    ? rootRailBotStatus(workspace, $agentsStore)
+    : ("none" as const);
 
   // True when the primary workspace of this workspace is currently active.
   // Makes the banner border solid only when the primary workspace
@@ -465,7 +465,7 @@
       hasActiveChild={hasActiveDescendant}
       {isPrimaryActive}
       {popoverActive}
-      needsAttention={railNeedsAttention}
+      botStatus={railBotStatus}
       scopeId={workspace.id}
       {containerBlockId}
       containerLabel={workspace.name}

--- a/src/lib/components/WorkspaceSectionContent.svelte
+++ b/src/lib/components/WorkspaceSectionContent.svelte
@@ -476,7 +476,13 @@
       <div
         style="display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0;"
       >
-        {#if workspaceBotStatus}
+        {#if workspaceBotStatus && workspace.spawnedBy != null}
+          <!-- BotIcon next to the title is reserved for orchestrator-
+               spawned workspaces — for those, the icon doubles as
+               provenance ("this row was created by an agent"). For
+               every other workspace the rail "hat" carries bot
+               status, so painting the icon here too would be
+               redundant. -->
           <span
             aria-label={workspaceBotStatus.label}
             title={workspaceBotStatus.label}

--- a/src/lib/services/menu-paste-router.ts
+++ b/src/lib/services/menu-paste-router.ts
@@ -1,0 +1,86 @@
+/**
+ * Menu paste router — handles the `menu-paste` event emitted from the
+ * native Edit > Paste menu item (Cmd+V on macOS / Ctrl+V on Linux).
+ *
+ * Why a custom router: the menu accelerator preempts webview keydown,
+ * so the in-terminal Cmd+V handler in terminal-service.ts is dead
+ * code in production. Worse, the default `PredefinedMenuItem::paste`
+ * dispatches the native NSText `paste:` action, which delivers via
+ * input events and bypasses xterm.js's bracketed-paste wrapping.
+ * Claude Code (and other TUIs) rely on `\x1b[200~…\x1b[201~` to
+ * recognize a paste — without it they process the buffer character-
+ * by-character, submitting on the first newline.
+ *
+ * The router routes by focus:
+ *   - terminal surface  → `surface.terminal.paste(text)` (bracketed)
+ *   - input/textarea    → splice at selection, fire `input` event
+ *   - contenteditable   → `document.execCommand("insertText")`
+ *   - nothing focused   → no-op
+ */
+import { readText as clipboardRead } from "@tauri-apps/plugin-clipboard-manager";
+import { get } from "svelte/store";
+import { workspaces } from "../stores/workspace";
+import {
+  getAllSurfaces,
+  isTerminalSurface,
+  type TerminalSurface,
+} from "../types";
+
+function findTerminalForElement(el: Element): TerminalSurface | null {
+  for (const ws of get(workspaces)) {
+    for (const surface of getAllSurfaces(ws)) {
+      if (isTerminalSurface(surface) && surface.termElement.contains(el)) {
+        return surface;
+      }
+    }
+  }
+  return null;
+}
+
+function pasteIntoInput(
+  el: HTMLInputElement | HTMLTextAreaElement,
+  text: string,
+): void {
+  const start = el.selectionStart ?? el.value.length;
+  const end = el.selectionEnd ?? el.value.length;
+  const next = el.value.slice(0, start) + text + el.value.slice(end);
+  el.value = next;
+  const cursor = start + text.length;
+  el.setSelectionRange(cursor, cursor);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+export async function handleMenuPaste(): Promise<void> {
+  let text: string;
+  try {
+    text = await clipboardRead();
+  } catch (err) {
+    console.warn("Menu paste: clipboard read failed:", err);
+    return;
+  }
+  if (!text) return;
+
+  const active = document.activeElement;
+  if (!active) return;
+
+  const terminal = findTerminalForElement(active);
+  if (terminal && terminal.ptyId >= 0) {
+    terminal.terminal.paste(text);
+    return;
+  }
+
+  if (
+    active instanceof HTMLInputElement ||
+    active instanceof HTMLTextAreaElement
+  ) {
+    pasteIntoInput(active, text);
+    return;
+  }
+
+  if (
+    active instanceof HTMLElement &&
+    (active.isContentEditable || active.contentEditable === "true")
+  ) {
+    document.execCommand("insertText", false, text);
+  }
+}

--- a/src/lib/services/rail-attention.ts
+++ b/src/lib/services/rail-attention.ts
@@ -1,24 +1,33 @@
 /**
  * Rail bot status — pure aggregator that decides whether a Root
- * workspace's collapsed-mode rail should paint a status hat and which
- * variant. Mirrors the buildAgentRows pattern (pure, store-free,
- * vitest-testable). Scope is intentionally Root + all branches, in
- * contrast to WorkspaceSectionContent's banner-level workspaceBotStatus,
- * which is root-only.
+ * workspace's rail should paint a status hat and which variant. The
+ * hat renders at every sidebar width (collapsed and expanded) since
+ * it's the canonical bot-notification surface. Mirrors the
+ * buildAgentRows pattern (pure, store-free, vitest-testable). Scope
+ * is intentionally Root + all branches, in contrast to
+ * WorkspaceSectionContent's banner-level workspaceBotStatus, which
+ * is root-only.
  *
  *   - "attention": at least one agent in the tree is waiting → yellow
- *                  pulsing hat (highest priority — supersedes thinking).
+ *                  pulsing hat (highest priority).
  *   - "thinking":  no waiting agents, but at least one is actively
  *                  working (running or active) → green static hat.
- *   - "none":      no agents in the tree, or all are idle/done/closed
- *                  → no hat painted.
+ *   - "idle":      no thinking/attention, but at least one detected
+ *                  agent is present (idle or done) → muted-grey
+ *                  static hat. Surfaces "agent attached, currently
+ *                  thinking" so presence is never invisible.
+ *   - "none":      no agents in the tree → no hat painted.
  */
 import type { DetectedAgent } from "./agent-detection-service";
 import type { RootWorkspace } from "../config";
 
-export type RailBotStatus = "none" | "thinking" | "attention";
+export type RailBotStatus = "none" | "thinking" | "attention" | "idle";
 
 const THINKING_STATUSES = new Set(["running", "active"]);
+const IDLE_STATUSES = new Set(["idle", "done"]);
+// "closed" means the agent process is gone — don't paint a hat for
+// a tombstone. Anything else lacking explicit handling falls
+// through to "none" too.
 
 export function rootRailBotStatus(
   root: RootWorkspace,
@@ -26,10 +35,14 @@ export function rootRailBotStatus(
 ): RailBotStatus {
   const ids = new Set([root.id, ...root.branchedWorkspaceIds]);
   let sawThinking = false;
+  let sawIdle = false;
   for (const agent of agents) {
     if (!ids.has(agent.workspaceId)) continue;
     if (agent.status === "waiting") return "attention";
     if (THINKING_STATUSES.has(agent.status)) sawThinking = true;
+    else if (IDLE_STATUSES.has(agent.status)) sawIdle = true;
   }
-  return sawThinking ? "thinking" : "none";
+  if (sawThinking) return "thinking";
+  if (sawIdle) return "idle";
+  return "none";
 }

--- a/src/lib/services/rail-attention.ts
+++ b/src/lib/services/rail-attention.ts
@@ -1,18 +1,35 @@
 /**
- * Rail attention — pure aggregator that decides whether a Root
- * workspace's collapsed-mode rail should paint the "needs attention"
- * hat. Mirrors the buildAgentRows pattern (pure, store-free, vitest-
- * testable). Scope is intentionally Root + all branches, in contrast
- * to WorkspaceSectionContent's banner-level workspaceBotStatus, which
- * is root-only.
+ * Rail bot status — pure aggregator that decides whether a Root
+ * workspace's collapsed-mode rail should paint a status hat and which
+ * variant. Mirrors the buildAgentRows pattern (pure, store-free,
+ * vitest-testable). Scope is intentionally Root + all branches, in
+ * contrast to WorkspaceSectionContent's banner-level workspaceBotStatus,
+ * which is root-only.
+ *
+ *   - "attention": at least one agent in the tree is waiting → yellow
+ *                  pulsing hat (highest priority — supersedes thinking).
+ *   - "thinking":  no waiting agents, but at least one is actively
+ *                  working (running or active) → green static hat.
+ *   - "none":      no agents in the tree, or all are idle/done/closed
+ *                  → no hat painted.
  */
 import type { DetectedAgent } from "./agent-detection-service";
 import type { RootWorkspace } from "../config";
 
-export function rootNeedsRailAttention(
+export type RailBotStatus = "none" | "thinking" | "attention";
+
+const THINKING_STATUSES = new Set(["running", "active"]);
+
+export function rootRailBotStatus(
   root: RootWorkspace,
   agents: DetectedAgent[],
-): boolean {
+): RailBotStatus {
   const ids = new Set([root.id, ...root.branchedWorkspaceIds]);
-  return agents.some((a) => ids.has(a.workspaceId) && a.status === "waiting");
+  let sawThinking = false;
+  for (const agent of agents) {
+    if (!ids.has(agent.workspaceId)) continue;
+    if (agent.status === "waiting") return "attention";
+    if (THINKING_STATUSES.has(agent.status)) sawThinking = true;
+  }
+  return sawThinking ? "thinking" : "none";
 }


### PR DESCRIPTION
## Summary

- **Cmd+V on macOS / Ctrl+V on Linux** now preserves xterm.js bracketed-paste wrapping. The native `PredefinedMenuItem::paste` action dispatched `NSText paste:`, which delivered text via input events and bypassed the `\x1b[200~…\x1b[201~` envelope — Claude Code and other TUIs processed pastes character-by-character and submitted on the first newline. Replaced with a custom `MenuItem` that emits `menu-paste`, routed through a new `menu-paste-router` that calls `terminal.paste()` inside terminal surfaces and splices into HTML inputs / contenteditables elsewhere.
- **Universal bot-status rail hat** with four states. `rootRailBotStatus` aggregates across Root + all branches and returns `"none" | "idle" | "thinking" | "attention"`. The hat now paints at every sidebar width (collapsed and expanded), is plumbed through `SidebarElement → SidebarRail → DragGrip` so each Branch row shows its own status, and tracks the rail width (4px collapsed, 8px expanded). Yellow pulse for waiting, green static for running/active, muted-grey static for idle/done presence, nothing for no-agent. Tombstoned (`closed`) agents are filtered.
- **WorkspaceItem** drops the per-row `BotIcon` status block — the rail hat is the canonical bot-status surface there. The banner-title `BotIcon` is gated to orchestrator-spawned workspaces only, where it doubles as a provenance marker.
- **WorkspaceDiffPrSubtitle popover** caches PR data at module scope and reserves row height to stop the visible size jump on hover. The cache is now backed by a writable Svelte store so `pr` derives from `(repoRoot, $prCacheStore)` reactively — fixes the "floating PR" bug where the previous row's PR briefly painted on the next collapsed-rail hover before the new fetch resolved.
- **macOS TCC usage descriptions** added via a new `src-tauri/Info.plist` (and mirrored in `Info.dev.plist`). Covers Documents, Downloads, Desktop, AppleMusic (~/Music), PhotoLibrary (~/Pictures), Removable and Network volumes. The first prompt per protected directory is macOS-mandated and unavoidable, but without app-supplied strings the prompts are generic and grants may not persist cleanly across launches — which manifests as repeated prompts when in-pane agents (claude) explore the filesystem.

## Test plan

- [ ] Rebuild the app (`npm run tauri dev` or `npm run build`) — the menu accelerator and Info.plist changes are in the Rust binary / bundle and won't pick up via HMR.
- [ ] In a terminal pane running `claude`, copy a multi-line snippet to the clipboard and press Cmd+V (macOS) — the prompt should receive the entire snippet as a single bracketed paste, not submit on the first newline.
- [ ] On Linux, repeat with Ctrl+V (or whatever your distro maps Edit > Paste to) — same bracketed-paste behavior.
- [ ] In a normal shell pane (no TUI), Cmd+V should paste clipboard text inline.
- [ ] Cmd+V into a non-terminal HTML input (e.g. command palette, rename dialog) inserts at the cursor / replaces selection.
- [ ] Collapse the sidebar. Open a Root workspace whose tree contains a Claude Code agent currently thinking — the Root rail hat shows green static.
- [ ] When the agent transitions to waiting, the hat turns pulsing yellow.
- [ ] When every agent in the tree is idle/done, the hat goes muted-grey.
- [ ] When all agents close, the hat disappears.
- [ ] Expand the sidebar — every Branch row paints its own rail hat at 8px width with the same color/pulse semantics. Root banner aggregates.
- [ ] Branch with a `BotIcon` next to the title appears only for orchestrator-spawned workspaces; non-orchestrator workspaces show no inline icon.
- [ ] Hover a Branch row whose PR has a `WorkspaceDiffPrSubtitle` — the row does not change height, and the popover loads without flicker on subsequent hovers (cached).
- [ ] Collapse the sidebar with two Root workspaces whose repos have *different* open PRs. Hover quickly between them — the popover for each row must only ever show its own PR number, never briefly the other row's.
- [ ] macOS: reset existing TCC grants for GnarTerm (`tccutil reset SystemPolicyDocumentsFolder com.thegnar.gnar-term` etc., or System Settings → Privacy & Security → Files & Folders → toggle off). Launch a fresh build, point Claude at a path under ~/Documents — the prompt should now show the GnarTerm-supplied reason text ("…and the coding agents running inside it read files in your Documents folder…"). Grant once. Re-launch the app and re-run the same exploration — no second prompt for that dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)