### PR TITLE
fix(git): refresh sidebar isGit when repo state changes mid-session

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,6 +14,7 @@
   import {
     workspaces,
     activeWorkspaceIdx,
+    activeWorkspace,
     activePane,
     activeSurface,
     activePseudoWorkspaceId,
@@ -71,7 +72,10 @@
   import { initPreview } from "./lib/bootstrap/init-preview";
   import { initAgentDetectionBootstrap } from "./lib/bootstrap/init-agent-detection";
   import { initCoreExtensionAPI } from "./lib/bootstrap/init-core-extension-api";
-  import { initWorkspaces } from "./lib/bootstrap/init-workspaces";
+  import {
+    initWorkspaces,
+    recheckWorkspaceIsGit,
+  } from "./lib/bootstrap/init-workspaces";
   import {
     restoreWorkspaces,
     markRestored,
@@ -582,12 +586,14 @@
   let _cleanupVisibilityRecover: (() => void) | null = null;
   let _cleanupDragDropRouter: (() => void) | null = null;
   let _rootPathSweepInterval: number | null = null;
+  let _gitRecheckInterval: ReturnType<typeof setInterval> | null = null;
   onDestroy(() => {
     _cleanupShortcutHints?.();
     _cleanupVisibilityRecover?.();
     _cleanupDragDropRouter?.();
     if (_rootPathSweepInterval !== null)
       window.clearInterval(_rootPathSweepInterval);
+    if (_gitRecheckInterval !== null) clearInterval(_gitRecheckInterval);
   });
 
   onMount(async () => {
@@ -827,6 +833,15 @@
       // Re-sweep workspace root paths on focus — picks up directories
       // that were renamed in Finder/`mv` while gnar-term was unfocused.
       void validateWorkspaceRootPaths();
+      // The user may have run `git init` / `git clone` (or removed a
+      // `.git`) in a terminal while the window was blurred. Re-check
+      // every root workspace so the sidebar banner reflects reality
+      // when focus returns.
+      for (const ws of get(workspaces)) {
+        if (ws.rootWorkspaceId === undefined && !ws.isDashboard) {
+          void recheckWorkspaceIsGit(ws.id);
+        }
+      }
     });
 
     // Periodic sweep — catches renames that happen while gnar-term is
@@ -835,6 +850,19 @@
     _rootPathSweepInterval = window.setInterval(() => {
       void validateWorkspaceRootPaths();
     }, 60_000);
+
+    // Polling backstop: focus / activation events miss the common
+    // case of running `git init` in the active workspace's terminal
+    // without leaving the window. A 5s `is_git_repo` stat against
+    // the active root keeps the sidebar in sync without watching
+    // the filesystem. updateWorkspace is only called on diff, so
+    // steady-state polling is a no-op.
+    _gitRecheckInterval = setInterval(() => {
+      const ws = get(activeWorkspace);
+      if (!ws) return;
+      const rootId = ws.rootWorkspaceId ?? ws.id;
+      void recheckWorkspaceIsGit(rootId);
+    }, 5000);
 
     // Flush workspace and extension state to disk before the window closes.
     // Tauri v2: the window closes synchronously unless we preventDefault the

--- a/src/__tests__/recheck-workspace-is-git.test.ts
+++ b/src/__tests__/recheck-workspace-is-git.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for `recheckWorkspaceIsGit` and the
+ * `workspace:activated` handler in init-workspaces.
+ *
+ * Bug: when a user ran `git init` inside an existing workspace, the
+ * sidebar banner didn't pick up the new git state. The root cause was
+ * (a) `onWorkspaceActivated` returned early when the activated
+ * workspace itself was the root (no `rootWorkspaceId`), and (b) no
+ * trigger re-ran `is_git_repo` after creation. The fix exposes
+ * `recheckWorkspaceIsGit` and wires it to activation, window focus,
+ * and a 5s poll on the active workspace.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { get } from "svelte/store";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { recheckWorkspaceIsGit } from "../lib/bootstrap/init-workspaces";
+import {
+  workspaces,
+  resetWorkspacesForTest,
+  setWorkspaces,
+} from "../lib/stores/workspace";
+import type { RootWorkspace } from "../lib/stores/workspace";
+
+function makeRoot(overrides: Partial<RootWorkspace> = {}): RootWorkspace {
+  return {
+    id: "root-1",
+    name: "Root",
+    path: "/repos/root",
+    color: "blue",
+    branchedWorkspaceIds: [],
+    isGit: false,
+    createdAt: "2026-01-01",
+    paneLayout: {
+      type: "pane",
+      pane: { id: "p1", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: "p1",
+    ...overrides,
+  } as RootWorkspace;
+}
+
+describe("recheckWorkspaceIsGit", () => {
+  beforeEach(() => {
+    resetWorkspacesForTest();
+    invokeMock.mockReset();
+  });
+
+  it("updates isGit when is_git_repo flips false → true", async () => {
+    const ws = makeRoot({ isGit: false });
+    setWorkspaces([ws]);
+    invokeMock.mockResolvedValueOnce(true);
+
+    await recheckWorkspaceIsGit(ws.id);
+
+    expect(invokeMock).toHaveBeenCalledWith("is_git_repo", {
+      path: "/repos/root",
+    });
+    const updated = get(workspaces).find((w) => w.id === ws.id);
+    expect(updated?.isGit).toBe(true);
+  });
+
+  it("updates isGit when is_git_repo flips true → false (`.git` removed)", async () => {
+    const ws = makeRoot({ isGit: true });
+    setWorkspaces([ws]);
+    invokeMock.mockResolvedValueOnce(false);
+
+    await recheckWorkspaceIsGit(ws.id);
+
+    const updated = get(workspaces).find((w) => w.id === ws.id);
+    expect(updated?.isGit).toBe(false);
+  });
+
+  it("is a no-op when the workspace's isGit already matches", async () => {
+    const ws = makeRoot({ isGit: true });
+    setWorkspaces([ws]);
+    invokeMock.mockResolvedValueOnce(true);
+
+    const before = get(workspaces).find((w) => w.id === ws.id);
+    await recheckWorkspaceIsGit(ws.id);
+    const after = get(workspaces).find((w) => w.id === ws.id);
+
+    // No mutation → identity preserved (updateWorkspace returns a new
+    // array reference, so we check field equality instead).
+    expect(after?.isGit).toBe(before?.isGit);
+  });
+
+  it("silently no-ops when the workspace id does not exist", async () => {
+    await recheckWorkspaceIsGit("missing");
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("silently swallows an invoke rejection (e.g. path gone)", async () => {
+    const ws = makeRoot({ isGit: true });
+    setWorkspaces([ws]);
+    invokeMock.mockRejectedValueOnce(new Error("ENOENT"));
+
+    await expect(recheckWorkspaceIsGit(ws.id)).resolves.toBeUndefined();
+
+    const updated = get(workspaces).find((w) => w.id === ws.id);
+    expect(updated?.isGit).toBe(true);
+  });
+});

--- a/src/lib/bootstrap/init-workspaces.ts
+++ b/src/lib/bootstrap/init-workspaces.ts
@@ -95,21 +95,40 @@ function onWorkspaceClosed(event: AppEvent): void {
   removeBranchFromAllWorkspaces(event.id);
 }
 
+/**
+ * Re-run `is_git_repo` for a root workspace and patch `isGit` if the
+ * filesystem has diverged from the stored value. Called whenever
+ * something signals the user may have changed the repo state at that
+ * path — workspace activation, window refocus, etc.
+ *
+ * Silently no-ops if the workspace is missing or the invoke fails
+ * (e.g. path no longer exists).
+ */
+export async function recheckWorkspaceIsGit(
+  rootWorkspaceId: string,
+): Promise<void> {
+  const workspace = getWorkspaces().find((w) => w.id === rootWorkspaceId);
+  if (!workspace) return;
+  try {
+    const isGit = await invoke<boolean>("is_git_repo", {
+      path: workspace.path,
+    });
+    if (isGit !== workspace.isGit) {
+      updateWorkspace(rootWorkspaceId, { isGit });
+    }
+  } catch {
+    // Path doesn't exist or invoke unavailable — leave isGit alone.
+  }
+}
+
 function onWorkspaceActivated(event: AppEvent): void {
   if (event.type !== "workspace:activated") return;
   const ws = get(workspaces).find((w) => w.id === event.id);
   if (!ws) return;
-  const rootWorkspaceId = ws.rootWorkspaceId;
-  if (typeof rootWorkspaceId !== "string") return;
-  const workspace = getWorkspaces().find((w) => w.id === rootWorkspaceId);
-  if (!workspace) return;
-  void invoke<boolean>("is_git_repo", { path: workspace.path })
-    .then((isGit) => {
-      if (isGit !== workspace.isGit) {
-        updateWorkspace(rootWorkspaceId, { isGit });
-      }
-    })
-    .catch(() => {});
+  // A root workspace has no `rootWorkspaceId` — its own id is the root.
+  // A branch carries its root's id. Either way, refresh that root.
+  const rootWorkspaceId = ws.rootWorkspaceId ?? ws.id;
+  void recheckWorkspaceIsGit(rootWorkspaceId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `isGit` was only checked at workspace creation, so running `git init` / `git clone` (or deleting `.git`) inside an existing workspace left the sidebar banner showing stale state.
- The `workspace:activated` handler also returned early when the activated workspace was itself a root (no `rootWorkspaceId`), so even re-activating a root never re-checked.

Fix:
1. Extract `recheckWorkspaceIsGit(rootWorkspaceId)` and call it on every activation; treat the activated workspace's own id as the root when `rootWorkspaceId` is absent.
2. On window refocus, re-check every root workspace.
3. Poll the active root every 5s as a backstop for the "ran `git init` and stayed in the same workspace" case. Diff-gated, so steady-state is a free `fs.stat`.

## Test plan

- [ ] Open a non-git workspace; `git init` in its terminal; banner shows the git branch chip within ~5s.
- [ ] In a git workspace, `rm -rf .git`; banner drops the git chip within ~5s.
- [ ] Switch to another app and back after `git init`; banner refreshes immediately on focus return.
- [ ] Activating an already-active root workspace (clicking its banner) triggers a re-check (verify in devtools logs).
- [ ] Other workspaces' banners are unaffected (no thrashing of inactive workspaces' state).
- [ ] `npm test` — all 1774 tests pass (includes new `recheck-workspace-is-git.test.ts`).
- [ ] `npm run build` — full Tauri build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)