### PR TITLE
feat(workspace): detect CWD renames via inode and update path automatically

### DIFF
--- a/src-tauri/src/fs_commands.rs
+++ b/src-tauri/src/fs_commands.rs
@@ -73,6 +73,58 @@ pub(crate) async fn file_exists(path: String) -> bool {
     }
 }
 
+/// Return the inode number for `path`. Used by the workspace-rename detector
+/// to fingerprint a CWD so a later sweep can rediscover it after rename.
+/// Returns `Err` on unsupported platforms (Windows) or unreadable paths.
+#[tauri::command]
+pub(crate) async fn get_path_inode(path: String) -> Result<u64, String> {
+    if is_blocked_path(&path) {
+        return Err(format!("Access denied: {path}"));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(&path).map_err(|e| format!("Failed to stat {path}: {e}"))?;
+        Ok(meta.ino())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Err("Inode not supported on this platform".to_string())
+    }
+}
+
+/// Scan `parent` for a directory whose inode matches `inode`. Used to
+/// rediscover a workspace CWD that was renamed within its parent directory.
+/// Returns `Ok(None)` if no entry matches; `Err` if `parent` cannot be read.
+#[tauri::command]
+pub(crate) async fn find_dir_by_inode(
+    parent: String,
+    inode: u64,
+) -> Result<Option<String>, String> {
+    if is_blocked_path(&parent) {
+        return Err(format!("Access denied: {parent}"));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let entries =
+            std::fs::read_dir(&parent).map_err(|e| format!("Failed to read dir {parent}: {e}"))?;
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() && meta.ino() == inode {
+                return Ok(Some(entry.path().to_string_lossy().to_string()));
+            }
+        }
+        Ok(None)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (parent, inode);
+        Err("Inode not supported on this platform".to_string())
+    }
+}
+
 /// List filenames in a directory (non-recursive, files only)
 #[tauri::command]
 pub(crate) async fn list_dir(path: String) -> Result<Vec<String>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,10 +20,10 @@ mod pty;
 
 use file_watch::{unwatch_claude_file, unwatch_file, watch_claude_file, watch_file};
 use fs_commands::{
-    detect_font, ensure_dir, file_exists, find_file, get_global_config_dir, get_home,
-    is_debug_build, list_claude_dir, list_dir, mcp_file_info, mcp_list_dir, open_url,
-    open_with_default_app, read_claude_file, read_file, read_file_base64, show_in_file_manager,
-    write_claude_file, write_file,
+    detect_font, ensure_dir, file_exists, find_dir_by_inode, find_file, get_global_config_dir,
+    get_home, get_path_inode, is_debug_build, list_claude_dir, list_dir, mcp_file_info,
+    mcp_list_dir, open_url, open_with_default_app, read_claude_file, read_file, read_file_base64,
+    show_in_file_manager, write_claude_file, write_file,
 };
 use pty::{
     get_all_pty_cwds, get_pty_cwd, get_pty_pid, get_pty_title, kill_pty, pause_pty, resize_pty,
@@ -253,6 +253,8 @@ pub fn run() {
             get_pty_pid,
             get_pty_title,
             file_exists,
+            get_path_inode,
+            find_dir_by_inode,
             list_dir,
             read_file,
             read_file_base64,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -580,10 +580,13 @@
   let _cleanupShortcutHints: (() => void) | null = null;
   let _cleanupVisibilityRecover: (() => void) | null = null;
   let _cleanupDragDropRouter: (() => void) | null = null;
+  let _rootPathSweepInterval: number | null = null;
   onDestroy(() => {
     _cleanupShortcutHints?.();
     _cleanupVisibilityRecover?.();
     _cleanupDragDropRouter?.();
+    if (_rootPathSweepInterval !== null)
+      window.clearInterval(_rootPathSweepInterval);
   });
 
   onMount(async () => {
@@ -816,7 +819,17 @@
           }
         }
       }
+      // Re-sweep workspace root paths on focus — picks up directories
+      // that were renamed in Finder/`mv` while gnar-term was unfocused.
+      void validateWorkspaceRootPaths();
     });
+
+    // Periodic sweep — catches renames that happen while gnar-term is
+    // focused but idle. 60s is a pragmatic floor; the sweep is cheap
+    // (one `stat` per workspace). Cleared in the top-level onDestroy.
+    _rootPathSweepInterval = window.setInterval(() => {
+      void validateWorkspaceRootPaths();
+    }, 60_000);
 
     // Flush workspace and extension state to disk before the window closes.
     // Tauri v2: the window closes synchronously unless we preventDefault the

--- a/src/__tests__/validate-workspace-root-paths.test.ts
+++ b/src/__tests__/validate-workspace-root-paths.test.ts
@@ -32,6 +32,47 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   };
 }
 
+/**
+ * Set up a `vi.mocked(invoke)` implementation that routes by command name.
+ * Each command can return a fixed value or throw. Useful because the sweep
+ * dispatches to `file_exists`, `get_path_inode`, and `find_dir_by_inode`.
+ */
+function mockInvokes(handlers: {
+  file_exists?: boolean | ((path: string) => boolean | Promise<boolean>);
+  get_path_inode?: number | Error | ((path: string) => number);
+  find_dir_by_inode?:
+    | string
+    | null
+    | Error
+    | ((parent: string, inode: number) => string | null);
+}): void {
+  vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
+    const a = (args ?? {}) as {
+      path?: string;
+      parent?: string;
+      inode?: number;
+    };
+    if (cmd === "file_exists") {
+      const h = handlers.file_exists;
+      if (typeof h === "function") return await h(a.path ?? "");
+      return h ?? true;
+    }
+    if (cmd === "get_path_inode") {
+      const h = handlers.get_path_inode;
+      if (h instanceof Error) throw h;
+      if (typeof h === "function") return h(a.path ?? "");
+      return h ?? 1;
+    }
+    if (cmd === "find_dir_by_inode") {
+      const h = handlers.find_dir_by_inode;
+      if (h instanceof Error) throw h;
+      if (typeof h === "function") return h(a.parent ?? "", a.inode ?? 0);
+      return h ?? null;
+    }
+    return undefined;
+  });
+}
+
 describe("validateWorkspaceRootPaths", () => {
   beforeEach(() => {
     workspaces.set([]);
@@ -39,45 +80,116 @@ describe("validateWorkspaceRootPaths", () => {
     vi.mocked(invoke).mockReset();
   });
 
-  it("stamps pathMissing=true when the workspace path does not exist", async () => {
+  it("stamps pathMissing=true when the workspace path does not exist and no inode is cached", async () => {
     setWorkspaces([makeWorkspace({ id: "g1", path: "/tmp/gone" })]);
-    vi.mocked(invoke).mockResolvedValue(false);
+    mockInvokes({ file_exists: false });
 
     await validateWorkspaceRootPaths();
 
     expect(getWorkspaces()[0]?.pathMissing).toBe(true);
+    expect(getWorkspaces()[0]?.path).toBe("/tmp/gone");
   });
 
-  it("clears pathMissing when the path exists again on a later sweep", async () => {
+  it("clears pathMissing and caches the inode when the path exists", async () => {
     setWorkspaces([
       makeWorkspace({ id: "g1", path: "/tmp/back", pathMissing: true }),
     ]);
-    vi.mocked(invoke).mockResolvedValue(true);
+    mockInvokes({ file_exists: true, get_path_inode: 42 });
 
     await validateWorkspaceRootPaths();
 
     expect(getWorkspaces()[0]?.pathMissing).toBe(false);
+    expect(getWorkspaces()[0]?.pathInode).toBe(42);
   });
 
-  it("treats a failing invoke as 'not missing' (best-effort)", async () => {
+  it("treats a failing file_exists invoke as 'not missing' (best-effort)", async () => {
     setWorkspaces([makeWorkspace({ id: "g1", path: "/tmp/transient" })]);
-    vi.mocked(invoke).mockRejectedValue(new Error("boom"));
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "file_exists") throw new Error("boom");
+      if (cmd === "get_path_inode") throw new Error("boom");
+      return undefined;
+    });
 
     await validateWorkspaceRootPaths();
 
     expect(getWorkspaces()[0]?.pathMissing ?? false).toBe(false);
   });
 
-  it("is a no-op when the flag already matches the FS state", async () => {
+  it("is a no-op when the flag and inode already match the FS state", async () => {
     setWorkspaces([
-      makeWorkspace({ id: "g1", path: "/tmp/here", pathMissing: false }),
+      makeWorkspace({
+        id: "g1",
+        path: "/tmp/here",
+        pathMissing: false,
+        pathInode: 99,
+      }),
     ]);
-    vi.mocked(invoke).mockResolvedValue(true);
+    mockInvokes({ file_exists: true, get_path_inode: 99 });
 
     const before = getWorkspaces()[0];
     await validateWorkspaceRootPaths();
     const after = getWorkspaces()[0];
 
-    expect(after?.pathMissing).toBe(before?.pathMissing);
+    expect(after).toBe(before);
+  });
+
+  it("rediscovers a renamed workspace and updates its path", async () => {
+    setWorkspaces([
+      makeWorkspace({ id: "g1", path: "/tmp/foo", pathInode: 7 }),
+    ]);
+    mockInvokes({
+      file_exists: false,
+      find_dir_by_inode: (parent, inode) => {
+        expect(parent).toBe("/tmp");
+        expect(inode).toBe(7);
+        return "/tmp/bar";
+      },
+    });
+
+    await validateWorkspaceRootPaths();
+
+    expect(getWorkspaces()[0]?.path).toBe("/tmp/bar");
+    expect(getWorkspaces()[0]?.pathMissing ?? false).toBe(false);
+  });
+
+  it("falls back to pathMissing when rediscovery finds no match", async () => {
+    setWorkspaces([
+      makeWorkspace({ id: "g1", path: "/tmp/foo", pathInode: 7 }),
+    ]);
+    mockInvokes({ file_exists: false, find_dir_by_inode: null });
+
+    await validateWorkspaceRootPaths();
+
+    expect(getWorkspaces()[0]?.path).toBe("/tmp/foo");
+    expect(getWorkspaces()[0]?.pathMissing).toBe(true);
+  });
+
+  it("does not call find_dir_by_inode when no inode is cached", async () => {
+    setWorkspaces([makeWorkspace({ id: "g1", path: "/tmp/foo" })]);
+    const findSpy = vi.fn().mockResolvedValue(null);
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "file_exists") return false;
+      if (cmd === "find_dir_by_inode") return findSpy();
+      return undefined;
+    });
+
+    await validateWorkspaceRootPaths();
+
+    expect(findSpy).not.toHaveBeenCalled();
+    expect(getWorkspaces()[0]?.pathMissing).toBe(true);
+  });
+
+  it("swallows a failing find_dir_by_inode and stamps pathMissing", async () => {
+    setWorkspaces([
+      makeWorkspace({ id: "g1", path: "/tmp/foo", pathInode: 7 }),
+    ]);
+    mockInvokes({
+      file_exists: false,
+      find_dir_by_inode: new Error("parent unreadable"),
+    });
+
+    await validateWorkspaceRootPaths();
+
+    expect(getWorkspaces()[0]?.pathMissing).toBe(true);
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -72,6 +72,7 @@ export interface WorkspaceTemplate {
   locked?: boolean;
   autoRunRestoreCommands?: boolean;
   path?: string;
+  pathInode?: number;
   isGit?: boolean;
   createdAt?: string;
   worktreePath?: string;
@@ -98,6 +99,12 @@ export interface WorkspaceDef {
   layout: LayoutNode;
   // Workspace-level fields (path-rooted Workspaces only)
   path?: string;
+  /**
+   * Inode of `path` at last successful sweep — persisted so rename
+   * detection still works for renames that happened while gnar-term
+   * was closed. See `validateWorkspaceRootPaths`.
+   */
+  pathInode?: number;
   color?: string;
   isGit?: boolean;
   createdAt?: string;

--- a/src/lib/services/workspace-runtime-service.ts
+++ b/src/lib/services/workspace-runtime-service.ts
@@ -199,6 +199,7 @@ export async function createWorkspaceFromDef(
   if (def.autoRunRestoreCommands !== undefined)
     ws.autoRunRestoreCommands = def.autoRunRestoreCommands;
   if (def.path !== undefined) ws.path = def.path;
+  if (def.pathInode !== undefined) ws.pathInode = def.pathInode;
   if (def.color !== undefined) ws.color = def.color;
   if (def.isGit !== undefined) ws.isGit = def.isGit;
   if (def.createdAt !== undefined) ws.createdAt = def.createdAt;

--- a/src/lib/services/workspace-service.ts
+++ b/src/lib/services/workspace-service.ts
@@ -456,28 +456,81 @@ export async function reconcilePrimaryWorkspaces(): Promise<void> {
  * Stamp `pathMissing: true` on any workspace whose `path` no longer
  * exists on disk (e.g. the user deleted the directory between sessions
  * or moved a worktree out from under the app). The flag is runtime-only
- * — not persisted — and is re-derived on every startup. Sidebar
+ * — not persisted — and is re-derived on every sweep. Sidebar
  * components surface a "path missing" affordance when the flag is set.
  *
- * Best-effort: a failing `file_exists` invoke is treated as "not
- * missing" so a transient FS error doesn't paint every workspace red.
- * Idempotent: a workspace whose path now exists has its flag cleared on
- * the next sweep.
+ * On each pass:
+ * - When the path exists, record its inode in `pathInode` (persisted)
+ *   so a future rename can be detected.
+ * - When the path does NOT exist but a `pathInode` is known, scan the
+ *   parent directory for a sibling with the same inode. If found, the
+ *   directory was renamed within its parent — update `path` to the new
+ *   location and clear `pathMissing` instead of flagging it.
+ *
+ * Best-effort: failing FS invokes are treated as "not missing" so a
+ * transient error doesn't paint every workspace red. Idempotent.
  */
 export async function validateWorkspaceRootPaths(): Promise<void> {
   const workspaces = getWorkspaces();
   for (const workspace of workspaces) {
+    if (!workspace.path) continue;
     let exists = true;
     try {
       exists = await invoke<boolean>("file_exists", { path: workspace.path });
     } catch {
       exists = true;
     }
-    const missing = !exists;
-    if ((workspace.pathMissing ?? false) !== missing) {
-      updateWorkspace(workspace.id, { pathMissing: missing });
+    if (exists) {
+      const patch: { pathMissing?: boolean; pathInode?: number } = {};
+      if ((workspace.pathMissing ?? false) !== false) patch.pathMissing = false;
+      try {
+        const inode = await invoke<number>("get_path_inode", {
+          path: workspace.path,
+        });
+        if (workspace.pathInode !== inode) patch.pathInode = inode;
+      } catch {
+        // Inode unavailable (Windows / unsupported FS). Skip cache
+        // refresh — rename detection just won't fire on this workspace.
+      }
+      if (Object.keys(patch).length > 0) {
+        updateWorkspace(workspace.id, patch);
+      }
+      continue;
+    }
+
+    // Path missing — try inode-based rediscovery before flagging.
+    const cachedInode = workspace.pathInode;
+    if (typeof cachedInode === "number") {
+      const parent = dirname(workspace.path);
+      try {
+        const found = await invoke<string | null>("find_dir_by_inode", {
+          parent,
+          inode: cachedInode,
+        });
+        if (found) {
+          updateWorkspace(workspace.id, {
+            path: found,
+            pathMissing: false,
+          });
+          continue;
+        }
+      } catch {
+        // Parent unreadable or platform doesn't support inodes. Fall
+        // through to flagging the workspace as missing.
+      }
+    }
+    if ((workspace.pathMissing ?? false) !== true) {
+      updateWorkspace(workspace.id, { pathMissing: true });
     }
   }
+}
+
+/** POSIX-style parent directory. Trailing slashes are stripped. */
+function dirname(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  if (idx <= 0) return "/";
+  return trimmed.slice(0, idx);
 }
 
 export { getWorkspace, getWorkspaces, setActiveWorkspaceId };

--- a/src/lib/stores/workspace.ts
+++ b/src/lib/stores/workspace.ts
@@ -70,6 +70,7 @@ export function workspaceDefToTemplate(
   // Workspace-level fields
   if (def.color !== undefined) nwDef.color = def.color;
   if (def.path !== undefined) nwDef.path = def.path;
+  if (def.pathInode !== undefined) nwDef.pathInode = def.pathInode;
   if (def.isGit !== undefined) nwDef.isGit = def.isGit;
   if (def.createdAt !== undefined) nwDef.createdAt = def.createdAt;
   if (def.autoRunRestoreCommands !== undefined)
@@ -284,6 +285,7 @@ export function serializeWorkspace(ws: Workspace): WorkspaceDef {
     layout: serializeLayout(ws.paneLayout),
   };
   if (ws.path !== undefined) def.path = ws.path;
+  if (ws.pathInode !== undefined) def.pathInode = ws.pathInode;
   if (ws.color !== undefined) def.color = ws.color;
   if (ws.isGit !== undefined) def.isGit = ws.isGit;
   if (ws.createdAt !== undefined) def.createdAt = ws.createdAt;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,13 @@ export interface Workspace {
   activePaneId: string | null;
   // Workspace-level (present on path-rooted Workspaces, absent on Branches)
   path?: string;
+  /**
+   * Inode of `path` at last successful sweep. Used by the rename-
+   * detection probe in `validateWorkspaceRootPaths` to rediscover the
+   * workspace when its directory is renamed within the same parent on
+   * a Unix filesystem. Unset until the first sweep populates it.
+   */
+  pathInode?: number;
   color?: string;
   isGit?: boolean;
   createdAt?: string;


### PR DESCRIPTION
## Summary
- When a workspace's root directory is renamed within its parent (e.g. via Finder or `mv`), gnar-term now rediscovers the new path automatically instead of flagging the workspace as `pathMissing`.
- Approach: persist `pathInode` on each successful sweep. When the path goes missing, scan the parent directory for a sibling with the matching inode — stable across rename on the filesystems gnar-term supports (macOS, Linux).
- Sweeps now fire at three points: startup (existing), on window focus (new), and every 60s while the app is running (new).

### Out of scope
- Cross-parent moves (e.g. `mv ~/Code/foo ~/Projects/foo`) — these still land as `pathMissing`. Easy to layer a wider search later if it matters.
- Branch (worktree) workspaces — `worktreePath` rename detection is a separate concern.
- Windows — gnar-term doesn't ship on Windows; the Rust commands return `Err` gracefully if invoked there.

### Files
- `src-tauri/src/fs_commands.rs` — two new commands: `get_path_inode`, `find_dir_by_inode`.
- `src-tauri/src/lib.rs` — register both.
- `src/lib/types.ts`, `src/lib/config.ts` — add `pathInode?: number` to `Workspace`, `WorkspaceDef`, `WorkspaceTemplate`.
- `src/lib/stores/workspace.ts`, `src/lib/services/workspace-runtime-service.ts` — plumb `pathInode` through persist/restore.
- `src/lib/services/workspace-service.ts` — extend `validateWorkspaceRootPaths` with inode-cache refresh and rediscovery-on-miss.
- `src/App.svelte` — wire window-focus + 60s periodic sweep.
- `src/__tests__/validate-workspace-root-paths.test.ts` — 8 cases covering rediscovery, no-match fallback, missing-inode fallback, and the unhappy paths.

## Test plan
- [ ] **Rename while gnar-term is unfocused.** Create a workspace at `/tmp/cwd-test-foo`. Switch to another app. Run `mv /tmp/cwd-test-foo /tmp/cwd-test-bar`. Refocus gnar-term — workspace banner should now show `/tmp/cwd-test-bar`, no `pathMissing` chrome.
- [ ] **Rename while gnar-term is focused.** Create `/tmp/cwd-test-foo`. Without leaving gnar-term, run `mv /tmp/cwd-test-foo /tmp/cwd-test-bar` in a terminal. Wait ≤60s — workspace banner should auto-update.
- [ ] **Rename while gnar-term is closed.** Create `/tmp/cwd-test-foo`. Quit gnar-term. `mv /tmp/cwd-test-foo /tmp/cwd-test-bar`. Relaunch — startup sweep should update path to the new location.
- [ ] **Cross-parent move stays `pathMissing`.** `mv /tmp/cwd-test-bar /Users/$USER/cwd-test-bar` — workspace should land as `pathMissing: true` (expected; out of scope for this PR).
- [ ] **Deletion still flags `pathMissing`.** `rm -rf /tmp/cwd-test-foo` with no rename target — banner shows the missing-path affordance.
- [ ] **Linux:** repeat steps 1–3 on Linux (inotify/ext4 path); confirm parity with macOS.
- [ ] `npm test` — 1781 tests pass (1773 prior + 8 new rediscovery cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)