### PR TITLE
fix(sidebar): gate DRAFT pill on Controlled branches, sync hat/icon, drop seam, align subtitle

### DIFF
--- a/src/__tests__/init-agent-status.test.ts
+++ b/src/__tests__/init-agent-status.test.ts
@@ -43,7 +43,27 @@ import {
   _testHelpers as branchLifecycleTestHelpers,
   resetBranchLifecycleForTests,
 } from "../lib/services/branch-lifecycle";
+import { workspaces } from "../lib/stores/workspace";
+import type { BranchedWorkspace } from "../lib/types";
 import WorkspaceAgentSubtitle from "../lib/components/WorkspaceAgentSubtitle.svelte";
+
+function makeControlledBranch(id: string): BranchedWorkspace {
+  return {
+    id,
+    name: id,
+    paneLayout: {
+      type: "pane",
+      pane: { id: "pane-1", surfaces: [], activeSurfaceId: null },
+    },
+    activePaneId: null,
+    rootWorkspaceId: "root-1",
+    worktreePath: "/repo/.worktrees/feat-x",
+    branch: "feat/x",
+    baseBranch: "main",
+    color: "#aaa",
+    controlled: true,
+  };
+}
 
 function makeAgent(overrides: Partial<DetectedAgent> = {}): DetectedAgent {
   return {
@@ -64,6 +84,7 @@ function resetRegistries() {
   resetWorkspaceSubtitles();
   setAgentsForTests([]);
   resetBranchLifecycleForTests();
+  workspaces.set([]);
 }
 
 describe("initAgentStatus() registration", () => {
@@ -234,7 +255,8 @@ describe("WorkspaceAgentSubtitle", () => {
     expect(focusSurfaceByIdMock).toHaveBeenCalledWith("surf-42");
   });
 
-  it("renders the lifecycle pill when exactly one workspace branch matches a pane", async () => {
+  it("renders the lifecycle pill when exactly one workspace branch matches a pane (controlled)", async () => {
+    workspaces.set([makeControlledBranch("ws-1")]);
     setAgentsForTests([
       makeAgent({
         agentId: "a1",
@@ -258,6 +280,33 @@ describe("WorkspaceAgentSubtitle", () => {
     const pill = container.querySelector("[data-lifecycle]");
     expect(pill).toBeTruthy();
     expect(pill!.getAttribute("data-lifecycle")).toBeTruthy();
+  });
+
+  it("hides the lifecycle pill for uncontrolled (manual) branches", async () => {
+    const uncontrolled = makeControlledBranch("ws-1");
+    delete uncontrolled.controlled;
+    workspaces.set([uncontrolled]);
+    setAgentsForTests([
+      makeAgent({
+        agentId: "a1",
+        workspaceId: "ws-1",
+        paneId: "pane-1",
+        status: "active",
+      }),
+    ]);
+    await branchLifecycleTestHelpers.seedBranch("branch-1", {
+      repoPath: "/repo",
+      branch: "feat/x",
+      baseBranch: "main",
+      hasCommits: true,
+      prState: null,
+      lastActivityAt: 0,
+      paneId: "pane-1",
+    });
+    const { container } = render(WorkspaceAgentSubtitle, {
+      props: { workspaceId: "ws-1" },
+    });
+    expect(container.querySelector("[data-lifecycle]")).toBeNull();
   });
 
   it("hides the lifecycle pill when multiple branches match (ambiguous)", async () => {

--- a/src/__tests__/workspace-grip.test.ts
+++ b/src/__tests__/workspace-grip.test.ts
@@ -159,7 +159,7 @@ describe("WorkspaceItem border", () => {
     expect(row.dataset.worktree).toBe("true");
   });
 
-  it("renders a 1px border in railColor for active workspaces", () => {
+  it("renders a 1px border in railColor on top/right/bottom for active workspaces (no left border)", () => {
     const { container } = render(WorkspaceItem, {
       props: {
         workspace: makeChildWorkspace(),
@@ -174,11 +174,17 @@ describe("WorkspaceItem border", () => {
       },
     });
     const row = container.querySelector("[data-drag-idx]") as HTMLElement;
-    expect(row.style.border).toContain("1px solid");
-    expect(row.style.border).toContain("rgb(255, 0, 170)");
+    // Left border is intentionally omitted so the row's leftmost edge
+    // is owned by the colored rail/hat — a 1px theme stripe there
+    // reads as "left edge of the hat" and undoes the bot-hat seam.
+    expect(row.style.borderTop).toContain("1px solid");
+    expect(row.style.borderRight).toContain("1px solid");
+    expect(row.style.borderBottom).toContain("1px solid");
+    expect(row.style.borderLeftStyle).toBe("none");
+    expect(row.style.borderTop).toContain("rgb(255, 0, 170)");
   });
 
-  it("renders a 1px inactive-theme border for inactive workspaces (worktree or not)", () => {
+  it("renders a 1px inactive-theme border on top/right/bottom for inactive workspaces (worktree or not)", () => {
     const { container } = render(WorkspaceItem, {
       props: {
         workspace: makeChildWorkspace(),
@@ -194,8 +200,11 @@ describe("WorkspaceItem border", () => {
     });
     const row = container.querySelector("[data-drag-idx]") as HTMLElement;
     expect(row.dataset.worktree).toBeUndefined();
-    expect(row.style.border).toContain("1px solid");
+    expect(row.style.borderTop).toContain("1px solid");
+    expect(row.style.borderRight).toContain("1px solid");
+    expect(row.style.borderBottom).toContain("1px solid");
+    expect(row.style.borderLeftStyle).toBe("none");
     // Inactive uses theme.border, NOT the accentColor.
-    expect(row.style.border).not.toContain("rgb(255, 0, 170)");
+    expect(row.style.borderTop).not.toContain("rgb(255, 0, 170)");
   });
 });

--- a/src/lib/components/SidebarElement.svelte
+++ b/src/lib/components/SidebarElement.svelte
@@ -144,9 +144,16 @@
     : isHovered
       ? $theme.bgHighlight
       : ($theme.bgSurface ?? 'transparent')};
-    border: 1px solid {isActive
+    border-top: 1px solid {isActive
     ? effectiveColor
     : ($theme.border ?? 'transparent')};
+    border-right: 1px solid {isActive
+    ? effectiveColor
+    : ($theme.border ?? 'transparent')};
+    border-bottom: 1px solid {isActive
+    ? effectiveColor
+    : ($theme.border ?? 'transparent')};
+    border-left: none;
     transition: background 0.1s;
   "
   on:contextmenu|preventDefault={onContextMenu}

--- a/src/lib/components/WorkspaceAgentSubtitle.svelte
+++ b/src/lib/components/WorkspaceAgentSubtitle.svelte
@@ -23,6 +23,7 @@
    */
   import { derived, get } from "svelte/store";
   import { agentsStore } from "../services/agent-detection-service";
+  import { attentionStore } from "../services/attention-api";
   import {
     branchLifecycleStore,
     listBranchDescriptors,
@@ -32,6 +33,9 @@
     TERMINAL_AGENT_STATUSES,
     agentStatusBucket,
   } from "../services/agent-status-service";
+  import { workspaceRailBotStatus } from "../services/rail-attention";
+  import { workspaces } from "../stores/workspace";
+  import { getAllPanes } from "../types";
   import { theme } from "../stores/theme";
   import { botHatColor, type BotHatStatus } from "../utils/bot-hat-color";
   import BotIcon from "../icons/BotIcon.svelte";
@@ -45,9 +49,24 @@
     ),
   );
 
+  // Pane ids owned by this workspace. Used by both the rail-attention
+  // aggregator (so it can scope OSC attention events to this workspace)
+  // and the lifecycle lookup. Reactive on `workspaces` so pane splits
+  // re-flow into the status.
+  const workspacePaneIds = derived(workspaces, ($ws) => {
+    const w = $ws.find((x) => x.id === workspaceId);
+    if (!w || !w.paneLayout) return [] as string[];
+    return getAllPanes(w.paneLayout).map((p) => p.id);
+  });
+
   const lifecycleEntry = derived(
-    [agentsStore, branchLifecycleStore],
-    ([$agents, $branchLifecycle]) => {
+    [agentsStore, branchLifecycleStore, workspaces],
+    ([$agents, $branchLifecycle, $workspaces]) => {
+      const ws = $workspaces.find((w) => w.id === workspaceId);
+      // Lifecycle pill is reserved for agentically-spawned (controlled)
+      // branches — manual branches stay pill-less.
+      if (!ws || ws.controlled !== true) return undefined;
+
       const paneIds = new Set(
         $agents
           .filter((a) => a.workspaceId === workspaceId && a.paneId !== null)
@@ -64,10 +83,14 @@
     },
   );
 
-  // Render distinct buckets present across this workspace's own active
-  // agents, in precedence order (waiting > running > idle). The inline
-  // status reports only the workspace's own bots — the rail "hat"
-  // aggregates root + branches and lives elsewhere.
+  // The icon color (and the row's `data-bot-status`) come from the
+  // canonical rail-attention pipeline so the inline bot icon's color
+  // always agrees with the rail's "hat" color — including OSC-driven
+  // attention events that flip the hat before any agent's status flips
+  // to "waiting". The textual label still enumerates the distinct
+  // agent-derived buckets present (waiting, running, idle) so the row
+  // reports *what* the agents are doing, while the color tracks the
+  // canonical "highest-priority signal" the rail surfaces.
   const BUCKET_LABEL: Record<BotHatStatus, string> = {
     attention: "Waiting",
     thinking: "Running",
@@ -86,7 +109,12 @@
     return BUCKET_ORDER.filter((b) => seen.has(b));
   })();
   $: statusLabel = presentBuckets.map((b) => BUCKET_LABEL[b]).join(", ");
-  $: dominantBucket = presentBuckets[0] ?? "none";
+  $: dominantBucket = workspaceRailBotStatus(
+    workspaceId,
+    $workspacePaneIds,
+    $agentsStore,
+    $attentionStore,
+  );
   $: iconColor = botHatColor(dominantBucket) ?? fgMuted;
   $: shouldRender = statusLabel !== "" || $lifecycleEntry !== undefined;
 
@@ -132,7 +160,11 @@
   .workspace-agent-subtitle {
     display: flex;
     flex-direction: column;
-    padding: 0 0 0 6px;
+    /* No inner padding: the wrapping SidebarSubtitleRow already supplies
+       the row-level x=2 alignment used by sibling subtitle rows. Adding
+       padding here pushed the bot icon out by 6px and broke left-edge
+       alignment with the inline worktree/lifecycle rows. */
+    padding: 0;
     overflow: hidden;
     line-height: 1.2;
     flex: 1;


### PR DESCRIPTION
## Summary
- **WorkspaceAgentSubtitle** now uses `workspaceRailBotStatus` (the canonical rail-attention pipeline) for the inline bot icon color, so the icon and the rail "hat" can never disagree — including the OSC-attention path that flips the hat before any agent's status reaches `waiting`. The textual label still enumerates the agent-derived buckets (e.g. `"Waiting, Running"`).
- **WorkspaceAgentSubtitle.lifecycleEntry** now gates on `workspace.controlled === true`, so the DRAFT pill stays hidden for branches spawned from the manual "New Branch" button. Controlled (agentically-spawned) branches still get it.
- **WorkspaceAgentSubtitle padding** drops the `0 0 0 6px` inner padding so the bot icon aligns to x=2 like the sibling inline subtitle rows (worktree status, lifecycle, path missing).
- **SidebarElement** omits the left border (`border-left: none`) so the row's leftmost 1px belongs to the colored rail/hat rather than the theme border — fixes the dark vertical seam on the left edge of the bot hat.

## Test plan
- [ ] Spawn a workspace from the manual "Branch Workspace" tile — confirm **no** DRAFT pill appears next to the agent status
- [ ] Spawn a workspace from the agentic "+ New agentic branch" flow — confirm the DRAFT pill is rendered as before
- [ ] Trigger an OSC attention event before an agent flips to `waiting` — confirm the inline bot icon turns yellow at the same instant as the rail hat (no green-icon-with-yellow-hat divergence)
- [ ] Verify on collapsed and expanded sidebar widths, on both root and branched rows
- [ ] Inspect a branch row in the sidebar — confirm the left edge of the bot hat has no dark vertical seam to its left
- [ ] Compare branch row subtitle alignment — bot icon should line up with worktree icon and lifecycle pill at the same left edge
- [ ] Active branch rows: confirm the accent border still wraps top/right/bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)