### PR TITLE
feat(rail): replace bot hat with floating notification bubble

### DIFF
--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -2325,7 +2325,7 @@ describe("TerminalSurface", () => {
 // ---------------------------------------------------------------------------
 
 describe("WorkspaceItem — harness sub-row", () => {
-  it("paints a green 'thinking' rail hat for a running agent", async () => {
+  it("paints a green 'thinking' rail bubble for a running agent", async () => {
     const { setAgentsForTests } =
       await import("../lib/services/agent-detection-service");
 
@@ -2358,15 +2358,17 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    // "thinking" hat is static, not pulsing.
-    expect(hat!.classList.contains("pulses")).toBe(false);
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
+    // "thinking" bubble is static, not pulsing.
+    expect(bubble!.classList.contains("pulses")).toBe(false);
     setAgentsForTests([]);
   });
 
-  it("paints a muted 'idle' rail hat when an agent is attached but idle", async () => {
-    // Idle agents still warrant a hat — it's the "currently
+  it("paints a muted 'idle' rail bubble when an agent is attached but idle", async () => {
+    // Idle agents still warrant a bubble — it's the "currently
     // thinking" presence indicator that survives the BotIcon
     // removal. Color is muted-grey, no pulse.
     const { setAgentsForTests } =
@@ -2411,13 +2413,15 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    expect(hat!.classList.contains("pulses")).toBe(false);
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
+    expect(bubble!.classList.contains("pulses")).toBe(false);
     setAgentsForTests([]);
   });
 
-  it("hides the rail hat when hideStatusBadges is true", async () => {
+  it("hides the rail bubble when hideStatusBadges is true", async () => {
     const { setStatusItem, clearAllStatusForWorkspace } =
       await import("../lib/services/status-registry");
 
@@ -2446,12 +2450,12 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    expect(container.querySelector(".rail-bot-hat")).toBeNull();
+    expect(container.querySelector(".rail-bot-bubble")).toBeNull();
     clearAllStatusForWorkspace(ws.id);
   });
 
-  it("paints a single 'thinking' hat regardless of how many agents are running", async () => {
-    // Multiple agents collapse to one hat — the hat is a per-row
+  it("paints a single 'thinking' bubble regardless of how many agents are running", async () => {
+    // Multiple agents collapse to one bubble — the bubble is a per-row
     // signal, not a per-agent one. Color stays the running-green.
     const { setAgentsForTests } =
       await import("../lib/services/agent-detection-service");
@@ -2506,12 +2510,12 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const hats = container.querySelectorAll(".rail-bot-hat");
-    expect(hats.length).toBe(1);
+    const bubbles = container.querySelectorAll(".rail-bot-bubble");
+    expect(bubbles.length).toBe(1);
     setAgentsForTests([]);
   });
 
-  it("paints a pulsing 'attention' hat for a waiting agent", async () => {
+  it("paints a pulsing 'attention' bubble for a waiting agent", async () => {
     const { setAgentsForTests } =
       await import("../lib/services/agent-detection-service");
 
@@ -2544,9 +2548,11 @@ describe("WorkspaceItem — harness sub-row", () => {
       },
     });
 
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    expect(hat!.classList.contains("pulses")).toBe(true);
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
+    expect(bubble!.classList.contains("pulses")).toBe(true);
     setAgentsForTests([]);
   });
 });

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -113,13 +113,18 @@ describe("DragGrip", () => {
       ".rail-bot-bubble",
     ) as HTMLElement | null;
     expect(bubble).not.toBeNull();
-    const computed = window.getComputedStyle(bubble!);
-    // Circular silhouette — border-radius set to 50% (or equivalent
-    // value ≥ half the short axis).
-    expect(
-      computed.borderRadius === "" || computed.borderRadius !== "0px",
-    ).toBe(true);
+    // Circular silhouette — verified at source level because jsdom
+    // doesn't evaluate scoped Svelte styles. computed.borderRadius is
+    // always "" here, so a DOM-level assertion would be a tautology.
+    const sourceText = readFileSync(
+      "src/lib/components/DragGrip.svelte",
+      "utf-8",
+    );
+    const ruleMatch = sourceText.match(/\.rail-bot-bubble\s*\{[^}]*\}/);
+    expect(ruleMatch).not.toBeNull();
+    expect(ruleMatch![0]).toMatch(/border-radius:\s*50%/);
     // No multi-stop gradient divider stripe (the old hat's hallmark).
+    const computed = window.getComputedStyle(bubble!);
     const bg = (bubble!.style.background || "") + (computed.background || "");
     expect(bg).not.toContain("linear-gradient");
   });

--- a/src/__tests__/drag-grip.test.ts
+++ b/src/__tests__/drag-grip.test.ts
@@ -75,7 +75,9 @@ describe("DragGrip", () => {
     expect(stripe!.style.width).toBe("4px");
   });
 
-  it("renders the bot-status hat in narrow (collapsed) mode", () => {
+  // AC-1: The .rail-bot-hat element is removed; a new .rail-bot-bubble
+  // takes its place when botStatus !== "none".
+  it("AC-1: renders the bot-status bubble in narrow (collapsed) mode", () => {
     const { container } = render(DragGrip, {
       props: {
         theme: stubTheme,
@@ -85,18 +87,19 @@ describe("DragGrip", () => {
         botStatus: "thinking",
       },
     });
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    expect(hat!.style.width).toBe("4px");
+    // Old cap shape must be gone.
+    expect(container.querySelector(".rail-bot-hat")).toBeNull();
+    // New bubble must paint.
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
   });
 
-  it("paints the 2px dark divider between hat and rail in narrow (collapsed) mode", () => {
-    // Regression: an earlier iteration dropped the divider in narrowRail
-    // mode on the theory that 4px was too thin to read as a separator.
-    // In practice, removing it made the hat color flow straight into
-    // the rail color — losing the discrete "hat above rail" silhouette
-    // that's the whole point of the shape. The divider must paint at
-    // every rail width.
+  // AC-5: The bubble has a circular silhouette (border-radius ≥ 50% of
+  // its short axis) — no rectangular cap shape, no bottom-divider
+  // gradient stripe.
+  it("AC-5: paints the bubble as a circle with a dark outline, no gradient divider", () => {
     const { container } = render(DragGrip, {
       props: {
         theme: stubTheme,
@@ -106,17 +109,42 @@ describe("DragGrip", () => {
         botStatus: "thinking",
       },
     });
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    const background = hat!.style.background;
-    expect(background).toContain("linear-gradient");
-    expect(background).toContain("rgba(0, 0, 0, 0.55)");
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
+    const computed = window.getComputedStyle(bubble!);
+    // Circular silhouette — border-radius set to 50% (or equivalent
+    // value ≥ half the short axis).
+    expect(
+      computed.borderRadius === "" || computed.borderRadius !== "0px",
+    ).toBe(true);
+    // No multi-stop gradient divider stripe (the old hat's hallmark).
+    const bg = (bubble!.style.background || "") + (computed.background || "");
+    expect(bg).not.toContain("linear-gradient");
   });
 
-  it("renders the bot-status hat in expanded (full-width) mode too", () => {
-    // Regression: bot status used to be hidden when the sidebar was
-    // expanded. Now the hat must paint at every rail width so agent
-    // notifications stay visible regardless of sidebar layout.
+  // AC-2: Bubble is absolutely positioned and visually overlaps the top
+  // edge of the row (its bounding box extends above the row by at least
+  // the bubble's radius). jsdom doesn't evaluate scoped Svelte styles,
+  // so we verify the rule at the source level — paired with the in-DOM
+  // presence checks in the other AC tests, this nails down both that
+  // the bubble is rendered AND that its CSS positions it above the row.
+  it("AC-2: positions the bubble above the row's top edge (source check)", () => {
+    const source = readFileSync("src/lib/components/DragGrip.svelte", "utf-8");
+    const ruleMatch = source.match(/\.rail-bot-bubble\s*\{[^}]*\}/);
+    expect(ruleMatch).not.toBeNull();
+    const rule = ruleMatch![0];
+    expect(rule).toMatch(/position:\s*absolute/);
+    // top must be negative — the bubble's box extends above the row top.
+    const topMatch = rule.match(/top:\s*(-?\d+(?:\.\d+)?)px/);
+    expect(topMatch).not.toBeNull();
+    expect(parseFloat(topMatch![1])).toBeLessThan(0);
+  });
+
+  // AC-4 (expanded mode): bubble still renders at every rail width and
+  // pulses when botStatus === "attention".
+  it("AC-4: renders the bubble in expanded (full-width) mode and pulses on attention", () => {
     const { container } = render(DragGrip, {
       props: {
         theme: stubTheme,
@@ -126,13 +154,15 @@ describe("DragGrip", () => {
         botStatus: "attention",
       },
     });
-    const hat = container.querySelector(".rail-bot-hat") as HTMLElement | null;
-    expect(hat).not.toBeNull();
-    expect(hat!.style.width).toBe("8px");
-    expect(hat!.classList.contains("pulses")).toBe(true);
+    const bubble = container.querySelector(
+      ".rail-bot-bubble",
+    ) as HTMLElement | null;
+    expect(bubble).not.toBeNull();
+    expect(bubble!.classList.contains("pulses")).toBe(true);
   });
 
-  it("hides the bot-status hat when botStatus is none", () => {
+  // AC-1 (none-state branch): no bubble when botStatus is "none".
+  it("AC-1: hides the bot-status bubble when botStatus is none", () => {
     const { container } = render(DragGrip, {
       props: {
         theme: stubTheme,
@@ -141,7 +171,37 @@ describe("DragGrip", () => {
         botStatus: "none",
       },
     });
+    expect(container.querySelector(".rail-bot-bubble")).toBeNull();
+    // Old hat must be gone too.
     expect(container.querySelector(".rail-bot-hat")).toBeNull();
+  });
+
+  // AC-3: Bubble presence does NOT change the row's layout height. Since
+  // the bubble is position:absolute it must not contribute to flow.
+  it("AC-3: bubble presence does not change drag-grip layout height", () => {
+    const renderAt = (botStatus: "none" | "idle" | "thinking" | "attention") =>
+      render(DragGrip, {
+        props: {
+          theme: stubTheme,
+          visible: false,
+          railColor: "#abcdef",
+          narrowRail: true,
+          botStatus,
+        },
+      });
+
+    const a = renderAt("none");
+    const aGrip = a.container.querySelector(".drag-grip") as HTMLElement;
+    const aHeight = aGrip.getBoundingClientRect().height;
+    cleanup();
+
+    const b = renderAt("attention");
+    const bGrip = b.container.querySelector(".drag-grip") as HTMLElement;
+    const bHeight = bGrip.getBoundingClientRect().height;
+
+    // jsdom usually reports zero for unsized boxes; the contract we
+    // actually care about is equality between the two states.
+    expect(bHeight).toBe(aHeight);
   });
 });
 

--- a/src/lib/components/DragGrip.svelte
+++ b/src/lib/components/DragGrip.svelte
@@ -130,20 +130,17 @@
   // 4px policy).
   $: railStripeWidth = narrowRail ? "4px" : "8px";
   $: dotsRender = alwaysShowDots && !narrowRail;
-  // Hat renders at every rail width — bot status is the one signal
+  // Bubble renders at every rail width — bot status is the one signal
   // we always surface on the rail itself so notification visibility
   // doesn't depend on whether the sidebar is collapsed.
-  $: showHat = botStatus !== "none";
-  $: hatColor =
+  $: showBubble = botStatus !== "none";
+  $: bubbleColor =
     botStatus === "attention"
       ? warningColor
       : botStatus === "thinking"
         ? successColor
         : mutedColor;
-  $: hatPulses = botStatus === "attention";
-  // Hat matches the rail's painted width so it caps the rail cleanly
-  // in both collapsed (4px) and expanded (8px) modes.
-  $: hatWidth = railStripeWidth;
+  $: bubblePulses = botStatus === "attention";
 </script>
 
 <!-- The grip is the rail's hover target. Hover state is `:hover`-driven
@@ -173,30 +170,21 @@
     style="width: {railStripeWidth}; background: {effectiveColor}; opacity: {railOpacity};"
   ></div>
 
-  {#if showHat}
-    <!-- Bot-status hat overlay: a small rounded "cap" that protrudes
-         4px above the row plus solid color inside the row, with a 2px
-         dark divider at the bottom so the hat reads as a discrete
-         chunk above the rail stripe. Width tracks the rail stripe
-         (4px in collapsed mode, 8px in expanded) so the cap caps the
-         rail cleanly without ever appearing thicker than the rail
-         itself. The divider paints at every rail width — the
-         separation between hat and rail is the whole point of the
-         hat shape. -->
+  {#if showBubble}
+    <!-- Bot-status bubble: a small OS-style notification badge floating
+         above the rail. The bubble is absolutely positioned so its
+         presence never changes the row's layout height; it overlaps the
+         top edge of the rail by ~2px so it reads as "sitting on" the
+         rail rather than detached from it. A 1px dark outline gives it
+         the contrasting border OS notification badges use to separate
+         from their background. -->
     <div
       aria-hidden="true"
-      class="rail-bot-hat"
-      class:pulses={hatPulses}
+      class="rail-bot-bubble"
+      class:pulses={bubblePulses}
       style="
-        width: {hatWidth};
-        --rail-hat-glow: {hatColor};
-        background: linear-gradient(
-          to bottom,
-          {hatColor} 0,
-          {hatColor} 14px,
-          rgba(0, 0, 0, 0.55) 14px,
-          rgba(0, 0, 0, 0.55) 16px
-        );
+        --rail-bubble-glow: {bubbleColor};
+        background: {bubbleColor};
       "
     ></div>
   {/if}
@@ -311,18 +299,27 @@
     display: block;
   }
 
-  .rail-bot-hat {
+  /* OS-style notification bubble. Absolutely positioned so its presence
+     never contributes to row layout — the gap between workspaces is
+     identical whether the bubble paints or not. The bubble is anchored
+     to the rail stripe's left edge and sits mostly above the row top,
+     overlapping the rail by ~2px so it visually crowns the rail. The
+     box-shadow outline acts as the contrasting border that makes the
+     bubble read as a discrete badge instead of bleeding into the rail's
+     color. */
+  .rail-bot-bubble {
     position: absolute;
     left: 0;
-    top: -4px;
-    height: 16px;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    top: -6px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
     pointer-events: none;
     z-index: 3;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
   }
-  .rail-bot-hat.pulses {
-    animation: dg-rail-hat-glow 1.6s ease-in-out infinite;
+  .rail-bot-bubble.pulses {
+    animation: dg-rail-bubble-glow 1.6s ease-in-out infinite;
   }
 
   .grip-chip {
@@ -369,14 +366,16 @@
     pointer-events: none;
   }
 
-  @keyframes dg-rail-hat-glow {
+  @keyframes dg-rail-bubble-glow {
     0%,
     100% {
-      box-shadow: 0 0 0 0 transparent;
+      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
     }
     50% {
-      box-shadow: 0 0 4px 1.5px
-        color-mix(in srgb, var(--rail-hat-glow) 55%, transparent);
+      box-shadow:
+        0 0 0 1px rgba(0, 0, 0, 0.55),
+        0 0 4px 1.5px
+          color-mix(in srgb, var(--rail-bubble-glow) 55%, transparent);
     }
   }
 </style>

--- a/src/lib/components/SidebarRail.svelte
+++ b/src/lib/components/SidebarRail.svelte
@@ -25,7 +25,6 @@
   import { theme } from "../stores/theme";
   import { sidebarVisible, canSidebarDrag } from "../stores/ui";
   import DragGrip from "./DragGrip.svelte";
-  import { botHatColor } from "../utils/bot-hat-color";
 
   export let mode: "row" | "container" = "row";
 
@@ -61,11 +60,12 @@
    */
   export let popoverActive: boolean = false;
   /**
-   * Bot status for the row this rail belongs to. Drives the hat
-   * overlay rendered by DragGrip — pulsing yellow for "attention",
-   * green for "thinking", muted-grey for "idle", nothing for
-   * "none". Renders at every sidebar width so bot presence stays
-   * visible whether the sidebar is collapsed or expanded.
+   * Bot status for the row this rail belongs to. Drives the
+   * bot-status bubble rendered by DragGrip — pulsing yellow for
+   * "attention", green for "thinking", muted-grey for "idle",
+   * nothing for "none". Renders at every sidebar width so bot
+   * presence stays visible whether the sidebar is collapsed or
+   * expanded.
    */
   export let botStatus: "none" | "thinking" | "attention" | "idle" = "none";
 
@@ -88,13 +88,13 @@
 
   $: effectiveCanDrag = canDrag && $canSidebarDrag;
   $: railBorderColor = $theme.border ?? "transparent";
-  // Top-border color matches the bot-hat's color when the rail is
-  // hatted, so the segment of the workspace border at the hat's
-  // section reads as part of the hat rather than the rail's accent.
-  // Falls back to the active-rail accent or the neutral border color
-  // otherwise, preserving the existing look for hat-less rows.
-  $: hatColor = botHatColor(botStatus);
-  $: topBorderColor = hatColor ?? (isActive ? color : railBorderColor);
+  // Top-border color: workspace accent when active, neutral theme
+  // border otherwise. The bot-status bubble floats above the row on
+  // its own (DragGrip positions it absolutely with a negative top), so
+  // the border no longer needs to tint to a bot-status color — the
+  // workspace's own borders read as the workspace's, regardless of
+  // bot activity.
+  $: topBorderColor = isActive ? color : railBorderColor;
   // Collapsed mode rail-width policy: thin (4px) when inactive and the
   // row isn't being dragged or showing a popover. Hover no longer
   // factors in — DragGrip's CSS owns the hover look, and the 4px stripe
@@ -139,15 +139,15 @@
     primaryClickable={!$sidebarVisible && !!onClick}
   />
   {#if mode === "container" && hasActiveStripe}
-    <!-- Active-descendant stripe. When a hat is painted, the stripe
-         starts below the hat so it never reads as "1px of workspace
-         accent framing the hat" — the hat owns the top 12px and the
-         stripe owns everything below it. -->
+    <!-- Active-descendant stripe. Spans the full height of the rail
+         row. The bot-status bubble (DragGrip) is absolutely positioned
+         above the row and contributes nothing to layout, so the stripe
+         no longer needs to skip a hat-shaped region at the top. -->
     <div
       aria-hidden="true"
       style="
         position: absolute;
-        top: {hatColor ? '12px' : '0'};
+        top: 0;
         left: 0; bottom: 0;
         width: 1px;
         background: {color};

--- a/src/lib/components/WorkspaceAgentSubtitle.svelte
+++ b/src/lib/components/WorkspaceAgentSubtitle.svelte
@@ -9,12 +9,13 @@
    * branch matches a pane, the branch-lifecycle pill rides on the same
    * row.
    *
-   * Scope is intentionally narrower than the rail "hat" — the hat on
-   * the workspace banner aggregates the root workspace AND its branched
-   * workspaces, while this inline row reports only the bots whose
-   * `workspaceId` matches the row's own workspace. Branched workspace
-   * rows therefore show their own scope, and the root banner shows
-   * only the root's own bots even when branches have activity.
+   * Scope is intentionally narrower than the rail bot-status bubble —
+   * the bubble on the workspace banner aggregates the root workspace
+   * AND its branched workspaces, while this inline row reports only
+   * the bots whose `workspaceId` matches the row's own workspace.
+   * Branched workspace rows therefore show their own scope, and the
+   * root banner shows only the root's own bots even when branches
+   * have activity.
    *
    * Hides itself entirely when no active agents are present (and no
    * lifecycle pill would render). Registered by core in
@@ -37,7 +38,7 @@
   import { workspaces } from "../stores/workspace";
   import { getAllPanes } from "../types";
   import { theme } from "../stores/theme";
-  import { botHatColor, type BotHatStatus } from "../utils/bot-hat-color";
+  import { botStatusColor, type BotStatus } from "../utils/bot-status-color";
   import BotIcon from "../icons/BotIcon.svelte";
 
   export let workspaceId: string;
@@ -85,23 +86,24 @@
 
   // The icon color (and the row's `data-bot-status`) come from the
   // canonical rail-attention pipeline so the inline bot icon's color
-  // always agrees with the rail's "hat" color — including OSC-driven
-  // attention events that flip the hat before any agent's status flips
-  // to "waiting". The textual label still enumerates the distinct
-  // agent-derived buckets present (waiting, running, idle) so the row
-  // reports *what* the agents are doing, while the color tracks the
-  // canonical "highest-priority signal" the rail surfaces.
-  const BUCKET_LABEL: Record<BotHatStatus, string> = {
+  // always agrees with the rail's bot-status bubble color — including
+  // OSC-driven attention events that flip the bubble before any
+  // agent's status flips to "waiting". The textual label still
+  // enumerates the distinct agent-derived buckets present (waiting,
+  // running, idle) so the row reports *what* the agents are doing,
+  // while the color tracks the canonical "highest-priority signal"
+  // the rail surfaces.
+  const BUCKET_LABEL: Record<BotStatus, string> = {
     attention: "Waiting",
     thinking: "Running",
     idle: "Idle",
     none: "",
   };
-  const BUCKET_ORDER: BotHatStatus[] = ["attention", "thinking", "idle"];
+  const BUCKET_ORDER: BotStatus[] = ["attention", "thinking", "idle"];
 
   $: fgMuted = ($theme["fgMuted"] ?? $theme.fgDim) as string;
   $: presentBuckets = (() => {
-    const seen = new Set<BotHatStatus>();
+    const seen = new Set<BotStatus>();
     for (const a of $activeAgents) {
       const b = agentStatusBucket(a.status);
       if (b !== "none") seen.add(b);
@@ -115,7 +117,7 @@
     $agentsStore,
     $attentionStore,
   );
-  $: iconColor = botHatColor(dominantBucket) ?? fgMuted;
+  $: iconColor = botStatusColor(dominantBucket) ?? fgMuted;
   $: shouldRender = statusLabel !== "" || $lifecycleEntry !== undefined;
 
   function handleClick() {

--- a/src/lib/services/agent-status-service.ts
+++ b/src/lib/services/agent-status-service.ts
@@ -9,7 +9,7 @@
  */
 
 import type { AgentState } from "./agent-state";
-import type { BotHatStatus } from "../utils/bot-hat-color";
+import type { BotStatus } from "../utils/bot-status-color";
 
 export const AGENT_STATUS_SOURCE = "core:agent-status";
 
@@ -32,8 +32,8 @@ export function isActiveStatus(status: string): boolean {
 }
 
 /**
- * Map a single agent's status to its hat-equivalent color bucket. Mirrors
- * the precedence used by rail-attention's `computeRailBotStatus`:
+ * Map a single agent's status to its color bucket. Mirrors the
+ * precedence used by rail-attention's `computeRailBotStatus`:
  *
  *   - waiting              → attention (yellow)
  *   - running / active     → thinking  (green)
@@ -41,9 +41,9 @@ export function isActiveStatus(status: string): boolean {
  *   - anything else        → none      (no color)
  *
  * Used by inline agent rows so the bot icon next to each agent matches
- * the color of the rail's hat for that agent's bucket.
+ * the color of the rail's bot-status bubble for that agent's bucket.
  */
-export function agentStatusBucket(status: string): BotHatStatus {
+export function agentStatusBucket(status: string): BotStatus {
   if (status === "waiting") return "attention";
   if (status === "running" || status === "active") return "thinking";
   if (status === "idle" || status === "done") return "idle";

--- a/src/lib/utils/bot-status-color.ts
+++ b/src/lib/utils/bot-status-color.ts
@@ -1,17 +1,17 @@
 import { variantColor } from "../status-colors";
 
-export type BotHatStatus = "none" | "thinking" | "attention" | "idle";
+export type BotStatus = "none" | "thinking" | "attention" | "idle";
 
 const ATTENTION = variantColor("warning");
 const THINKING = variantColor("success");
 const IDLE = variantColor("muted");
 
 /**
- * Color for the rail "hat" overlay and the rail's top border when a
- * bot is present. Returns `null` for "none" so callers can branch on
- * "no hat painted at all".
+ * Color for the rail bot-status bubble overlay and any inline
+ * affordances that should agree with it. Returns `null` for `"none"`
+ * so callers can branch on "no bot signal painted at all".
  */
-export function botHatColor(status: BotHatStatus): string | null {
+export function botStatusColor(status: BotStatus): string | null {
   switch (status) {
     case "attention":
       return ATTENTION;


### PR DESCRIPTION
## Summary

- Replaces the in-row `.rail-bot-hat` cap on the workspace rail with an OS-style `.rail-bot-bubble` — an 8×8 circle absolutely positioned at `top: -6px` so it floats above the row.
- Bubble contributes nothing to layout flow, so workspace gaps stay constant regardless of bot status (idle / thinking / attention / none).
- Preserves the existing three-state color mapping and the pulse animation on `attention`.
- **Follow-up cleanup in this PR:** Renames `bot-hat-color.ts` → `bot-status-color.ts` (`BotHatStatus` → `BotStatus`, `botHatColor` → `botStatusColor`) now that the "hat" concept is gone. Drops the SidebarRail hat-era seam tinting (top border tinted to bot color) and the 12px stripe offset that skipped the in-row hat region. Workspace borders now read as the workspace's own (active accent or neutral theme border) regardless of bot activity; the active-descendant stripe spans the full row height.

Closes #143

## Test plan

- [ ] Pull the branch, run `npm run tauri dev`, and confirm the rail bot indicator now reads as a small round bubble floating above the rail rather than a hat sitting in-row.
- [ ] In a workspace with the rail visible, toggle `botStatus` through `idle → thinking → attention → none` (e.g. trigger a real agent activity flow). Confirm the bubble color steps correctly and that `attention` pulses.
- [ ] With multiple workspaces stacked, switch one between `none` and `attention` repeatedly and verify the gap between workspace rows does NOT change — the bubble's appearance/disappearance must be invisible to layout.
- [ ] Confirm the workspace's top border now stays in the workspace's own color (accent when active, neutral theme border otherwise) regardless of bot state — no more bot-tinted seam at the top of the rail row.
- [ ] Confirm the active-descendant stripe (1px accent line on container-mode rails with active children) spans the full height of the rail row when a bubble is present — no longer offset by 12px.
- [ ] Collapse the rail (narrow mode) and confirm the bubble still paints on top of the 4px rail stripe; expand it back to full width and confirm the bubble still paints in the right place.
- [ ] Click the close (×) and lock chips on a rail row while a bubble is visible — confirm clicks register (bubble's `pointer-events: none` should let them through).
- [ ] Run `npm test` — expect 2155/2155 passing including the six new AC-numbered bubble tests in `drag-grip.test.ts`.
- [ ] Run `npm run build` — expect the `.app` bundle to build cleanly (DMG packaging may fail locally on dev machines without signing setup; that's unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)