### PR TITLE
fix(config): npm run dev honors ~/.config/gnar-term/gnar-term.json

### DIFF
--- a/src/__tests__/config-migration.test.ts
+++ b/src/__tests__/config-migration.test.ts
@@ -465,3 +465,221 @@ describe("loadConfig — config path policy (gnar-term.json canonical)", () => {
     expect(cfg.theme).toBe("project-wins");
   });
 });
+
+describe("loadConfig — debug builds fall back to prod config dir", () => {
+  const HOME = "/home/test";
+  const DEV_CONFIG_DIR = `${HOME}/.config/gnar-term-dev`;
+  const PROD_CONFIG_DIR = `${HOME}/.config/gnar-term`;
+
+  beforeEach(async () => {
+    vi.mocked(invoke).mockReset();
+    const { resetConfigDirForTests, resetIsDebugBuildForTests } =
+      await import("../lib/services/service-helpers");
+    resetConfigDirForTests();
+    resetIsDebugBuildForTests();
+    resetConfigStateForTests();
+  });
+
+  function mockEnv(opts: {
+    debug: boolean;
+    configDir: string;
+    files: Record<string, string>;
+  }) {
+    vi.mocked(invoke).mockImplementation(
+      async (cmd: string, args?: unknown) => {
+        if (cmd === "get_home") return HOME;
+        if (cmd === "get_global_config_dir") return opts.configDir;
+        if (cmd === "is_debug_build") return opts.debug;
+        if (cmd === "ensure_dir") return null;
+        if (cmd === "read_file") {
+          const path = (args as { path: string }).path;
+          if (opts.files[path] !== undefined) return opts.files[path];
+          throw new Error(`ENOENT: ${path}`);
+        }
+        if (cmd === "write_file") return null;
+        return null;
+      },
+    );
+  }
+
+  it("debug build with empty dev dir loads prod gnar-term.json", async () => {
+    mockEnv({
+      debug: true,
+      configDir: DEV_CONFIG_DIR,
+      files: {
+        [`${PROD_CONFIG_DIR}/gnar-term.json`]: JSON.stringify({
+          theme: "prod-theme",
+          autoload: ["prod-ws"],
+        }),
+      },
+    });
+    const cfg = await loadConfig();
+    expect(cfg.theme).toBe("prod-theme");
+    expect(cfg.autoload).toEqual(["prod-ws"]);
+  });
+
+  it("debug build saves stay in dev dir even when prod config was loaded", async () => {
+    mockEnv({
+      debug: true,
+      configDir: DEV_CONFIG_DIR,
+      files: {
+        [`${PROD_CONFIG_DIR}/gnar-term.json`]: JSON.stringify({
+          theme: "prod-theme",
+        }),
+      },
+    });
+    await loadConfig();
+    await saveConfig({ theme: "changed-in-dev" });
+
+    const writes = vi
+      .mocked(invoke)
+      .mock.calls.filter(([cmd]) => cmd === "write_file")
+      .map(([, args]) => (args as { path: string }).path);
+    expect(writes).toContain(`${DEV_CONFIG_DIR}/gnar-term.json`);
+    expect(writes).not.toContain(`${PROD_CONFIG_DIR}/gnar-term.json`);
+  });
+
+  it("debug build prefers dev-dir gnar-term.json over prod when both exist", async () => {
+    mockEnv({
+      debug: true,
+      configDir: DEV_CONFIG_DIR,
+      files: {
+        [`${DEV_CONFIG_DIR}/gnar-term.json`]: JSON.stringify({
+          theme: "dev-wins",
+        }),
+        [`${PROD_CONFIG_DIR}/gnar-term.json`]: JSON.stringify({
+          theme: "prod-loses",
+        }),
+      },
+    });
+    const cfg = await loadConfig();
+    expect(cfg.theme).toBe("dev-wins");
+  });
+
+  it("release build does NOT fall back — prod path is already the canonical configDir", async () => {
+    // In release builds configDir === PROD_CONFIG_DIR, so the prod entry is
+    // already in the canonical candidate list. The fallback block must not
+    // run (and must not duplicate-write to gnar-term.json on save).
+    mockEnv({
+      debug: false,
+      configDir: PROD_CONFIG_DIR,
+      files: {
+        [`${PROD_CONFIG_DIR}/gnar-term.json`]: JSON.stringify({
+          theme: "release",
+        }),
+      },
+    });
+    const cfg = await loadConfig();
+    expect(cfg.theme).toBe("release");
+
+    await saveConfig({ theme: "release2" });
+    const writes = vi
+      .mocked(invoke)
+      .mock.calls.filter(([cmd]) => cmd === "write_file")
+      .map(([, args]) => (args as { path: string }).path);
+    expect(writes).toContain(`${PROD_CONFIG_DIR}/gnar-term.json`);
+  });
+});
+
+describe("loadState — debug builds fall back to prod state.json", () => {
+  const HOME = "/home/test";
+  const DEV_CONFIG_DIR = `${HOME}/.config/gnar-term-dev`;
+  const PROD_CONFIG_DIR = `${HOME}/.config/gnar-term`;
+
+  beforeEach(async () => {
+    vi.mocked(invoke).mockReset();
+    const { resetConfigDirForTests, resetIsDebugBuildForTests } =
+      await import("../lib/services/service-helpers");
+    resetConfigDirForTests();
+    resetIsDebugBuildForTests();
+    resetConfigStateForTests();
+  });
+
+  function mockEnv(opts: {
+    debug: boolean;
+    configDir: string;
+    files: Record<string, string>;
+  }) {
+    vi.mocked(invoke).mockImplementation(
+      async (cmd: string, args?: unknown) => {
+        if (cmd === "get_home") return HOME;
+        if (cmd === "get_global_config_dir") return opts.configDir;
+        if (cmd === "is_debug_build") return opts.debug;
+        if (cmd === "ensure_dir") return null;
+        if (cmd === "read_file") {
+          const path = (args as { path: string }).path;
+          if (opts.files[path] !== undefined) return opts.files[path];
+          throw new Error(`ENOENT: ${path}`);
+        }
+        if (cmd === "write_file") return null;
+        return null;
+      },
+    );
+  }
+
+  it("debug build with no dev state.json reads prod state.json", async () => {
+    const { loadState } = await import("../lib/config");
+    mockEnv({
+      debug: true,
+      configDir: DEV_CONFIG_DIR,
+      files: {
+        [`${PROD_CONFIG_DIR}/state.json`]: JSON.stringify({
+          workspaces: [
+            {
+              name: "from-prod",
+              layout: { pane: { surfaces: [{ type: "terminal" }] } },
+            },
+          ],
+        }),
+      },
+    });
+    const state = await loadState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces![0].name).toBe("from-prod");
+  });
+
+  it("debug build prefers dev state.json when both exist", async () => {
+    const { loadState } = await import("../lib/config");
+    mockEnv({
+      debug: true,
+      configDir: DEV_CONFIG_DIR,
+      files: {
+        [`${DEV_CONFIG_DIR}/state.json`]: JSON.stringify({
+          workspaces: [
+            { name: "from-dev", layout: { pane: { surfaces: [] } } },
+          ],
+        }),
+        [`${PROD_CONFIG_DIR}/state.json`]: JSON.stringify({
+          workspaces: [
+            { name: "from-prod", layout: { pane: { surfaces: [] } } },
+          ],
+        }),
+      },
+    });
+    const state = await loadState();
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces![0].name).toBe("from-dev");
+  });
+
+  it("release build does NOT fall back to a different path", async () => {
+    const { loadState } = await import("../lib/config");
+    mockEnv({
+      debug: false,
+      configDir: PROD_CONFIG_DIR,
+      files: {
+        [`${PROD_CONFIG_DIR}/state.json`]: JSON.stringify({
+          workspaces: [{ name: "release", layout: { pane: { surfaces: [] } } }],
+        }),
+      },
+    });
+    const state = await loadState();
+    expect(state.workspaces![0].name).toBe("release");
+
+    // Only one read path attempted (no fallback dance).
+    const reads = vi
+      .mocked(invoke)
+      .mock.calls.filter(([cmd]) => cmd === "read_file")
+      .map(([, args]) => (args as { path: string }).path);
+    expect(reads).toEqual([`${PROD_CONFIG_DIR}/state.json`]);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,11 +11,22 @@
  *
  * Runtime state:
  *   ~/.config/gnar-term/state.json      (written on quit, restored on launch)
+ *
+ * Debug builds (`npm run dev`, `tauri build --debug`) use
+ * `~/.config/gnar-term-dev/` for both config and state so dev runs cannot
+ * clobber a user's real install. On first launch the dev dir is empty,
+ * which would otherwise hide the user's prod config — so `loadConfig` and
+ * `loadState` fall back to reading the prod paths when the dev dir has no
+ * equivalent. Writes always stay in the dev dir.
  */
 
 import { invoke } from "@tauri-apps/api/core";
 import { writable, type Readable } from "svelte/store";
-import { getHome, getConfigDir } from "./services/service-helpers";
+import {
+  getHome,
+  getConfigDir,
+  isDebugBuild,
+} from "./services/service-helpers";
 import type { ThemeDef } from "./theme-data";
 import { migrateAgentsConfig, type AgentPreset } from "./agents-config";
 
@@ -396,7 +407,11 @@ export async function loadConfig(
     }
   }
 
-  const [home, configDir] = await Promise.all([getHome(), getConfigDir()]);
+  const [home, configDir, debug] = await Promise.all([
+    getHome(),
+    getConfigDir(),
+    isDebugBuild(),
+  ]);
 
   // Try per-project config first (higher priority), then global. Each
   // entry is `{ read, writeForward? }`: `read` is the file we try to
@@ -418,6 +433,32 @@ export async function loadConfig(
       writeForward: `${configDir}/gnar-term.json`,
     },
   ];
+
+  // Debug builds (`npm run dev`, `tauri build --debug`) read state and
+  // config from `~/.config/gnar-term-dev/` to keep dev runs isolated from
+  // the user's real prod install. That isolation is desirable for writes
+  // — we never want a dev run to clobber the prod config — but a brand-new
+  // dev dir means the user's existing prod `gnar-term.json` is invisible,
+  // and `npm run dev` boots into an empty default workspace instead of
+  // honoring their autoload/theme/commands. Fix: when nothing matched in
+  // the dev dir, fall back to reading the prod paths. `writeForward` is
+  // pinned to the dev `configDir` so the next save still lands in the
+  // dev dir — prod stays untouched.
+  if (debug) {
+    const prodConfigDir = `${home}/.config/gnar-term`;
+    if (prodConfigDir !== configDir) {
+      candidates.push(
+        {
+          read: `${prodConfigDir}/gnar-term.json`,
+          writeForward: `${configDir}/gnar-term.json`,
+        },
+        {
+          read: `${prodConfigDir}/cmux.json`,
+          writeForward: `${configDir}/gnar-term.json`,
+        },
+      );
+    }
+  }
 
   for (const { read, writeForward } of candidates) {
     // Read and parse are split so JSON.parse failures (file present but
@@ -517,17 +558,37 @@ export function resetConfigStateForTests(): void {
 }
 
 export async function loadState(): Promise<AppState> {
-  const configDir = await getConfigDir();
-  const path = `${configDir}/state.json`;
+  const [configDir, home, debug] = await Promise.all([
+    getConfigDir(),
+    getHome(),
+    isDebugBuild(),
+  ]);
+  const primary = `${configDir}/state.json`;
+  // Read candidates in priority order: dev dir first, then prod dir as a
+  // read-only fallback for debug builds. Writes always target `primary`.
+  // This mirrors the loadConfig fallback so a fresh dev install picks up
+  // the user's real session instead of booting empty.
+  const candidates: string[] = [primary];
+  if (debug) {
+    const prodPath = `${home}/.config/gnar-term/state.json`;
+    if (prodPath !== primary) candidates.push(prodPath);
+  }
+
   // Split read from parse so a corrupt state.json surfaces loudly instead
   // of looking like "no state file" — the latter triggers auto-default
   // Terminal which would then overwrite the user's persisted session on
   // the next saveState.
   _stateLoadCorrupt = false;
-  let content: string;
-  try {
-    content = await invoke<string>("read_file", { path });
-  } catch {
+  let content: string | null = null;
+  for (const path of candidates) {
+    try {
+      content = await invoke<string>("read_file", { path });
+      break;
+    } catch {
+      continue;
+    }
+  }
+  if (content === null) {
     _appState = {};
     _appStateStore.set(_appState);
     return _appState;
@@ -537,7 +598,7 @@ export async function loadState(): Promise<AppState> {
   } catch (err) {
     _stateLoadCorrupt = true;
     console.warn(
-      `[state] Failed to parse ${path}; refusing to overwrite until it is repaired. Falling back to empty state for this session.`,
+      `[state] Failed to parse state.json; refusing to overwrite until it is repaired. Falling back to empty state for this session.`,
       err,
     );
     _appState = {};


### PR DESCRIPTION
## Summary

Closes #145. Running `npm run dev` (or any debug build) now loads the user's real `~/.config/gnar-term/gnar-term.json` instead of booting into an empty default Terminal workspace.

### Why this was broken after #146

Debug builds isolate state under `~/.config/gnar-term-dev/` (see `global_config_dir()` in `fs_commands.rs`). That's correct policy for writes — we don't want a dev session to clobber a user's real config — but `loadConfig`/`loadState` only ever read from `configDir`, so the prod `gnar-term.json` was invisible. On first launch the dev dir is empty → `restoreWorkspaces` hits step 5 → auto-default Terminal at `$HOME` → that gets persisted to the dev `state.json` → every subsequent `npm run dev` restores the empty default.

From the user's POV: \"I have a gnar-term.json with theme + autoload + commands, and the dev build ignores it.\" From the AC of #145: \"Launch with an existing `~/.config/gnar-term/gnar-term.json` still loads that config\" — true for release, silently false for `npm run dev`.

### Fix

`src/lib/config.ts`:
- `loadConfig`: in debug builds, append `~/.config/gnar-term/gnar-term.json` (and legacy `cmux.json`) to the candidate list, both with `writeForward = ${devConfigDir}/gnar-term.json`. Reads use prod when dev dir is empty; the next save lands in the dev dir, so prod is read-only from the dev build's perspective.
- `loadState`: same pattern — try dev `state.json` first, fall back to prod `state.json` in debug builds. Writes always target dev.
- Release builds: `configDir` already equals the prod path, so the fallback block is a no-op. No behavioral change.

### Tests

`src/__tests__/config-migration.test.ts` adds 7 new cases (2137 total, all green):

- Debug build with empty dev dir loads prod `gnar-term.json`.
- Debug build with both dev and prod present prefers dev.
- Debug build saves stay in the dev dir even when prod config was the read source.
- Release build does not trigger the fallback (single-path read, save back to prod).
- Same three for `loadState`.

## Test plan

- [ ] `git checkout fix/dev-build-loads-prod-config`
- [ ] `rm -rf ~/.config/gnar-term-dev` (clean dev dir) — your prod `~/.config/gnar-term/gnar-term.json` is untouched.
- [ ] `npm run dev` — verify it boots into your real workspaces (autoload entries from prod `gnar-term.json` fire; theme matches; commands palette includes your commands).
- [ ] Quit, relaunch `npm run dev` — verify `~/.config/gnar-term-dev/state.json` got written (not prod's state.json) and the session resumes from the dev state file going forward.
- [ ] Verify prod `~/.config/gnar-term/gnar-term.json` and `state.json` mtimes are unchanged after the dev session.
- [ ] `npm test` — all green (2137).
- [ ] `npm run build` — succeeds.
- [ ] Release sanity: install/run a release build (or just confirm tests pass `release build does NOT fall back`). Prod path resolution is unchanged.

## Notes

- I parked the existing stale `~/.config/gnar-term-dev/state.json` (the one with the auto-default Terminal) at `~/.config/gnar-term-dev/state.json.stale-from-issue145` so the next dev launch picks up prod state. Delete that file whenever — it's only kept so the original symptom is recoverable for forensics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)