### PR TITLE
ci: disable nightly dev build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,9 @@ name: "Nightly"
 # and explicitly checks out `dev` to build.
 
 on:
-  schedule:
-    - cron: "0 8 * * *" # 08:00 UTC = 01:00 PT / 04:00 ET
+  # Nightly schedule disabled. Re-enable by uncommenting the schedule block.
+  # schedule:
+  #   - cron: "0 8 * * *" # 08:00 UTC = 01:00 PT / 04:00 ET
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Disables the automatic nightly build from the `dev` branch by commenting out the `schedule` (cron) trigger in `.github/workflows/nightly.yml`.

The workflow itself is preserved and can still be triggered manually via `workflow_dispatch`. Re-enabling automatic nightlies is a one-line uncomment.

## Test plan

- [ ] Confirm the `Nightly` scheduled run no longer appears in the Actions schedule (no cron trigger on the workflow)
- [ ] Confirm the `Nightly` workflow can still be triggered manually via **Run workflow** (workflow_dispatch) from the Actions tab
- [ ] Verify no other workflows reference or depend on the nightly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)