### PR TITLE
QoL from dev: drag interactions, bracketed paste, focus affordances, desktop notifications

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -119,6 +119,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +342,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -458,6 +602,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -848,6 +1001,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1059,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1053,6 +1254,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1365,6 +1579,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-notification",
  "tokio",
 ]
 
@@ -1474,6 +1689,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2033,6 +2254,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fd0110fd05744c3c904acf1a8ca624a721d75a35638f127cd5fb6b7ccfb1bf"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2446,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2567,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2390,6 +2640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2683,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2658,6 +2924,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2977,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2845,6 +3136,15 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -2908,6 +3208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,6 +3238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3431,6 +3760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,6 +4187,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,6 +4303,31 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4259,7 +4642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4321,6 +4716,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5483,6 +5889,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5575,4 +6042,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.1",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1"
 portable-pty = "0.9"
 clap = { version = "4", features = ["derive"] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-notification = "2"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "io-std", "sync", "time"] }
 
 [build-dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-destroy",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(AppState {
             ptys: Mutex::new(HashMap::new()),
             watch_flags: Mutex::new(HashMap::new()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,7 +97,13 @@ pub fn run() {
                 // Terminal surfaces override Cmd+C/V via attachCustomKeyEventHandler.
                 let cut = PredefinedMenuItem::cut(handle, None)?;
                 let copy = PredefinedMenuItem::copy(handle, None)?;
-                let paste = PredefinedMenuItem::paste(handle, None)?;
+                // Custom Paste (not PredefinedMenuItem::paste): the predefined
+                // item fires the native NSText paste, which bypasses xterm.js's
+                // bracketed-paste wrapping (\x1b[200~…\x1b[201~). TUIs like
+                // Claude Code rely on that wrapping to treat a multiline paste
+                // as one block; without it they submit on the first newline.
+                // We emit `menu-paste` and let the frontend route it by focus.
+                let paste = MenuItem::with_id(handle, "menu-paste", "Paste", true, Some("CmdOrCtrl+V"))?;
                 let select_all = PredefinedMenuItem::select_all(handle, None)?;
 
                 let edit_menu = Submenu::with_items(
@@ -155,6 +161,8 @@ pub fn run() {
                 let _ = app.emit("menu-cmd-palette", ());
             } else if id == "close-tab" {
                 let _ = app.emit("menu-close-tab", ());
+            } else if id == "menu-paste" {
+                let _ = app.emit("menu-paste", ());
             }
         })
         .run(tauri::generate_context!())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -14,7 +14,7 @@
 
   // Services
   import { createWorkspace, createWorkspaceFromDef, switchWorkspace, closeWorkspace, renameWorkspace, reorderWorkspaces, saveCurrentWorkspace } from "./lib/services/workspace-service";
-  import { splitPane, closePane, focusPane, reorderTab, focusDirection, flashFocusedPane, splitFromSidebar, togglePaneZoom } from "./lib/services/pane-service";
+  import { splitPane, closePane, focusPane, focusDirection, flashFocusedPane, splitFromSidebar, togglePaneZoom } from "./lib/services/pane-service";
   import { selectSurface, closeSurfaceById, newSurface, nextSurface, prevSurface, selectSurfaceByNumber, closeActiveSurface, openPreviewInPane, newSurfaceFromSidebar } from "./lib/services/surface-service";
   import { initMcpServer } from "./lib/services/mcp-server";
   import { confirmQuit } from "./lib/services/quit-confirmation-service";
@@ -288,7 +288,6 @@
           onSplitDown={(paneId) => splitPane(paneId, "vertical")}
           onClosePane={closePane}
           onFocusPane={focusPane}
-          onReorderTab={reorderTab}
         />
       {/each}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,7 @@
   // Services
   import { createWorkspace, createWorkspaceFromDef, switchWorkspace, closeWorkspace, renameWorkspace, reorderWorkspaces, saveCurrentWorkspace } from "./lib/services/workspace-service";
   import { splitPane, closePane, focusPane, focusDirection, flashFocusedPane, splitFromSidebar, togglePaneZoom } from "./lib/services/pane-service";
+  import { handleMenuPaste } from "./lib/services/menu-paste-router";
   import { selectSurface, closeSurfaceById, newSurface, nextSurface, prevSurface, selectSurfaceByNumber, closeActiveSurface, openPreviewInPane, newSurfaceFromSidebar } from "./lib/services/surface-service";
   import { initMcpServer } from "./lib/services/mcp-server";
   import { confirmQuit } from "./lib/services/quit-confirmation-service";
@@ -240,6 +241,12 @@
 
     await listen("menu-close-tab", () => {
       closeActiveSurface();
+    });
+
+    // Edit > Paste routes here so terminals get bracketed paste (the native
+    // paste bypasses xterm's \x1b[200~ wrapping, breaking multiline paste).
+    await listen("menu-paste", () => {
+      void handleMenuPaste();
     });
 
     // Don't tear down live PTYs silently — intercept the window close request

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -256,7 +256,7 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<div id="app" style="display: flex; height: 100vh; overflow: hidden;">
+<div id="app" style="display: flex; height: 100vh; overflow: hidden; --theme-accent: {$theme.accent}; --theme-fg-dim: {$theme.fgDim};">
   <Sidebar
     bind:this={sidebarComponent}
     onNewWorkspace={() => createWorkspace(`Workspace ${$workspaces.length + 1}`)}
@@ -300,3 +300,33 @@
 <ContextMenu />
 <InputPrompt />
 <ConfirmPrompt />
+
+<style>
+  /* xterm.js v6 ships an unstyled `.xterm-slider` thumb (its CSS depends on a
+     VSCode scrollbar-slider var we don't set), which leaves an empty rail with
+     no visible handle in terminal panes. Paint the thumb with the theme's
+     dimmed foreground and brighten on hover/active so it's discoverable. */
+  :global(.xterm-slider) {
+    background: var(--theme-fg-dim, rgba(255, 255, 255, 0.25));
+    border-radius: 4px;
+    opacity: 0.5;
+    transition: opacity 0.15s;
+  }
+  :global(.xterm-scrollable-element:hover .xterm-slider) {
+    opacity: 0.8;
+  }
+  :global(.xterm-slider:hover),
+  :global(.xterm-slider.active) {
+    opacity: 1;
+  }
+
+  /* Suppress the default focus outline but keep a visible keyboard ring on
+     :focus-visible, so mouse focus stays clean without losing a11y. */
+  :global(.no-default-outline) {
+    outline: none;
+  }
+  :global(.no-default-outline:focus-visible) {
+    outline: 2px solid var(--theme-accent, #7c6aff);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/__tests__/app-render.test.ts
+++ b/src/__tests__/app-render.test.ts
@@ -277,13 +277,15 @@ describe("Flash focused pane", () => {
 });
 
 describe("Tab drag reorder within pane", () => {
-  it("Tab.svelte has drag handlers", async () => {
+  it("Tab.svelte uses the mouse-driven drag (not HTML5 DnD, broken in WKWebView)", async () => {
     const fs = await import("fs");
     const source = fs.readFileSync("src/lib/components/Tab.svelte", "utf-8");
-    expect(source).toContain('draggable="true"');
-    expect(source).toContain("on:dragstart=");
-    expect(source).toContain("on:drop=");
-    expect(source).toContain("onReorder");
+    // HTML5 DnD was replaced by a mouse-event state machine.
+    expect(source).not.toContain('draggable="true"');
+    expect(source).toContain("startTabDrag");
+    expect(source).toContain("on:mousedown=");
+    expect(source).toContain("data-tab-surface-id");
+    expect(source).toContain("data-tab-idx");
   });
 
   it("pane-service has reorderTab", async () => {

--- a/src/__tests__/components.test.ts
+++ b/src/__tests__/components.test.ts
@@ -746,10 +746,12 @@ describe("WorkspaceItem", () => {
     expect(screen.getByText("Build complete")).toBeTruthy();
   });
 
-  it("is draggable", () => {
+  it("carries the reorder data-attr for the mouse-driven drag engine", () => {
+    // HTML5 `draggable` was replaced by a mouse-event reorder engine that
+    // keys off data-ws-drag-idx (WKWebView's HTML5 DnD is unreliable).
     const { container } = renderWorkspaceItem();
-    const draggable = container.querySelector("[draggable='true']");
-    expect(draggable).toBeTruthy();
+    expect(container.querySelector("[draggable='true']")).toBeNull();
+    expect(container.querySelector("[data-ws-drag-idx]")).toBeTruthy();
   });
 });
 

--- a/src/__tests__/desktop-notification.test.ts
+++ b/src/__tests__/desktop-notification.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Desktop-notification focus suppression — a terminal attention notification
+ * fires only when the user is NOT already looking at that surface. The
+ * foreground check keys off the active workspace + active pane + active
+ * surface, all on the splitRoot pane model.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted: vi.fn(async () => true),
+  requestPermission: vi.fn(async () => "granted"),
+  sendNotification: vi.fn(),
+}));
+
+import type {
+  Workspace,
+  Pane,
+  Surface,
+  SplitNode,
+  TerminalSurface,
+} from "../lib/types";
+import { isSurfaceInForeground } from "../lib/terminal-service";
+
+function term(id: string): TerminalSurface {
+  return {
+    kind: "terminal",
+    id,
+    terminal: {} as any,
+    fitAddon: {} as any,
+    searchAddon: {} as any,
+    termElement: document.createElement("div"),
+    ptyId: 1,
+    title: id,
+    hasUnread: false,
+    opened: true,
+  };
+}
+
+function pane(id: string, surfaces: Surface[], activeSurfaceId: string): Pane {
+  return { id, surfaces, activeSurfaceId };
+}
+
+// Workspace: split of p1 (active, showing s1; s2 hidden) | p2 (showing s3).
+function makeWs(id: string, activePaneId: string): Workspace {
+  const splitRoot: SplitNode = {
+    type: "split",
+    direction: "horizontal",
+    ratio: 0.5,
+    children: [
+      { type: "pane", pane: pane("p1", [term("s1"), term("s2")], "s1") },
+      { type: "pane", pane: pane("p2", [term("s3")], "s3") },
+    ],
+  };
+  return { id, name: id, splitRoot, activePaneId };
+}
+
+describe("isSurfaceInForeground", () => {
+  it("true: active surface in the active pane of the active workspace", () => {
+    const ws = makeWs("ws1", "p1");
+    expect(isSurfaceInForeground(ws, ws, "s1")).toBe(true);
+  });
+
+  it("false: surface is in the active pane but not its active tab", () => {
+    const ws = makeWs("ws1", "p1");
+    expect(isSurfaceInForeground(ws, ws, "s2")).toBe(false);
+  });
+
+  it("false: surface is the active tab of a non-focused pane", () => {
+    const ws = makeWs("ws1", "p1"); // p1 focused, so p2's s3 is background
+    expect(isSurfaceInForeground(ws, ws, "s3")).toBe(false);
+  });
+
+  it("false: workspace is not the active workspace", () => {
+    const ws = makeWs("ws1", "p1");
+    const otherActive = makeWs("ws2", "p1");
+    expect(isSurfaceInForeground(ws, otherActive, "s1")).toBe(false);
+  });
+
+  it("false: no active workspace at all", () => {
+    const ws = makeWs("ws1", "p1");
+    expect(isSurfaceInForeground(ws, null, "s1")).toBe(false);
+  });
+});

--- a/src/__tests__/drag-reorder.test.ts
+++ b/src/__tests__/drag-reorder.test.ts
@@ -1,0 +1,145 @@
+/**
+ * drag-reorder engine tests — the mouse-driven replacement for HTML5 DnD
+ * (which is unreliable in Tauri's WKWebView). Verifies the activation
+ * threshold, drop-index math (before/after edge), and Escape-to-cancel.
+ *
+ * jsdom returns zeroed getBoundingClientRect/elementFromPoint, so we stub
+ * a 3-row vertical list and drive the cursor by Y coordinate.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createDragReorder } from "../lib/actions/drag-reorder";
+
+const ROW_H = 20;
+
+function buildList(): HTMLElement {
+  const container = document.createElement("div");
+  container.className = "workspace-list";
+  for (let i = 0; i < 3; i++) {
+    const row = document.createElement("div");
+    row.setAttribute("data-ws-drag-idx", String(i));
+    Object.defineProperty(row, "offsetHeight", {
+      value: ROW_H,
+      configurable: true,
+    });
+    Object.defineProperty(row, "offsetWidth", {
+      value: 100,
+      configurable: true,
+    });
+    row.getBoundingClientRect = () =>
+      ({
+        top: i * ROW_H,
+        bottom: (i + 1) * ROW_H,
+        left: 0,
+        right: 100,
+        height: ROW_H,
+        width: 100,
+        x: 0,
+        y: i * ROW_H,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    container.appendChild(row);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+function rowAtY(container: HTMLElement, y: number): HTMLElement | null {
+  const rows = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-ws-drag-idx]"),
+  );
+  return (
+    rows.find((r) => {
+      const rect = r.getBoundingClientRect();
+      return y >= rect.top && y < rect.bottom;
+    }) ?? null
+  );
+}
+
+describe("createDragReorder", () => {
+  let container: HTMLElement;
+  let onDrop: ReturnType<typeof vi.fn>;
+  let handle: ReturnType<typeof createDragReorder>;
+
+  beforeEach(() => {
+    container = buildList();
+    onDrop = vi.fn();
+    handle = createDragReorder({
+      dataAttr: "ws-drag-idx",
+      containerSelector: ".workspace-list",
+      ghostStyle: () => ({ background: "#000", border: "1px solid #fff" }),
+      onDrop,
+    });
+    document.elementFromPoint = ((x: number, y: number) =>
+      rowAtY(container, y)) as typeof document.elementFromPoint;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  function startDrag(idx: number) {
+    const row =
+      container.querySelectorAll<HTMLElement>("[data-ws-drag-idx]")[idx];
+    const e = new MouseEvent("mousedown", {
+      button: 0,
+      clientX: 50,
+      clientY: idx * ROW_H + 10,
+      bubbles: true,
+    });
+    Object.defineProperty(e, "target", { value: row });
+    handle.start(e, idx);
+  }
+
+  function move(x: number, y: number) {
+    window.dispatchEvent(
+      new MouseEvent("mousemove", { clientX: x, clientY: y }),
+    );
+  }
+  function up() {
+    window.dispatchEvent(new MouseEvent("mouseup"));
+  }
+
+  it("does not start a drag below the 5px threshold", () => {
+    startDrag(0);
+    move(52, 12); // <5px total from (50,10)
+    up();
+    expect(handle.getState().active).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("drops row 0 after the last row → onDrop(0, 3)", () => {
+    startDrag(0);
+    move(60, 30); // activate (>5px)
+    move(60, 55); // bottom half of row 2 → after
+    up();
+    expect(onDrop).toHaveBeenCalledWith(0, 3);
+  });
+
+  it("drops row 2 before row 0 → onDrop(2, 0)", () => {
+    startDrag(2);
+    move(60, 30); // activate
+    move(60, 2); // top half of row 0 → before
+    up();
+    expect(onDrop).toHaveBeenCalledWith(2, 0);
+  });
+
+  it("does not fire onDrop when the drop resolves to the same slot", () => {
+    startDrag(1);
+    move(60, 35); // activate, within row 1
+    move(60, 22); // top half of row 1 → before idx 1 → to=1 === from
+    up();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("Escape cancels the drag without firing onDrop", () => {
+    startDrag(0);
+    move(60, 30); // activate
+    move(60, 55);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handle.getState().active).toBe(false);
+    up();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/drag-resize.test.ts
+++ b/src/__tests__/drag-resize.test.ts
@@ -1,0 +1,74 @@
+/**
+ * drag-resize action tests — verify the drag lifecycle and, critically, that a
+ * mid-drag unmount (destroy() while the user is still dragging) releases the
+ * window-level listeners so onDrag never fires against a stale closure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { dragResize } from "../lib/actions/drag-resize";
+
+function mousedown() {
+  return new MouseEvent("mousedown", { bubbles: true });
+}
+function mousemove(clientX = 50) {
+  return new MouseEvent("mousemove", { clientX, bubbles: true });
+}
+function mouseup() {
+  return new MouseEvent("mouseup", { bubbles: true });
+}
+
+describe("dragResize action", () => {
+  let node: HTMLElement;
+
+  beforeEach(() => {
+    node = document.createElement("div");
+    document.body.appendChild(node);
+  });
+
+  it("calls onDrag on mousemove during an active drag", () => {
+    const onDrag = vi.fn();
+    dragResize(node, { onDrag });
+
+    node.dispatchEvent(mousedown());
+    window.dispatchEvent(mousemove());
+    expect(onDrag).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onEnd and stops onDrag after mouseup", () => {
+    const onDrag = vi.fn();
+    const onEnd = vi.fn();
+    dragResize(node, { onDrag, onEnd });
+
+    node.dispatchEvent(mousedown());
+    window.dispatchEvent(mousemove());
+    window.dispatchEvent(mouseup());
+    expect(onEnd).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(mousemove());
+    expect(onDrag).toHaveBeenCalledTimes(1); // no further calls after mouseup
+  });
+
+  it("respects onStart returning false (no drag begins)", () => {
+    const onDrag = vi.fn();
+    dragResize(node, { onDrag, onStart: () => false });
+
+    node.dispatchEvent(mousedown());
+    window.dispatchEvent(mousemove());
+    expect(onDrag).not.toHaveBeenCalled();
+  });
+
+  it("releases listeners when destroyed mid-drag (no stale onDrag)", () => {
+    const onDrag = vi.fn();
+    const handle = dragResize(node, { onDrag });
+
+    node.dispatchEvent(mousedown());
+    window.dispatchEvent(mousemove());
+    expect(onDrag).toHaveBeenCalledTimes(1);
+
+    // Host element unmounts while the drag is still in flight.
+    handle.destroy();
+
+    window.dispatchEvent(mousemove());
+    expect(onDrag).toHaveBeenCalledTimes(1); // listener was torn down
+  });
+});

--- a/src/__tests__/menu-paste.test.ts
+++ b/src/__tests__/menu-paste.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Menu paste router tests — the Edit > Paste menu item emits `menu-paste` and
+ * the router pastes by focus. The key behavior: a focused terminal receives
+ * `terminal.paste(text)` (which applies xterm's bracketed-paste wrapping) so
+ * multiline pastes into TUIs like Claude Code arrive as one block instead of
+ * submitting on the first newline.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const clip = vi.hoisted(() => ({ text: "line1\nline2" }));
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn(async () => clip.text),
+}));
+
+import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
+import type { Workspace, Pane, TerminalSurface } from "../lib/types";
+import { handleMenuPaste } from "../lib/services/menu-paste-router";
+
+function makeTerminalSurface(termElement: HTMLElement): TerminalSurface {
+  return {
+    kind: "terminal",
+    id: "s1",
+    terminal: { paste: vi.fn() } as any,
+    fitAddon: {} as any,
+    searchAddon: {} as any,
+    termElement,
+    ptyId: 7,
+    title: "shell",
+    hasUnread: false,
+    opened: true,
+  };
+}
+
+function setWorkspace(surface: TerminalSurface) {
+  const pane: Pane = {
+    id: "p1",
+    surfaces: [surface],
+    activeSurfaceId: surface.id,
+  };
+  const ws: Workspace = {
+    id: "ws1",
+    name: "ws",
+    splitRoot: { type: "pane", pane },
+    activePaneId: "p1",
+  };
+  workspaces.set([ws]);
+  activeWorkspaceIdx.set(0);
+}
+
+describe("handleMenuPaste", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    clip.text = "line1\nline2";
+  });
+
+  it("pastes into the focused terminal via terminal.paste (bracketed)", async () => {
+    // xterm's helper textarea lives inside termElement; focusing it means the
+    // active element is contained by the surface.
+    const termEl = document.createElement("div");
+    const helper = document.createElement("textarea");
+    termEl.appendChild(helper);
+    document.body.appendChild(termEl);
+    const surface = makeTerminalSurface(termEl);
+    setWorkspace(surface);
+    helper.focus();
+
+    await handleMenuPaste();
+
+    expect(surface.terminal.paste).toHaveBeenCalledWith("line1\nline2");
+  });
+
+  it("does not paste when the terminal is disconnected (ptyId < 0)", async () => {
+    const termEl = document.createElement("div");
+    const helper = document.createElement("textarea");
+    termEl.appendChild(helper);
+    document.body.appendChild(termEl);
+    const surface = makeTerminalSurface(termEl);
+    surface.ptyId = -1;
+    setWorkspace(surface);
+    helper.focus();
+
+    await handleMenuPaste();
+
+    expect(surface.terminal.paste).not.toHaveBeenCalled();
+  });
+
+  it("splices into a focused textarea (not a terminal), preserving newlines", async () => {
+    const termEl = document.createElement("div");
+    document.body.appendChild(termEl);
+    setWorkspace(makeTerminalSurface(termEl));
+
+    const input = document.createElement("textarea");
+    input.value = "ab";
+    document.body.appendChild(input);
+    input.focus();
+    input.setSelectionRange(1, 1); // cursor between a|b
+
+    await handleMenuPaste();
+
+    expect(input.value).toBe("aline1\nline2b");
+  });
+
+  it("is a no-op when the clipboard is empty", async () => {
+    clip.text = "";
+    const termEl = document.createElement("div");
+    const helper = document.createElement("textarea");
+    termEl.appendChild(helper);
+    document.body.appendChild(termEl);
+    const surface = makeTerminalSurface(termEl);
+    setWorkspace(surface);
+    helper.focus();
+
+    await handleMenuPaste();
+
+    expect(surface.terminal.paste).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/tab-drag.test.ts
+++ b/src/__tests__/tab-drag.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tab drag-and-drop tests — verify the pane-service mutations that back the
+ * mouse-driven tab drag (cross-pane merge, directional surface-split, source
+ * collapse) and that commitTabDrop dispatches to the right one.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../lib/config", () => ({
+  getConfig: () => ({}),
+  saveConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { workspaces, activeWorkspaceIdx } from "../lib/stores/workspace";
+import type {
+  Workspace,
+  Pane,
+  Surface,
+  SplitNode,
+  TerminalSurface,
+} from "../lib/types";
+import { getAllPanes, findPaneInWorkspace } from "../lib/types";
+import {
+  mergeTabToPane,
+  splitPaneWithSurface,
+} from "../lib/services/pane-service";
+import {
+  commitTabDrop,
+  __setTabDropTargetForTest,
+} from "../lib/services/tab-drag";
+
+function term(id: string): TerminalSurface {
+  return {
+    kind: "terminal",
+    id,
+    terminal: { focus: vi.fn() } as any,
+    fitAddon: {} as any,
+    searchAddon: {} as any,
+    termElement: document.createElement("div"),
+    ptyId: 1,
+    title: id,
+    hasUnread: false,
+    opened: true,
+  };
+}
+
+function pane(id: string, surfaces: Surface[]): Pane {
+  return { id, surfaces, activeSurfaceId: surfaces[0]?.id ?? null };
+}
+
+// Workspace: horizontal split of p1 [s1, s2] | p2 [s3].
+function buildWorkspace(): Workspace {
+  const splitRoot: SplitNode = {
+    type: "split",
+    direction: "horizontal",
+    ratio: 0.5,
+    children: [
+      { type: "pane", pane: pane("p1", [term("s1"), term("s2")]) },
+      { type: "pane", pane: pane("p2", [term("s3")]) },
+    ],
+  };
+  return { id: "ws1", name: "ws", splitRoot, activePaneId: "p1" };
+}
+
+beforeEach(() => {
+  workspaces.set([buildWorkspace()]);
+  activeWorkspaceIdx.set(0);
+});
+
+describe("mergeTabToPane", () => {
+  it("moves a surface into the target pane's tab list and activates it", () => {
+    mergeTabToPane("s2", "p1", "p2");
+    const ws = get(workspaces)[0];
+    const p1 = findPaneInWorkspace(ws, "p1")!;
+    const p2 = findPaneInWorkspace(ws, "p2")!;
+    expect(p1.surfaces.map((s) => s.id)).toEqual(["s1"]);
+    expect(p2.surfaces.map((s) => s.id)).toEqual(["s3", "s2"]);
+    expect(p2.activeSurfaceId).toBe("s2");
+    expect(ws.activePaneId).toBe("p2");
+  });
+
+  it("collapses the source pane when the move empties it", () => {
+    // p2 holds only s3 — merging it into p1 empties p2, collapsing the split.
+    mergeTabToPane("s3", "p2", "p1");
+    const ws = get(workspaces)[0];
+    expect(ws.splitRoot.type).toBe("pane");
+    if (ws.splitRoot.type === "pane") {
+      expect(ws.splitRoot.pane.id).toBe("p1");
+      expect(ws.splitRoot.pane.surfaces.map((s) => s.id)).toEqual([
+        "s1",
+        "s2",
+        "s3",
+      ]);
+    }
+    expect(getAllPanes(ws.splitRoot)).toHaveLength(1);
+  });
+
+  it("is a no-op when source and target are the same pane", () => {
+    mergeTabToPane("s1", "p1", "p1");
+    const ws = get(workspaces)[0];
+    expect(findPaneInWorkspace(ws, "p1")!.surfaces.map((s) => s.id)).toEqual([
+      "s1",
+      "s2",
+    ]);
+  });
+});
+
+describe("splitPaneWithSurface", () => {
+  it("splits the target pane, placing the dragged surface in a new pane (after)", () => {
+    splitPaneWithSurface("s1", "p1", "p2", "vertical", false);
+    const ws = get(workspaces)[0];
+    // p1 keeps s2; a new pane holding s1 now sits below p2.
+    expect(findPaneInWorkspace(ws, "p1")!.surfaces.map((s) => s.id)).toEqual([
+      "s2",
+    ]);
+    const panes = getAllPanes(ws.splitRoot);
+    const newPane = panes.find((p) => p.surfaces.some((s) => s.id === "s1"));
+    expect(newPane).toBeDefined();
+    expect(newPane!.id).not.toBe("p1");
+    expect(ws.activePaneId).toBe(newPane!.id);
+  });
+
+  it("honors before=true for top/left drops (new pane first)", () => {
+    splitPaneWithSurface("s1", "p1", "p2", "horizontal", true);
+    const ws = get(workspaces)[0];
+    // Find the split node whose target is p2 and confirm the new pane is child 0.
+    const panes = getAllPanes(ws.splitRoot);
+    const newPane = panes.find((p) => p.surfaces.some((s) => s.id === "s1"))!;
+    function findSplitContaining(
+      node: SplitNode,
+      id: string,
+    ): (SplitNode & { type: "split" }) | null {
+      if (node.type === "pane") return null;
+      const hit = node.children.some(
+        (c) => c.type === "pane" && c.pane.id === id,
+      );
+      if (hit) return node;
+      return (
+        findSplitContaining(node.children[0], id) ||
+        findSplitContaining(node.children[1], id)
+      );
+    }
+    const split = findSplitContaining(ws.splitRoot, newPane.id)!;
+    expect(split.children[0].type === "pane" && split.children[0].pane.id).toBe(
+      newPane.id,
+    );
+  });
+});
+
+describe("commitTabDrop dispatch", () => {
+  it("dispatches a merge drop target to mergeTabToPane", () => {
+    __setTabDropTargetForTest({
+      surfaceId: "s2",
+      sourcePaneId: "p1",
+      sourceWorkspaceId: "ws1",
+      position: { x: 0, y: 0 },
+      dropTarget: { kind: "merge", paneId: "p2" },
+    });
+    commitTabDrop();
+    const ws = get(workspaces)[0];
+    expect(findPaneInWorkspace(ws, "p2")!.surfaces.map((s) => s.id)).toEqual([
+      "s3",
+      "s2",
+    ]);
+  });
+
+  it("dispatches a surface-split drop target to splitPaneWithSurface", () => {
+    __setTabDropTargetForTest({
+      surfaceId: "s1",
+      sourcePaneId: "p1",
+      sourceWorkspaceId: "ws1",
+      position: { x: 0, y: 0 },
+      dropTarget: { kind: "surface-split", paneId: "p2", zone: "right" },
+    });
+    commitTabDrop();
+    const ws = get(workspaces)[0];
+    const newPane = getAllPanes(ws.splitRoot).find((p) =>
+      p.surfaces.some((s) => s.id === "s1"),
+    )!;
+    expect(newPane.id).not.toBe("p1");
+  });
+
+  it("is a no-op when there is no drop target", () => {
+    __setTabDropTargetForTest(null);
+    commitTabDrop();
+    const ws = get(workspaces)[0];
+    expect(getAllPanes(ws.splitRoot).map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
+});

--- a/src/lib/actions/drag-reorder.ts
+++ b/src/lib/actions/drag-reorder.ts
@@ -1,0 +1,228 @@
+/**
+ * Shared drag-to-reorder logic for sidebar lists.
+ *
+ * Creates mouse-driven drag state (HTML5 DnD is broken in Tauri WKWebView —
+ * drags can stall mid-flight or never fire `dragend`). Each instance tracks
+ * its own ghost element, insert indicator, and drag state. The caller
+ * provides: a data attribute selector, ghost styling, and an onDrop callback.
+ */
+
+export interface DragReorderConfig {
+  /** The data attribute used on draggable items, e.g. "drag-idx" → `[data-drag-idx]` */
+  dataAttr: string;
+  /** Container selector for keeping the indicator alive when inside the sidebar */
+  containerSelector: string;
+  /** Return ghost element background/border colors */
+  ghostStyle: () => {
+    background: string;
+    border: string;
+  };
+  /** Called when a valid drop occurs */
+  onDrop: (fromIdx: number, toIdx: number) => void;
+  /** Optional precondition — if provided, must return true for drag to start */
+  canStart?: () => boolean;
+  /**
+   * Optional callback fired on every state transition (start, move, drop,
+   * cancel). Svelte consumers use this to re-read `getState()` and mirror
+   * into reactive state — without it, Escape-to-cancel would leave the UI
+   * stuck until the next mouse event.
+   */
+  onStateChange?: () => void;
+}
+
+export interface DragReorderState {
+  sourceIdx: number | null;
+  indicator: { idx: number; edge: "before" | "after" } | null;
+  active: boolean;
+  /** Height of the source element at drag start, in pixels. Consumers
+   *  use this to render a ghost placeholder matching the source size
+   *  at the drop target — so the drag preview matches the drop result. */
+  sourceHeight: number;
+}
+
+export interface DragReorderHandle {
+  /** Call from mousedown on a draggable item */
+  start: (e: MouseEvent, idx: number) => void;
+  /** Reactive state — read these to render indicators and opacity */
+  getState: () => DragReorderState;
+}
+
+export function createDragReorder(
+  config: DragReorderConfig,
+): DragReorderHandle {
+  const selector = `[data-${config.dataAttr}]`;
+  const dataKey = config.dataAttr.replace(/-([a-z])/g, (_, c) =>
+    c.toUpperCase(),
+  );
+
+  let sourceIdx: number | null = null;
+  let indicator: { idx: number; edge: "before" | "after" } | null = null;
+  let active = false;
+  let sourceHeight = 0;
+  let ghostEl: HTMLElement | null = null;
+  /** The specific container element the drag started in. Captured at
+   *  drag-start and used to scope querySelectorAll during move so a
+   *  drag in one list never picks up items from another. */
+  let sourceContainer: HTMLElement | null = null;
+
+  function onDragMove(e: MouseEvent) {
+    if (sourceIdx === null) return;
+    if (ghostEl) {
+      ghostEl.style.left = e.clientX + 8 + "px";
+      ghostEl.style.top = e.clientY - 12 + "px";
+    }
+    const prev = indicator;
+
+    // Gather visible items in THIS drop zone, scoped to the specific
+    // container the drag started in. Using the source's captured
+    // container (not a global querySelector) keeps separate lists from
+    // leaking into one another.
+    const items = sourceContainer
+      ? Array.from(
+          sourceContainer.querySelectorAll<HTMLElement>(selector),
+        ).filter((el) => {
+          const r = el.getBoundingClientRect();
+          return r.height > 0 && r.width > 0;
+        })
+      : [];
+
+    if (items.length > 0) {
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const firstRect = first.getBoundingClientRect();
+      const lastRect = last.getBoundingClientRect();
+      const firstIdx = parseInt(first.dataset[dataKey]!, 10);
+      const lastIdx = parseInt(last.dataset[dataKey]!, 10);
+
+      if (e.clientY < firstRect.top) {
+        // Cursor is ABOVE the drop zone — park at the top slot.
+        indicator = { idx: firstIdx, edge: "before" };
+      } else if (e.clientY > lastRect.bottom) {
+        // Cursor is BELOW the drop zone — park at the bottom slot.
+        indicator = { idx: lastIdx, edge: "after" };
+      } else {
+        // Cursor is vertically inside the drop zone. Resolve to a
+        // specific item's before/after edge when possible; otherwise
+        // keep the last indicator (handles gaps between rows).
+        const el = document.elementFromPoint(e.clientX, e.clientY);
+        const item = el
+          ? ((el as HTMLElement).closest(selector) as HTMLElement | null)
+          : null;
+        if (item) {
+          const targetIdx = parseInt(item.dataset[dataKey]!, 10);
+          const rect = item.getBoundingClientRect();
+          const edge: "before" | "after" =
+            e.clientY - rect.top < rect.height / 2 ? "before" : "after";
+          indicator = { idx: targetIdx, edge };
+        }
+      }
+    }
+
+    if (prev?.idx !== indicator?.idx || prev?.edge !== indicator?.edge) {
+      config.onStateChange?.();
+    }
+  }
+
+  function teardownDrag() {
+    window.removeEventListener("mousemove", onDragMove);
+    window.removeEventListener("mouseup", onDragEnd);
+    window.removeEventListener("keydown", onKeyDown);
+    if (ghostEl) {
+      ghostEl.remove();
+      ghostEl = null;
+    }
+    sourceIdx = null;
+    indicator = null;
+    active = false;
+    sourceHeight = 0;
+    sourceContainer = null;
+    document.body.style.cursor = "";
+    config.onStateChange?.();
+  }
+
+  function onDragEnd() {
+    const from = sourceIdx;
+    const dropIndicator = indicator;
+    if (from !== null && dropIndicator) {
+      let to = dropIndicator.idx;
+      if (dropIndicator.edge === "after") to += 1;
+      if (from !== to) {
+        config.onDrop(from, to);
+      }
+    }
+    teardownDrag();
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      teardownDrag();
+    }
+  }
+
+  function start(e: MouseEvent, idx: number) {
+    if (e.button !== 0) return;
+    if (config.canStart && !config.canStart()) return;
+
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const originEl = (e.target as HTMLElement).closest(
+      selector,
+    ) as HTMLElement | null;
+
+    function onMove(ev: MouseEvent) {
+      if (Math.abs(ev.clientX - startX) + Math.abs(ev.clientY - startY) > 5) {
+        ev.preventDefault();
+        window.removeEventListener("mousemove", onMove);
+        window.removeEventListener("mouseup", onUpCancel);
+        sourceIdx = idx;
+        active = true;
+        sourceHeight = originEl?.offsetHeight ?? 0;
+        sourceContainer = (originEl?.closest(config.containerSelector) ??
+          null) as HTMLElement | null;
+        // Park the drop indicator at the source's own position so the
+        // ghost renders exactly where the dragged item used to be.
+        // Without this, the source hides on drag start and the list
+        // collapses by one row until the cursor enters a valid target.
+        indicator = { idx, edge: "before" };
+        document.body.style.cursor = "grabbing";
+        config.onStateChange?.();
+        if (originEl) {
+          ghostEl = originEl.cloneNode(true) as HTMLElement;
+          const { background, border } = config.ghostStyle();
+          Object.assign(ghostEl.style, {
+            position: "fixed",
+            zIndex: "99999",
+            pointerEvents: "none",
+            width: originEl.offsetWidth + "px",
+            opacity: "0.8",
+            background,
+            border,
+            borderRadius: "6px",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            left: ev.clientX + 8 + "px",
+            top: ev.clientY - 12 + "px",
+          });
+          document.body.appendChild(ghostEl);
+        }
+        window.addEventListener("mousemove", onDragMove);
+        window.addEventListener("mouseup", onDragEnd);
+        window.addEventListener("keydown", onKeyDown);
+      }
+    }
+
+    function onUpCancel() {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUpCancel);
+    }
+
+    e.preventDefault();
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUpCancel);
+  }
+
+  return {
+    start,
+    getState: () => ({ sourceIdx, indicator, active, sourceHeight }),
+  };
+}

--- a/src/lib/actions/drag-resize.ts
+++ b/src/lib/actions/drag-resize.ts
@@ -16,6 +16,11 @@ export interface DragResizeOptions {
 
 export function dragResize(node: HTMLElement, options: DragResizeOptions) {
   let opts = options;
+  // Tracks the teardown for an in-flight drag so a mid-drag unmount (the host
+  // element is removed while the user is still holding the divider) can release
+  // the window-level mousemove/mouseup listeners. Without this, an interrupted
+  // drag leaks listeners that fire onDrag against a stale closure.
+  let activeCleanup: (() => void) | null = null;
 
   function handleMousedown(e: MouseEvent) {
     if (opts.onStart) {
@@ -28,12 +33,18 @@ export function dragResize(node: HTMLElement, options: DragResizeOptions) {
       opts.onDrag(ev);
     }
 
-    function onUp() {
-      opts.onEnd?.();
+    function cleanup() {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
+      activeCleanup = null;
     }
 
+    function onUp() {
+      opts.onEnd?.();
+      cleanup();
+    }
+
+    activeCleanup = cleanup;
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
   }
@@ -46,6 +57,8 @@ export function dragResize(node: HTMLElement, options: DragResizeOptions) {
     },
     destroy() {
       node.removeEventListener("mousedown", handleMousedown);
+      // Release any listeners from a drag still in flight at unmount.
+      activeCleanup?.();
     },
   };
 }

--- a/src/lib/components/DropGhost.svelte
+++ b/src/lib/components/DropGhost.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  /**
+   * DropGhost — a styled placeholder that marks where a dragged item
+   * would land if released: a generic grey scrim with a dashed outline,
+   * sized to the source row's height so the drop slot matches the drop
+   * result.
+   */
+  export let height: number;
+  /** Left/right margin (in px) to match the hosting list's inset. */
+  export let inset: number = 8;
+</script>
+
+<div
+  style="
+    height: {height}px;
+    margin: 2px {inset}px;
+    border: 1px dashed rgba(255, 255, 255, 0.85);
+    border-radius: 6px;
+    background: rgba(40, 40, 40, 0.6);
+    box-sizing: border-box;
+    pointer-events: none;
+  "
+  aria-hidden="true"
+></div>

--- a/src/lib/components/InputPrompt.svelte
+++ b/src/lib/components/InputPrompt.svelte
@@ -52,13 +52,14 @@
     >
       <input
         bind:this={inputEl}
+        class="no-default-outline"
         type="text"
         placeholder={$inputPrompt.placeholder}
         value={$inputPrompt.defaultValue || ""}
         style="
           padding: 10px 14px; background: {$theme.bg}; border: 1px solid {$theme.borderActive};
           border-radius: 8px; color: {$theme.fg}; font-size: 14px;
-          outline: none; font-family: inherit; width: 100%; box-sizing: border-box;
+          font-family: inherit; width: 100%; box-sizing: border-box;
         "
       />
       <div style="display: flex; justify-content: flex-end; gap: 8px;">

--- a/src/lib/components/PaneView.svelte
+++ b/src/lib/components/PaneView.svelte
@@ -6,8 +6,13 @@
   import PreviewSurface from "./PreviewSurface.svelte";
   import type { Pane } from "../types";
   import { isTerminalSurface, isPreviewSurface } from "../types";
+  import { tabDragState } from "../services/tab-drag";
 
   export let pane: Pane;
+  export let workspaceId: string;
+  /** True when this is the workspace's focused pane — drives the focus border
+   *  and dims the others. */
+  export let isActive: boolean = false;
   export let onSelectSurface: (surfaceId: string) => void;
   export let onCloseSurface: (surfaceId: string) => void;
   export let onNewSurface: () => void;
@@ -15,7 +20,17 @@
   export let onSplitDown: () => void;
   export let onClosePane: () => void;
   export let onFocusPane: () => void;
-  export let onReorderTab: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+
+  // Directional split-zone highlight while a tab is dragged over this pane body.
+  $: surfaceSplitZone =
+    $tabDragState?.dropTarget?.kind === "surface-split" &&
+    $tabDragState.dropTarget.paneId === pane.id
+      ? $tabDragState.dropTarget.zone
+      : null;
+  // Whole-pane highlight while a tab is dragged onto this pane to merge.
+  $: mergeTarget =
+    $tabDragState?.dropTarget?.kind === "merge" &&
+    $tabDragState.dropTarget.paneId === pane.id;
 
   let paneEl: HTMLElement;
   let resizeObserver: ResizeObserver;
@@ -47,30 +62,56 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   bind:this={paneEl}
+  data-pane-body={pane.id}
   style="
     flex: 1; display: flex; flex-direction: column;
-    min-width: 0; min-height: 0;
-    border: 1px solid {$theme.border};
+    min-width: 0; min-height: 0; position: relative;
+    border: 1px solid {isActive || mergeTarget ? $theme.accent : $theme.border};
     border-radius: 4px; overflow: hidden;
   "
   on:mousedown={onFocusPane}
 >
-  <TabBar
-    {pane}
-    {onSelectSurface}
-    {onCloseSurface}
-    {onNewSurface}
-    {onSplitRight}
-    {onSplitDown}
-    {onClosePane}
-    {onReorderTab}
-  />
+  <!-- Content wrapper carries the inactive-pane dimming so the drag overlays
+       below stay at full opacity. -->
+  <div
+    style="
+      flex: 1; display: flex; flex-direction: column;
+      min-width: 0; min-height: 0;
+      opacity: {isActive ? 1 : 0.5}; transition: opacity 0.15s;
+    "
+  >
+    <TabBar
+      {pane}
+      {workspaceId}
+      paneIsActive={isActive}
+      {onSelectSurface}
+      {onCloseSurface}
+      {onNewSurface}
+      {onSplitRight}
+      {onSplitDown}
+      {onClosePane}
+    />
 
-  {#each pane.surfaces as surface (surface.id)}
-    {#if isTerminalSurface(surface)}
-      <TerminalSurface {surface} visible={surface.id === pane.activeSurfaceId} cwd={surface.cwd} />
-    {:else if isPreviewSurface(surface)}
-      <PreviewSurface {surface} visible={surface.id === pane.activeSurfaceId} />
-    {/if}
-  {/each}
+    {#each pane.surfaces as surface (surface.id)}
+      {#if isTerminalSurface(surface)}
+        <TerminalSurface {surface} visible={surface.id === pane.activeSurfaceId} cwd={surface.cwd} />
+      {:else if isPreviewSurface(surface)}
+        <PreviewSurface {surface} visible={surface.id === pane.activeSurfaceId} />
+      {/if}
+    {/each}
+  </div>
+
+  {#if surfaceSplitZone}
+    <div
+      aria-hidden="true"
+      style="
+        position: absolute; pointer-events: none; z-index: 100;
+        background: {$theme.accent}33; border: 2px solid {$theme.accent};
+        {surfaceSplitZone === 'top' ? 'top: 28px; left: 0; right: 0; bottom: 50%;' : ''}
+        {surfaceSplitZone === 'bottom' ? 'top: 50%; left: 0; right: 0; bottom: 0;' : ''}
+        {surfaceSplitZone === 'left' ? 'top: 28px; left: 0; bottom: 0; right: 50%;' : ''}
+        {surfaceSplitZone === 'right' ? 'top: 28px; left: 50%; bottom: 0; right: 0;' : ''}
+      "
+    ></div>
+  {/if}
 </div>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2,9 +2,11 @@
   import { theme } from "../stores/theme";
   import { sidebarVisible, sidebarWidth, contextMenu } from "../stores/ui";
   import { dragResize } from "../actions/drag-resize";
+  import { createDragReorder, type DragReorderState } from "../actions/drag-reorder";
   import { workspaces, activeWorkspaceIdx } from "../stores/workspace";
   import { extensionSections } from "../stores/extension-sidebar";
   import WorkspaceItem from "./WorkspaceItem.svelte";
+  import DropGhost from "./DropGhost.svelte";
   import ExtensionSidebarSection from "./ExtensionSidebarSection.svelte";
   import type { MenuItem } from "../context-menu-types";
 
@@ -25,6 +27,20 @@
   }
 
   let dragging = false;
+
+  // Mouse-driven workspace reorder (HTML5 DnD is unreliable in WKWebView).
+  let wsDrag: DragReorderState = { sourceIdx: null, indicator: null, active: false, sourceHeight: 0 };
+  const wsReorder = createDragReorder({
+    dataAttr: "ws-drag-idx",
+    containerSelector: ".workspace-list",
+    ghostStyle: () => ({ background: $theme.bgActive, border: `1px solid ${$theme.accent}` }),
+    onDrop: (from, to) => onReorderWorkspaces(from, to),
+    onStateChange: () => { wsDrag = wsReorder.getState(); },
+  });
+  $: showGhostBefore = (idx: number) =>
+    wsDrag.active && wsDrag.indicator?.idx === idx && wsDrag.indicator?.edge === "before";
+  $: showGhostAfter = (idx: number) =>
+    wsDrag.active && wsDrag.indicator?.idx === idx && wsDrag.indicator?.edge === "after";
 
   function showWorkspaceContextMenu(x: number, y: number, idx: number) {
     const items: MenuItem[] = [
@@ -88,8 +104,11 @@
     </div>
 
     <!-- Workspace list (always first) + extension sections -->
-    <div style="flex: 1; overflow-y: auto; padding: 4px 0;">
+    <div class="workspace-list" style="flex: 1; overflow-y: auto; padding: 4px 0;">
       {#each $workspaces as ws, idx (ws.id)}
+        {#if showGhostBefore(idx)}
+          <DropGhost height={wsDrag.sourceHeight} />
+        {/if}
         <WorkspaceItem
           bind:this={workspaceItems[ws.id]}
           workspace={ws}
@@ -99,8 +118,13 @@
           onClose={() => onCloseWorkspace(idx)}
           onRename={(name) => onRenameWorkspace(idx, name)}
           onContextMenu={(x, y) => showWorkspaceContextMenu(x, y, idx)}
-          onReorder={onReorderWorkspaces}
+          dataDragIdx={idx}
+          dragHidden={wsDrag.sourceIdx === idx}
+          onDragMousedown={(e) => wsReorder.start(e, idx)}
         />
+        {#if showGhostAfter(idx)}
+          <DropGhost height={wsDrag.sourceHeight} />
+        {/if}
       {/each}
       {#each $extensionSections as section (section.sectionId)}
         <ExtensionSidebarSection {section} />

--- a/src/lib/components/SplitNodeView.svelte
+++ b/src/lib/components/SplitNodeView.svelte
@@ -16,7 +16,6 @@
   export let onSplitDown: (paneId: string) => void;
   export let onClosePane: (paneId: string) => void;
   export let onFocusPane: (paneId: string) => void;
-  export let onReorderTab: ((paneId: string, fromIdx: number, toIdx: number) => void) | undefined = undefined;
 
   let dragging = false;
   let dragRect: DOMRect | null = null;
@@ -45,6 +44,8 @@
 {#if node.type === "pane"}
   <PaneView
     pane={node.pane}
+    workspaceId={workspace.id}
+    isActive={workspace.activePaneId === node.pane.id}
     onSelectSurface={(sid) => onSelectSurface(node.pane.id, sid)}
     onCloseSurface={(sid) => onCloseSurface(node.pane.id, sid)}
     onNewSurface={() => onNewSurface(node.pane.id)}
@@ -52,7 +53,6 @@
     onSplitDown={() => onSplitDown(node.pane.id)}
     onClosePane={() => onClosePane(node.pane.id)}
     onFocusPane={() => onFocusPane(node.pane.id)}
-    onReorderTab={onReorderTab ? (from, to) => onReorderTab!(node.pane.id, from, to) : undefined}
   />
 {:else}
   {@const zoomed = $zoomedSurfaceId}
@@ -78,7 +78,6 @@
         {onSplitDown}
         {onClosePane}
         {onFocusPane}
-        {onReorderTab}
       />
     </div>
     {#if !zoomActive}
@@ -108,7 +107,6 @@
         {onSplitDown}
         {onClosePane}
         {onFocusPane}
-        {onReorderTab}
       />
     </div>
   </div>

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,30 +1,28 @@
 <script lang="ts">
   import { theme } from "../stores/theme";
   import type { Surface } from "../types";
+  import { startTabDrag } from "../services/tab-drag";
 
   export let surface: Surface;
   export let index: number;
   export let isActive: boolean;
+  /** Whether the owning pane is the focused pane — greys the active underline
+   *  when false so the focused tab ties to the focused pane. */
+  export let paneIsActive: boolean = false;
   export let onSelect: () => void;
   export let onClose: () => void;
-  export let onReorder: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+  /** Pane + workspace that own this tab — needed to resolve drop targets. */
+  export let paneId: string;
+  export let workspaceId: string;
 
   let hovered = false;
   let closeHovered = false;
-  let dragOver = false;
 
-  function handleDragStart(e: DragEvent) {
-    e.dataTransfer?.setData("text/plain", index.toString());
-    e.dataTransfer!.effectAllowed = "move";
-  }
-
-  function handleDrop(e: DragEvent) {
-    e.preventDefault();
-    dragOver = false;
-    const fromIdx = parseInt(e.dataTransfer?.getData("text/plain") || "-1", 10);
-    if (fromIdx >= 0 && fromIdx !== index && onReorder) {
-      onReorder(fromIdx, index);
-    }
+  // Arm the mouse-driven tab drag (reorder / cross-pane merge / split). The
+  // engine preventDefaults mousedown but lets the subsequent click through, so
+  // tab selection and the close button still work when no drag occurs.
+  function handleMousedown(e: MouseEvent) {
+    startTabDrag(e, surface.id, paneId, workspaceId);
   }
 </script>
 
@@ -32,23 +30,20 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="tab"
-  draggable="true"
+  data-tab-surface-id={surface.id}
+  data-tab-idx={index}
   style="
     padding: 2px 10px; font-size: 11px; cursor: pointer;
     color: {isActive ? $theme.fg : $theme.fgMuted};
     background: {isActive ? $theme.bgActive : hovered ? $theme.bgHighlight : 'transparent'};
-    border-bottom: 2px solid {isActive ? $theme.accent : 'transparent'};
+    border-bottom: 2px solid {isActive ? (paneIsActive ? $theme.accent : $theme.border) : 'transparent'};
     border-radius: 4px 4px 0 0; white-space: nowrap;
     display: flex; align-items: center; gap: 4px;
-    {dragOver ? `outline: 1px solid ${$theme.accent};` : ''}
   "
   on:click={onSelect}
+  on:mousedown={handleMousedown}
   on:mouseenter={() => hovered = true}
   on:mouseleave={() => hovered = false}
-  on:dragstart={handleDragStart}
-  on:dragover|preventDefault={() => dragOver = true}
-  on:dragleave={() => dragOver = false}
-  on:drop={handleDrop}
 >
   {#if surface.hasUnread && !isActive}
     <span style="width: 5px; height: 5px; border-radius: 50%; background: {$theme.notify}; flex-shrink: 0;"></span>

--- a/src/lib/components/TabBar.svelte
+++ b/src/lib/components/TabBar.svelte
@@ -1,36 +1,95 @@
 <script lang="ts">
+  import { onMount, onDestroy, tick } from "svelte";
   import { theme } from "../stores/theme";
   import Tab from "./Tab.svelte";
   import type { Pane } from "../types";
 
   export let pane: Pane;
+  export let workspaceId: string;
+  export let paneIsActive: boolean = false;
   export let onSelectSurface: (surfaceId: string) => void;
   export let onCloseSurface: (surfaceId: string) => void;
   export let onNewSurface: () => void;
   export let onSplitRight: () => void;
   export let onSplitDown: () => void;
   export let onClosePane: () => void;
-  export let onReorderTab: ((fromIdx: number, toIdx: number) => void) | undefined = undefined;
+
+  // Overflow scroll affordance: when the tab strip overflows its width the
+  // scrollbar is hidden, so without chevrons the off-screen tabs are
+  // unreachable. Track scroll position to show ‹ / › only when scrollable.
+  let scrollEl: HTMLElement;
+  let canScrollLeft = false;
+  let canScrollRight = false;
+  let resizeObserver: ResizeObserver;
+
+  function updateScroll() {
+    if (!scrollEl) return;
+    canScrollLeft = scrollEl.scrollLeft > 0;
+    canScrollRight =
+      scrollEl.scrollLeft + scrollEl.clientWidth < scrollEl.scrollWidth - 1;
+  }
+
+  function scrollBy(delta: number) {
+    scrollEl?.scrollBy({ left: delta, behavior: "smooth" });
+    // scrollBy is async; re-read after it settles.
+    setTimeout(updateScroll, 200);
+  }
+
+  // Re-check overflow whenever the tab set changes.
+  $: if (scrollEl) { void pane.surfaces.length; tick().then(updateScroll); }
+
+  onMount(() => {
+    updateScroll();
+    resizeObserver = new ResizeObserver(updateScroll);
+    if (scrollEl) resizeObserver.observe(scrollEl);
+  });
+  onDestroy(() => resizeObserver?.disconnect());
 </script>
 
 <div
+  data-pane-id={pane.id}
   style="
     display: flex; align-items: center; gap: 1px;
     background: {$theme.tabBarBg}; border-bottom: 1px solid {$theme.tabBarBorder};
-    height: 28px; padding: 0 4px; flex-shrink: 0; overflow-x: auto;
-    scrollbar-width: none;
+    height: 28px; padding: 0 4px; flex-shrink: 0;
   "
 >
-  {#each pane.surfaces as surface, i (surface.id)}
-    <Tab
-      {surface}
-      index={i}
-      isActive={surface.id === pane.activeSurfaceId}
-      onSelect={() => onSelectSurface(surface.id)}
-      onClose={() => onCloseSurface(surface.id)}
-      onReorder={onReorderTab}
-    />
-  {/each}
+  {#if canScrollLeft}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <span
+      title="Scroll tabs left"
+      style="color: {$theme.fgDim}; cursor: pointer; padding: 0 2px; font-size: 12px; flex-shrink: 0;"
+      on:click|stopPropagation={() => scrollBy(-120)}
+    >‹</span>
+  {/if}
+  <div
+    bind:this={scrollEl}
+    on:scroll={updateScroll}
+    style="display: flex; align-items: center; gap: 1px; overflow-x: auto; scrollbar-width: none; flex: 0 1 auto; min-width: 0;"
+  >
+    {#each pane.surfaces as surface, i (surface.id)}
+      <Tab
+        {surface}
+        index={i}
+        isActive={surface.id === pane.activeSurfaceId}
+        {paneIsActive}
+        paneId={pane.id}
+        {workspaceId}
+        onSelect={() => onSelectSurface(surface.id)}
+        onClose={() => onCloseSurface(surface.id)}
+      />
+    {/each}
+  </div>
+  {#if canScrollRight}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <span
+      title="Scroll tabs right"
+      style="color: {$theme.fgDim}; cursor: pointer; padding: 0 2px; font-size: 12px; flex-shrink: 0;"
+      on:click|stopPropagation={() => scrollBy(120)}
+    >›</span>
+  {/if}
 
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/WorkspaceItem.svelte
+++ b/src/lib/components/WorkspaceItem.svelte
@@ -30,13 +30,26 @@
   export let onClose: () => void;
   export let onRename: (name: string) => void;
   export let onContextMenu: (x: number, y: number) => void;
-  export let onReorder: (fromIdx: number, toIdx: number) => void;
+  /** Index advertised on the row for the mouse-driven reorder engine. */
+  export let dataDragIdx: number = index;
+  /** mousedown handler that arms the drag-reorder engine (owned by Sidebar). */
+  export let onDragMousedown: (e: MouseEvent) => void = () => {};
+  /** When true the row is the active drag source — hidden in place while a
+   *  floating ghost + DropGhost slot stand in for it. */
+  export let dragHidden: boolean = false;
 
   let hovered = false;
   let closeHovered = false;
   let nameEl: HTMLSpanElement;
   let renaming = false;
-  let dragOver = false;
+
+  // Arm the reorder engine on mousedown, except while inline-renaming: the
+  // engine preventDefaults the mousedown, which would block caret placement
+  // in the contentEditable name.
+  function handleMousedown(e: MouseEvent) {
+    if (renaming) return;
+    onDragMousedown(e);
+  }
 
   $: allSurfaces = getAllSurfaces(workspace);
   $: hasUnread = allSurfaces.some(s => s.hasUnread);
@@ -77,33 +90,19 @@
     renaming = false;
   }
 
-  function handleDragStart(e: DragEvent) {
-    e.dataTransfer?.setData("text/plain", index.toString());
-  }
-
-  function handleDrop(e: DragEvent) {
-    e.preventDefault();
-    dragOver = false;
-    const fromIdx = parseInt(e.dataTransfer?.getData("text/plain") || "-1", 10);
-    if (fromIdx >= 0 && fromIdx !== index) {
-      onReorder(fromIdx, index);
-    }
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  draggable="true"
+  data-ws-drag-idx={dataDragIdx}
   style="
-    margin: {dragOver ? '24px' : '2px'} 8px 2px 8px; border-radius: 6px; overflow: hidden;
+    margin: 2px 8px; border-radius: 6px; overflow: hidden;
+    display: {dragHidden ? 'none' : 'block'};
     background: {isActive ? $theme.bgActive : hovered ? $theme.bgHighlight : 'transparent'};
     border-left: 3px solid {isActive ? $theme.accent : 'transparent'};
-    transition: margin 0.15s, opacity 0.15s;
+    transition: opacity 0.15s;
   "
-  on:dragstart={handleDragStart}
-  on:dragover|preventDefault={() => dragOver = true}
-  on:dragleave={() => dragOver = false}
-  on:drop={handleDrop}
+  on:mousedown={handleMousedown}
 >
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div

--- a/src/lib/components/WorkspaceView.svelte
+++ b/src/lib/components/WorkspaceView.svelte
@@ -11,7 +11,6 @@
   export let onSplitDown: (paneId: string) => void;
   export let onClosePane: (paneId: string) => void;
   export let onFocusPane: (paneId: string) => void;
-  export let onReorderTab: ((paneId: string, fromIdx: number, toIdx: number) => void) | undefined = undefined;
 </script>
 
 <div style="flex: 1; display: flex; min-height: 0; min-width: 0; {visible ? '' : 'display: none;'}">
@@ -25,6 +24,5 @@
     {onSplitDown}
     {onClosePane}
     {onFocusPane}
-    {onReorderTab}
   />
 </div>

--- a/src/lib/services/menu-paste-router.ts
+++ b/src/lib/services/menu-paste-router.ts
@@ -1,0 +1,85 @@
+/**
+ * Menu paste router — handles the `menu-paste` event emitted from the native
+ * Edit > Paste menu item (Cmd+V on macOS / Ctrl+V on Linux/Windows).
+ *
+ * Why a custom router: the menu accelerator preempts webview keydown, so the
+ * in-terminal Cmd+V handler in terminal-service.ts is effectively dead in
+ * production. Worse, the default `PredefinedMenuItem::paste` dispatches the
+ * native NSText `paste:` action, which delivers via input events and bypasses
+ * xterm.js's bracketed-paste wrapping. Claude Code (and other TUIs) rely on
+ * `\x1b[200~…\x1b[201~` to recognize a paste — without it they process the
+ * buffer character-by-character, submitting on the first newline.
+ *
+ * The router routes by focus:
+ *   - terminal surface  → `surface.terminal.paste(text)` (bracketed)
+ *   - input/textarea    → splice at selection, fire `input` event
+ *   - contenteditable   → `document.execCommand("insertText")`
+ *   - nothing focused   → no-op
+ */
+import { readText as clipboardRead } from "@tauri-apps/plugin-clipboard-manager";
+import { get } from "svelte/store";
+import { workspaces } from "../stores/workspace";
+import {
+  getAllSurfaces,
+  isTerminalSurface,
+  type TerminalSurface,
+} from "../types";
+
+function findTerminalForElement(el: Element): TerminalSurface | null {
+  for (const ws of get(workspaces)) {
+    for (const surface of getAllSurfaces(ws)) {
+      if (isTerminalSurface(surface) && surface.termElement.contains(el)) {
+        return surface;
+      }
+    }
+  }
+  return null;
+}
+
+function pasteIntoInput(
+  el: HTMLInputElement | HTMLTextAreaElement,
+  text: string,
+): void {
+  const start = el.selectionStart ?? el.value.length;
+  const end = el.selectionEnd ?? el.value.length;
+  const next = el.value.slice(0, start) + text + el.value.slice(end);
+  el.value = next;
+  const cursor = start + text.length;
+  el.setSelectionRange(cursor, cursor);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+export async function handleMenuPaste(): Promise<void> {
+  let text: string;
+  try {
+    text = await clipboardRead();
+  } catch (err) {
+    console.warn("Menu paste: clipboard read failed:", err);
+    return;
+  }
+  if (!text) return;
+
+  const active = document.activeElement;
+  if (!active) return;
+
+  const terminal = findTerminalForElement(active);
+  if (terminal && terminal.ptyId >= 0) {
+    terminal.terminal.paste(text);
+    return;
+  }
+
+  if (
+    active instanceof HTMLInputElement ||
+    active instanceof HTMLTextAreaElement
+  ) {
+    pasteIntoInput(active, text);
+    return;
+  }
+
+  if (
+    active instanceof HTMLElement &&
+    (active.isContentEditable || active.contentEditable === "true")
+  ) {
+    document.execCommand("insertText", false, text);
+  }
+}

--- a/src/lib/services/pane-service.ts
+++ b/src/lib/services/pane-service.ts
@@ -167,5 +167,132 @@ export function splitFromSidebar(direction: "horizontal" | "vertical") {
  * (or zooming a different surface) restores the split layout.
  */
 export function togglePaneZoom(surfaceId: string) {
-  zoomedSurfaceId.update((current) => (current === surfaceId ? null : surfaceId));
+  zoomedSurfaceId.update((current) =>
+    current === surfaceId ? null : surfaceId,
+  );
+}
+
+/**
+ * Collapse a now-empty source pane out of the workspace tree by replacing its
+ * parent split with the sibling subtree. The caller has already moved the
+ * surface out, so — unlike closePane — no PTY is killed here. No-op when the
+ * source pane is the workspace root (there is nothing to collapse into).
+ */
+function collapseEmptyPane(ws: Workspace, sourcePaneId: string) {
+  if (ws.splitRoot.type === "pane" && ws.splitRoot.pane.id === sourcePaneId)
+    return;
+  const parentInfo = findParentSplit(ws.splitRoot, sourcePaneId);
+  if (parentInfo && parentInfo.parent.type === "split") {
+    const sibling = parentInfo.parent.children[parentInfo.index === 0 ? 1 : 0];
+    if (ws.splitRoot === parentInfo.parent) {
+      ws.splitRoot = sibling;
+    } else {
+      replaceNodeInTree(ws.splitRoot, parentInfo.parent, sibling);
+    }
+  }
+}
+
+/**
+ * Drag a tab onto another pane's body: split the target pane, placing the
+ * dragged surface in a fresh pane beside it. `direction`/`before` encode which
+ * edge of the target the tab was dropped against (top/left → before). Backs the
+ * directional split-zone drop in tab drag-and-drop.
+ */
+export function splitPaneWithSurface(
+  surfaceId: string,
+  sourcePaneId: string,
+  targetPaneId: string,
+  direction: "horizontal" | "vertical" = "horizontal",
+  before = false,
+): void {
+  const ws = get(activeWorkspace);
+  if (!ws) return;
+  const allPanes = getAllPanes(ws.splitRoot);
+  const sourcePane = allPanes.find((p) => p.id === sourcePaneId);
+  const targetPane = allPanes.find((p) => p.id === targetPaneId);
+  if (!sourcePane || !targetPane) return;
+
+  const surfaceIdx = sourcePane.surfaces.findIndex((s) => s.id === surfaceId);
+  if (surfaceIdx === -1) return;
+  const [surface] = sourcePane.surfaces.splice(surfaceIdx, 1);
+  if (!surface) return;
+  if (sourcePane.activeSurfaceId === surfaceId) {
+    sourcePane.activeSurfaceId = sourcePane.surfaces[0]?.id ?? null;
+  }
+
+  const newPane: Pane = {
+    id: uid(),
+    surfaces: [surface],
+    activeSurfaceId: surface.id,
+  };
+  const newSplit: SplitNode = {
+    type: "split",
+    direction,
+    children: before
+      ? [
+          { type: "pane", pane: newPane },
+          { type: "pane", pane: targetPane },
+        ]
+      : [
+          { type: "pane", pane: targetPane },
+          { type: "pane", pane: newPane },
+        ],
+    ratio: 0.5,
+  };
+
+  if (ws.splitRoot.type === "pane" && ws.splitRoot.pane.id === targetPaneId) {
+    ws.splitRoot = newSplit;
+  } else {
+    const parentInfo = findParentSplit(ws.splitRoot, targetPaneId);
+    if (parentInfo && parentInfo.parent.type === "split") {
+      parentInfo.parent.children[parentInfo.index] = newSplit;
+    }
+  }
+
+  // Collapse the source pane if the move emptied it. The new split (target +
+  // dragged surface) was just spliced in above, so when target was the root
+  // the source can only be nested — safe to collapse.
+  if (sourcePane.surfaces.length === 0) {
+    collapseEmptyPane(ws, sourcePaneId);
+  }
+
+  ws.activePaneId = newPane.id;
+  workspaces.update((l) => [...l]);
+  safeFocus(surface);
+}
+
+/**
+ * Drag a tab onto another pane's tab bar: move the surface into that pane's tab
+ * list. The source pane collapses if the move empties it. No PTY is killed —
+ * the surface is relocated, not closed.
+ */
+export function mergeTabToPane(
+  surfaceId: string,
+  sourcePaneId: string,
+  targetPaneId: string,
+): void {
+  if (sourcePaneId === targetPaneId) return;
+  const ws = get(activeWorkspace);
+  if (!ws) return;
+  const allPanes = getAllPanes(ws.splitRoot);
+  const sourcePane = allPanes.find((p) => p.id === sourcePaneId);
+  const targetPane = allPanes.find((p) => p.id === targetPaneId);
+  if (!sourcePane || !targetPane) return;
+
+  const idx = sourcePane.surfaces.findIndex((s) => s.id === surfaceId);
+  if (idx === -1) return;
+  const [surface] = sourcePane.surfaces.splice(idx, 1);
+  if (!surface) return;
+  if (sourcePane.activeSurfaceId === surfaceId) {
+    sourcePane.activeSurfaceId = sourcePane.surfaces[0]?.id ?? null;
+  }
+  if (sourcePane.surfaces.length === 0) {
+    collapseEmptyPane(ws, sourcePaneId);
+  }
+
+  targetPane.surfaces.push(surface);
+  targetPane.activeSurfaceId = surface.id;
+  ws.activePaneId = targetPane.id;
+  workspaces.update((l) => [...l]);
+  safeFocus(surface);
 }

--- a/src/lib/services/tab-drag.ts
+++ b/src/lib/services/tab-drag.ts
@@ -1,0 +1,332 @@
+/**
+ * Tab drag-and-drop state machine.
+ *
+ * Tauri's WKWebView implements HTML5 DnD unreliably — drags can stall
+ * mid-flight or never fire `dragend` on the renderer side. The sidebar
+ * already replaced HTML5 DnD with a mouse-event state machine
+ * (`drag-reorder.ts`); this module mirrors that pattern for tab drags.
+ *
+ * The state machine activates after the cursor moves >5px from the
+ * mousedown origin, then publishes a live `tabDragState` describing the
+ * current drop target. On mouseup the resolved drop target dispatches
+ * to the right service call: within-pane reorder, cross-pane merge (drop
+ * on a tab bar), or directional surface-split (drop on a pane body).
+ */
+import { writable, get, type Readable } from "svelte/store";
+import { workspaces } from "../stores/workspace";
+import { theme } from "../stores/theme";
+import { getAllPanes } from "../types";
+import {
+  reorderTab,
+  mergeTabToPane,
+  splitPaneWithSurface,
+} from "./pane-service";
+
+export type TabDropTarget =
+  | { kind: "reorder"; paneId: string; insertIdx: number }
+  | { kind: "merge"; paneId: string }
+  | {
+      kind: "surface-split";
+      paneId: string;
+      zone: "top" | "bottom" | "left" | "right";
+    }
+  | null;
+
+export interface TabDragState {
+  surfaceId: string;
+  sourcePaneId: string;
+  sourceWorkspaceId: string;
+  position: { x: number; y: number };
+  dropTarget: TabDropTarget;
+}
+
+const _tabDragState = writable<TabDragState | null>(null);
+export const tabDragState: Readable<TabDragState | null> = {
+  subscribe: _tabDragState.subscribe,
+};
+
+let ghost: HTMLElement | null = null;
+let lastHoveredTabId: string | null = null;
+let activeCleanup: (() => void) | null = null;
+
+function activateHoveredTab(x: number, y: number, sourcePaneId: string): void {
+  const el = document.elementFromPoint(x, y);
+  if (!el) {
+    lastHoveredTabId = null;
+    return;
+  }
+  const tabEl = (el as Element).closest(
+    "[data-tab-surface-id]",
+  ) as HTMLElement | null;
+  if (!tabEl) {
+    lastHoveredTabId = null;
+    return;
+  }
+  const tabBarEl = tabEl.closest("[data-pane-id]") as HTMLElement | null;
+  if (!tabBarEl) {
+    lastHoveredTabId = null;
+    return;
+  }
+  const paneId = tabBarEl.getAttribute("data-pane-id");
+  const surfaceId = tabEl.getAttribute("data-tab-surface-id");
+  if (!paneId || !surfaceId || paneId === sourcePaneId) {
+    lastHoveredTabId = null;
+    return;
+  }
+  if (surfaceId === lastHoveredTabId) return;
+  lastHoveredTabId = surfaceId;
+  workspaces.update((wsList) =>
+    wsList.map((ws) => {
+      const pane = getAllPanes(ws.splitRoot).find((p) => p.id === paneId);
+      if (!pane || !pane.surfaces.find((s) => s.id === surfaceId)) return ws;
+      pane.activeSurfaceId = surfaceId;
+      return { ...ws };
+    }),
+  );
+}
+
+export function startTabDrag(
+  e: MouseEvent,
+  surfaceId: string,
+  paneId: string,
+  workspaceId: string,
+): void {
+  if (e.button !== 0) return;
+  e.preventDefault();
+
+  const startX = e.clientX;
+  const startY = e.clientY;
+  const sourceEl = e.currentTarget as HTMLElement | null;
+  let activated = false;
+
+  function onMove(ev: MouseEvent): void {
+    if (!activated) {
+      if (
+        Math.abs(ev.clientX - startX) < 5 &&
+        Math.abs(ev.clientY - startY) < 5
+      )
+        return;
+      activated = true;
+      if (sourceEl) {
+        const t = get(theme);
+        ghost = sourceEl.cloneNode(true) as HTMLElement;
+        Object.assign(ghost.style, {
+          position: "fixed",
+          pointerEvents: "none",
+          zIndex: "9999",
+          opacity: "0.9",
+          width: `${sourceEl.offsetWidth}px`,
+          left: `${ev.clientX + 8}px`,
+          top: `${ev.clientY - 12}px`,
+          background: t.bgActive,
+          color: t.fg,
+          borderBottom: `2px solid ${t.accent}`,
+          borderRadius: "4px 4px 0 0",
+          boxShadow: "0 4px 12px rgba(0,0,0,0.4)",
+          cursor: "grabbing",
+        });
+        document.body.appendChild(ghost);
+      }
+      activateHoveredTab(ev.clientX, ev.clientY, paneId);
+      const newDrop = detectDropTarget(
+        ev.clientX,
+        ev.clientY,
+        paneId,
+        workspaceId,
+      );
+      _tabDragState.set({
+        surfaceId,
+        sourcePaneId: paneId,
+        sourceWorkspaceId: workspaceId,
+        position: { x: ev.clientX, y: ev.clientY },
+        dropTarget: newDrop,
+      });
+    } else {
+      if (ghost) {
+        ghost.style.left = `${ev.clientX + 8}px`;
+        ghost.style.top = `${ev.clientY - 12}px`;
+      }
+      activateHoveredTab(ev.clientX, ev.clientY, paneId);
+      const newDrop = detectDropTarget(
+        ev.clientX,
+        ev.clientY,
+        paneId,
+        workspaceId,
+      );
+      _tabDragState.update((s) =>
+        s
+          ? {
+              ...s,
+              position: { x: ev.clientX, y: ev.clientY },
+              dropTarget: newDrop,
+            }
+          : s,
+      );
+    }
+  }
+
+  function onUp(): void {
+    cleanup();
+    commitTabDrop();
+  }
+
+  function onKey(ev: KeyboardEvent): void {
+    if (ev.key === "Escape") {
+      cleanup();
+      cancelTabDrag();
+    }
+  }
+
+  function cleanup(): void {
+    window.removeEventListener("mousemove", onMove);
+    window.removeEventListener("mouseup", onUp);
+    window.removeEventListener("keydown", onKey);
+    if (ghost) {
+      ghost.remove();
+      ghost = null;
+    }
+  }
+
+  activeCleanup = cleanup;
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mouseup", onUp);
+  window.addEventListener("keydown", onKey);
+}
+
+function detectDropTarget(
+  x: number,
+  y: number,
+  sourcePaneId: string,
+  sourceWorkspaceId: string,
+): TabDropTarget {
+  const el = document.elementFromPoint(x, y);
+
+  // el-dependent checks (tab bar → reorder/merge).
+  if (el) {
+    const tabBar = el.closest("[data-pane-id]") as HTMLElement | null;
+    if (tabBar) {
+      const paneId = tabBar.getAttribute("data-pane-id");
+      if (!paneId) return null;
+      if (paneId === sourcePaneId) {
+        const tabs = Array.from(
+          tabBar.querySelectorAll("[data-tab-idx]"),
+        ) as HTMLElement[];
+        let insertIdx = tabs.length;
+        for (const tab of tabs) {
+          const rect = tab.getBoundingClientRect();
+          if (x < rect.left + rect.width / 2) {
+            insertIdx = parseInt(tab.getAttribute("data-tab-idx") || "0", 10);
+            break;
+          }
+        }
+        return { kind: "reorder", paneId, insertIdx };
+      }
+      return { kind: "merge", paneId };
+    }
+  }
+
+  // Pane surface body — directional split hint.
+  // Use a bounding-rect scan instead of closest() so the xterm canvas
+  // (which sits at the top of the z-stack) doesn't block detection.
+  const paneBodies = Array.from(
+    document.querySelectorAll("[data-pane-body]"),
+  ) as HTMLElement[];
+  for (const bodyEl of paneBodies) {
+    const paneId = bodyEl.getAttribute("data-pane-body");
+    if (!paneId) continue;
+    if (paneId === sourcePaneId) {
+      // Allow same-pane surface-split only when there are ≥2 surfaces to split from.
+      const allWs = get(workspaces);
+      const srcWs = allWs.find((w) => w.id === sourceWorkspaceId);
+      const srcPane =
+        srcWs &&
+        getAllPanes(srcWs.splitRoot).find((p) => p.id === sourcePaneId);
+      if (!srcPane || srcPane.surfaces.length <= 1) continue;
+    }
+    const rect = bodyEl.getBoundingClientRect();
+    if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom)
+      continue;
+    const tabBarEl = bodyEl.querySelector(
+      "[data-pane-id]",
+    ) as HTMLElement | null;
+    const tabBarH = tabBarEl ? tabBarEl.getBoundingClientRect().height : 0;
+    const surfaceTop = rect.top + tabBarH;
+    const surfaceH = rect.height - tabBarH;
+    if (surfaceH <= 0) continue;
+    const relX = (x - rect.left) / rect.width;
+    const relY = (y - surfaceTop) / surfaceH;
+    const zone =
+      Math.abs(relX - 0.5) > Math.abs(relY - 0.5)
+        ? relX < 0.5
+          ? "left"
+          : "right"
+        : relY < 0.5
+          ? "top"
+          : "bottom";
+    return { kind: "surface-split", paneId, zone };
+  }
+
+  return null;
+}
+
+export function commitTabDrop(): void {
+  const state = get(_tabDragState);
+  _tabDragState.set(null);
+  lastHoveredTabId = null;
+  if (!state || !state.dropTarget) return;
+
+  const { surfaceId, sourcePaneId, sourceWorkspaceId, dropTarget } = state;
+
+  switch (dropTarget.kind) {
+    case "reorder": {
+      const allWs = get(workspaces);
+      const srcWs = allWs.find((w) => w.id === sourceWorkspaceId);
+      if (!srcWs) return;
+      const pane = getAllPanes(srcWs.splitRoot).find(
+        (p) => p.id === dropTarget.paneId,
+      );
+      if (!pane) return;
+      const fromIdx = pane.surfaces.findIndex((s) => s.id === surfaceId);
+      if (fromIdx === -1) return;
+      reorderTab(dropTarget.paneId, fromIdx, dropTarget.insertIdx);
+      break;
+    }
+    case "merge": {
+      mergeTabToPane(surfaceId, sourcePaneId, dropTarget.paneId);
+      break;
+    }
+    case "surface-split": {
+      const direction =
+        dropTarget.zone === "left" || dropTarget.zone === "right"
+          ? "horizontal"
+          : "vertical";
+      const before = dropTarget.zone === "left" || dropTarget.zone === "top";
+      splitPaneWithSurface(
+        surfaceId,
+        sourcePaneId,
+        dropTarget.paneId,
+        direction,
+        before,
+      );
+      break;
+    }
+    default:
+      // Unknown / not-yet-handled drop kinds are silent no-ops.
+      break;
+  }
+}
+
+export function cancelTabDrag(): void {
+  lastHoveredTabId = null;
+  activeCleanup?.();
+  activeCleanup = null;
+  _tabDragState.set(null);
+}
+
+/**
+ * Test-only seam — sets the internal drag state directly so tests can
+ * exercise commitTabDrop's branches without simulating a full drag.
+ */
+export function __setTabDropTargetForTest(state: TabDragState | null): void {
+  _tabDragState.set(state);
+}

--- a/src/lib/terminal-service.ts
+++ b/src/lib/terminal-service.ts
@@ -21,14 +21,35 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SearchAddon } from "@xterm/addon-search";
 import { invoke, Channel } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { readText as clipboardRead, writeText as clipboardWrite } from "@tauri-apps/plugin-clipboard-manager";
+import {
+  readText as clipboardRead,
+  writeText as clipboardWrite,
+} from "@tauri-apps/plugin-clipboard-manager";
+import {
+  isPermissionGranted as notifPermissionGranted,
+  requestPermission as notifRequestPermission,
+  sendNotification as notifSend,
+} from "@tauri-apps/plugin-notification";
 import { get } from "svelte/store";
 import { xtermTheme } from "./stores/theme";
 import { workspaces, activeWorkspaceIdx } from "./stores/workspace";
 import { contextMenu, pendingAction } from "./stores/ui";
-import { canPreview, getSupportedExtensions, openPreview } from "../preview/index";
+import {
+  canPreview,
+  getSupportedExtensions,
+  openPreview,
+} from "../preview/index";
 import type { TerminalSurface, Pane, Workspace } from "./types";
-import { uid, getAllSurfaces, getAllPanes, isTerminalSurface, findParentSplit, replaceNodeInTree, findSurfaceByPtyId, findPaneContainingSurface } from "./types";
+import {
+  uid,
+  getAllSurfaces,
+  getAllPanes,
+  isTerminalSurface,
+  findParentSplit,
+  replaceNodeInTree,
+  findSurfaceByPtyId,
+  findPaneContainingSurface,
+} from "./types";
 import type { MenuItem } from "./context-menu-types";
 import { getConfig } from "./config";
 import { reportError } from "./services/error-reporting";
@@ -39,13 +60,26 @@ import { ptyReady } from "./terminal/pty-ready";
 import "@xterm/xterm/css/xterm.css";
 
 // --- Re-exports: preserve the public API of ./terminal-service ---
-export { FONT_SIZE_MIN, FONT_SIZE_MAX, FONT_SIZE_DEFAULT, getFontSize, adjustFontSize, resetFontSize } from "./terminal/font-size";
-export { resolveFilePath, resolvedFontFamily, fontReady } from "./terminal/path-utils";
+export {
+  FONT_SIZE_MIN,
+  FONT_SIZE_MAX,
+  FONT_SIZE_DEFAULT,
+  getFontSize,
+  adjustFontSize,
+  resetFontSize,
+} from "./terminal/font-size";
+export {
+  resolveFilePath,
+  resolvedFontFamily,
+  fontReady,
+} from "./terminal/path-utils";
 export { handlePtyChunk } from "./terminal/flow-control";
 export { waitForPtyReady } from "./terminal/pty-ready";
 
 /** Platform detection — used for Cmd (macOS) vs Ctrl (Linux/Windows) shortcuts. */
-export const isMac = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
+export const isMac =
+  typeof navigator !== "undefined" &&
+  navigator.platform.toUpperCase().includes("MAC");
 
 /** Shortcut label helpers for platform-appropriate display. */
 export const modLabel = isMac ? "⌘" : "Ctrl+";
@@ -53,14 +87,59 @@ export const shiftModLabel = isMac ? "⇧⌘" : "Ctrl+Shift+";
 
 // --- Event Listeners ---
 
+/**
+ * True when `surfaceId` is the foreground surface of the foreground pane in the
+ * active workspace — i.e. the user is already looking at it, so an attention
+ * notification should be suppressed.
+ */
+export function isSurfaceInForeground(
+  ws: Workspace,
+  activeWs: Workspace | null,
+  surfaceId: string,
+): boolean {
+  if (ws.id !== activeWs?.id) return false;
+  return getAllPanes(ws.splitRoot).some(
+    (p) => p.id === ws.activePaneId && p.activeSurfaceId === surfaceId,
+  );
+}
+
+/**
+ * Show a desktop notification (Tauri plugin). Lazily requests permission on
+ * first use; silently no-ops if denied. Failures are swallowed — a missing
+ * notification daemon (Linux) shouldn't crash the terminal pipeline.
+ */
+async function sendDesktopNotification(
+  title: string,
+  body: string,
+): Promise<void> {
+  try {
+    let permitted = await notifPermissionGranted();
+    if (!permitted) {
+      permitted = (await notifRequestPermission()) === "granted";
+    }
+    if (!permitted) return;
+    notifSend({ title, body });
+  } catch (err) {
+    console.warn("[terminal-service] desktop notification failed:", err);
+  }
+}
+
 export async function setupListeners() {
   // On Linux, prevent WebKitGTK from intercepting Ctrl+Shift+C/V before xterm.js
   if (!isMac) {
-    window.addEventListener("keydown", (e) => {
-      if (e.ctrlKey && e.shiftKey && (e.key === "C" || e.key === "c" || e.key === "V" || e.key === "v")) {
-        e.preventDefault();
-      }
-    }, { capture: true });
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        if (
+          e.ctrlKey &&
+          e.shiftKey &&
+          (e.key === "C" || e.key === "c" || e.key === "V" || e.key === "v")
+        ) {
+          e.preventDefault();
+        }
+      },
+      { capture: true },
+    );
   }
   await listen<{ pty_id: number }>("pty-exit", (event) => {
     const { pty_id } = event.payload;
@@ -74,17 +153,21 @@ export async function setupListeners() {
       for (const ws of wsList) {
         for (const pane of getAllPanes(ws.splitRoot)) {
           const idx = pane.surfaces.findIndex(
-            (s) => isTerminalSurface(s) && s.ptyId === pty_id
+            (s) => isTerminalSurface(s) && s.ptyId === pty_id,
           );
           if (idx >= 0) {
             pane.surfaces.splice(idx, 1);
             if (pane.surfaces.length > 0) {
-              pane.activeSurfaceId = pane.surfaces[Math.min(idx, pane.surfaces.length - 1)].id;
+              pane.activeSurfaceId =
+                pane.surfaces[Math.min(idx, pane.surfaces.length - 1)].id;
             } else {
               // Pane is empty — collapse it from the split tree
               pane.activeSurfaceId = null;
               pane.resizeObserver?.disconnect();
-              if (ws.splitRoot.type === "pane" && ws.splitRoot.pane.id === pane.id) {
+              if (
+                ws.splitRoot.type === "pane" &&
+                ws.splitRoot.pane.id === pane.id
+              ) {
                 // This was the only pane in the workspace — remove the workspace
                 const wsIdx = wsList.indexOf(ws);
                 wsList.splice(wsIdx, 1);
@@ -100,7 +183,8 @@ export async function setupListeners() {
               // Find parent split and collapse it
               const parentInfo = findParentSplit(ws.splitRoot, pane.id);
               if (parentInfo && parentInfo.parent.type === "split") {
-                const sibling = parentInfo.parent.children[parentInfo.index === 0 ? 1 : 0];
+                const sibling =
+                  parentInfo.parent.children[parentInfo.index === 0 ? 1 : 0];
                 if (ws.splitRoot === parentInfo.parent) {
                   ws.splitRoot = sibling;
                 } else {
@@ -120,25 +204,43 @@ export async function setupListeners() {
     }
   });
 
-  await listen<{ pty_id: number; text: string }>("pty-notification", (event) => {
-    const { pty_id, text } = event.payload;
-    // Filter out escape-sequence fragments that slipped through (e.g. "4;0;")
-    if (/^\d+[;\d:\/]*$/.test(text) || !text.trim()) return;
-    workspaces.update((wsList) => {
-      const s = findSurfaceByPtyId(wsList, pty_id);
-      if (s) {
-        s.notification = text;
-        s.hasUnread = true;
+  await listen<{ pty_id: number; text: string }>(
+    "pty-notification",
+    (event) => {
+      const { pty_id, text } = event.payload;
+      // Filter out escape-sequence fragments that slipped through (e.g. "4;0;")
+      if (/^\d+[;\d:\/]*$/.test(text) || !text.trim()) return;
+      let notifyWorkspaceName: string | null = null;
+      workspaces.update((wsList) => {
+        const activeWs = wsList[get(activeWorkspaceIdx)];
+        for (const ws of wsList) {
+          for (const s of getAllSurfaces(ws)) {
+            if (isTerminalSurface(s) && s.ptyId === pty_id) {
+              s.notification = text;
+              s.hasUnread = true;
+              // Only fire a desktop notification when the user isn't already
+              // looking at this surface.
+              if (!isSurfaceInForeground(ws, activeWs, s.id)) {
+                notifyWorkspaceName = ws.name;
+              }
+              return wsList;
+            }
+          }
+        }
+        return wsList;
+      });
+      if (notifyWorkspaceName) {
+        void sendDesktopNotification(notifyWorkspaceName, text);
       }
-      return wsList;
-    });
-  });
+    },
+  );
 
   // OSC 0/2: shell sets window title (shows process name or custom title)
   await listen<{ pty_id: number; title: string }>("pty-title", (event) => {
     const { pty_id, title } = event.payload;
     // Filter out escape-sequence fragments that may slip through
-    if (!title || /[\x00-\x1f\x7f]/.test(title) || /^\d+[;\d:\/]*$/.test(title)) return;
+    if (!title || /[\x00-\x1f\x7f]/.test(title) || /^\d+[;\d:\/]*$/.test(title))
+      return;
     workspaces.update((wsList) => {
       const s = findSurfaceByPtyId(wsList, pty_id);
       if (s) {
@@ -161,13 +263,13 @@ export function startCwdPolling() {
       for (const s of getAllSurfaces(ws)) {
         if (isTerminalSurface(s) && s.ptyId >= 0) {
           invoke<string>("get_pty_cwd", { ptyId: s.ptyId })
-            .then(cwd => {
+            .then((cwd) => {
               if (cwd && cwd !== s.cwd) {
                 s.cwd = cwd;
                 const basename = cwd.split("/").pop() || cwd;
                 if (!s.title || s.title.startsWith("Shell ")) {
                   s.title = basename || "~";
-                  workspaces.update(l => [...l]);
+                  workspaces.update((l) => [...l]);
                 }
               }
             })
@@ -189,13 +291,16 @@ export async function createDefaultWorkspace() {
     activePaneId: pane.id,
   };
   await createTerminalSurface(pane);
-  workspaces.update(list => [...list, ws]);
+  workspaces.update((list) => [...list, ws]);
   activeWorkspaceIdx.set(0);
 }
 
 // --- Surface Creation ---
 
-export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<TerminalSurface> {
+export async function createTerminalSurface(
+  pane: Pane,
+  cwd?: string,
+): Promise<TerminalSurface> {
   const ptyId = -1; // PTY spawned later via connectPty() after fit()
 
   const currentXtermTheme = get(xtermTheme);
@@ -221,21 +326,31 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
   terminal.loadAddon(searchAddon);
 
   const termElement = document.createElement("div");
-  termElement.style.cssText = "flex: 1; min-height: 0; min-width: 0; padding: 2px 4px;";
+  termElement.style.cssText =
+    "flex: 1; min-height: 0; min-width: 0; padding: 2px 4px;";
 
   const surface: TerminalSurface = {
     kind: "terminal",
-    id: uid(), terminal, fitAddon, searchAddon, termElement, ptyId,
+    id: uid(),
+    terminal,
+    fitAddon,
+    searchAddon,
+    termElement,
+    ptyId,
     title: `Shell ${pane.surfaces.length + 1}`,
     cwd: cwd,
-    hasUnread: false, opened: false,
+    hasUnread: false,
+    opened: false,
   };
 
   // Cmd+click file path detection for preview
   terminal.registerLinkProvider({
     provideLinks: (lineNumber, callback) => {
       const line = terminal.buffer.active.getLine(lineNumber - 1);
-      if (!line) { callback(undefined); return; }
+      if (!line) {
+        callback(undefined);
+        return;
+      }
       const text = line.translateToString();
       const exts = getSupportedExtensions().join("|");
       const patterns = [
@@ -255,15 +370,23 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
         candidates.push({ path, startX, endX: startX + path.length });
       }
 
-      if (candidates.length === 0) { callback(undefined); return; }
+      if (candidates.length === 0) {
+        callback(undefined);
+        return;
+      }
 
       Promise.all(
         candidates.map(async (c) => {
           const fullPath = await resolveFilePath(c.path, surface.cwd);
-          const exists = await invoke<boolean>("file_exists", { path: fullPath });
+          const exists = await invoke<boolean>("file_exists", {
+            path: fullPath,
+          });
           if (!exists) return null;
           return {
-            range: { start: { x: c.startX + 1, y: lineNumber }, end: { x: c.endX + 1, y: lineNumber } },
+            range: {
+              start: { x: c.startX + 1, y: lineNumber },
+              end: { x: c.endX + 1, y: lineNumber },
+            },
             text: c.path,
             activate: async (e: MouseEvent, linkText: string) => {
               if (e.button !== 0) return;
@@ -271,9 +394,11 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
               pendingAction.set({ type: "open-preview", payload: resolved });
             },
           };
-        })
+        }),
       ).then((results) => {
-        const links = results.filter((r): r is NonNullable<typeof r> => r !== null);
+        const links = results.filter(
+          (r): r is NonNullable<typeof r> => r !== null,
+        );
         callback(links.length > 0 ? links : undefined);
       });
     },
@@ -287,15 +412,28 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
 
     // Linux: Ctrl+Shift+C = copy, Ctrl+Shift+V = paste
     // Uses Tauri clipboard plugin because webview clipboard access isn't guaranteed.
-    if (e.ctrlKey && e.shiftKey && !e.metaKey && (e.key === "C" || e.key === "c")) {
+    if (
+      e.ctrlKey &&
+      e.shiftKey &&
+      !e.metaKey &&
+      (e.key === "C" || e.key === "c")
+    ) {
       const sel = terminal.getSelection();
       if (sel) clipboardWrite(sel);
       return false;
     }
-    if (e.ctrlKey && e.shiftKey && !e.metaKey && (e.key === "V" || e.key === "v")) {
+    if (
+      e.ctrlKey &&
+      e.shiftKey &&
+      !e.metaKey &&
+      (e.key === "V" || e.key === "v")
+    ) {
       e.preventDefault();
-      clipboardRead().then(text => {
-        if (text && surface.ptyId >= 0) invoke("write_pty", { ptyId: surface.ptyId, data: text }).catch((e) => reportError(e, "write_pty"));
+      clipboardRead().then((text) => {
+        if (text && surface.ptyId >= 0)
+          invoke("write_pty", { ptyId: surface.ptyId, data: text }).catch((e) =>
+            reportError(e, "write_pty"),
+          );
       });
       return false;
     }
@@ -320,25 +458,35 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
       // Cmd+V — paste
       if (!alt && !shift && k === "v") {
         e.preventDefault();
-        clipboardRead().then(text => {
-          if (text && surface.ptyId >= 0) invoke("write_pty", { ptyId: surface.ptyId, data: text }).catch((e) => reportError(e, "write_pty"));
-        }).catch((err) => console.warn("Clipboard read failed:", err));
+        clipboardRead()
+          .then((text) => {
+            if (text && surface.ptyId >= 0)
+              invoke("write_pty", { ptyId: surface.ptyId, data: text }).catch(
+                (e) => reportError(e, "write_pty"),
+              );
+          })
+          .catch((err) => console.warn("Clipboard read failed:", err));
         return false;
       }
 
       // Cmd+key (no alt) — let App.svelte handle
       if (!alt && !shift) {
-        if (["n","t","d","w","b","p","k","f","g"].includes(k)) return false;
+        if (["n", "t", "d", "w", "b", "p", "k", "f", "g"].includes(k))
+          return false;
         if (k >= "1" && k <= "9") return false;
       }
       // Shift+Cmd+key
       if (shift && !alt) {
-        if (["d","w","h","r","p","g","t"].includes(k)) return false;
+        if (["d", "w", "h", "r", "p", "g", "t"].includes(k)) return false;
         if (k === "enter") return false;
         if (k === "[" || k === "]") return false;
       }
       // Alt+Cmd+arrows for pane nav
-      if (alt && ["arrowleft","arrowright","arrowup","arrowdown"].includes(k)) return false;
+      if (
+        alt &&
+        ["arrowleft", "arrowright", "arrowup", "arrowdown"].includes(k)
+      )
+        return false;
     } else {
       // Linux/Windows: only intercept Ctrl+Shift combos for app shortcuts.
       // Plain Ctrl+key passes through to PTY for TUI apps.
@@ -348,7 +496,8 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
       const alt = e.altKey;
       // Ctrl+Shift+key — let App.svelte handle app shortcuts
       if (!alt) {
-        if (["n","t","d","w","b","p","k","f","g","h","r"].includes(k)) return false;
+        if (["n", "t", "d", "w", "b", "p", "k", "f", "g", "h", "r"].includes(k))
+          return false;
         if (k === "enter") return false;
         if (k === "[" || k === "]") return false;
       }
@@ -358,10 +507,16 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
   });
 
   terminal.onData((data) => {
-    if (surface.ptyId >= 0) invoke("write_pty", { ptyId: surface.ptyId, data }).catch((e) => reportError(e, "write_pty"));
+    if (surface.ptyId >= 0)
+      invoke("write_pty", { ptyId: surface.ptyId, data }).catch((e) =>
+        reportError(e, "write_pty"),
+      );
   });
   terminal.onResize(({ cols, rows }) => {
-    if (surface.ptyId >= 0) invoke("resize_pty", { ptyId: surface.ptyId, cols, rows }).catch((e) => reportError(e, "resize_pty"));
+    if (surface.ptyId >= 0)
+      invoke("resize_pty", { ptyId: surface.ptyId, cols, rows }).catch((e) =>
+        reportError(e, "resize_pty"),
+      );
   });
   // NOTE: We intentionally do NOT use terminal.onTitleChange() here.
   // xterm.js fires it with raw/partial escape sequence fragments (OSC 7 cwd data,
@@ -380,7 +535,11 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
     }
     surface.cwd = cwd;
     const basename = cwd.split("/").pop() || cwd;
-    if (!surface.title || surface.title.startsWith("Shell ") || !surface.title.includes(" ")) {
+    if (
+      !surface.title ||
+      surface.title.startsWith("Shell ") ||
+      !surface.title.includes(" ")
+    ) {
       surface.title = basename || "~";
     }
     return true;
@@ -405,14 +564,25 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
     items.push({
       label: "Paste",
       shortcut: isMac ? "⌘V" : "Ctrl+Shift+V",
-      action: () => clipboardRead().then(t => {
-        if (t && surface.ptyId >= 0) invoke("write_pty", { ptyId: surface.ptyId, data: t }).catch((e) => reportError(e, "write_pty"));
-      }).catch((e) => reportError(e, "clipboard-read")),
+      action: () =>
+        clipboardRead()
+          .then((t) => {
+            if (t && surface.ptyId >= 0)
+              invoke("write_pty", { ptyId: surface.ptyId, data: t }).catch(
+                (e) => reportError(e, "write_pty"),
+              );
+          })
+          .catch((e) => reportError(e, "clipboard-read")),
     });
 
     // Check if selection looks like a file path
     const pathText = (selection || "").trim();
-    const looksLikePath = pathText && (pathText.startsWith("/") || pathText.startsWith("./") || pathText.startsWith("~/") || pathText.match(/^[\w.-]+\.[a-z]+$/i));
+    const looksLikePath =
+      pathText &&
+      (pathText.startsWith("/") ||
+        pathText.startsWith("./") ||
+        pathText.startsWith("~/") ||
+        pathText.match(/^[\w.-]+\.[a-z]+$/i));
 
     if (looksLikePath) {
       const resolvePath = () => resolveFilePath(pathText, surface.cwd);
@@ -433,12 +603,14 @@ export async function createTerminalSurface(pane: Pane, cwd?: string): Promise<T
 
       items.push({
         label: "Show in File Manager",
-        action: async () => invoke("show_in_file_manager", { path: await resolvePath() }),
+        action: async () =>
+          invoke("show_in_file_manager", { path: await resolvePath() }),
       });
 
       items.push({
         label: "Open with Default App",
-        action: async () => invoke("open_with_default_app", { path: await resolvePath() }),
+        action: async () =>
+          invoke("open_with_default_app", { path: await resolvePath() }),
       });
     }
 
@@ -499,7 +671,10 @@ function findContextForSurface(
  *  when the surface is already attached to a workspace pane. This is the
  *  delivery mechanism for the MCP connection-binding contract — see the
  *  Spacebase MCP spec § Connection binding. */
-export async function connectPty(surface: TerminalSurface, cwd?: string): Promise<void> {
+export async function connectPty(
+  surface: TerminalSurface,
+  cwd?: string,
+): Promise<void> {
   if (surface.ptyId >= 0) return; // already connected
   const cols = surface.terminal.cols;
   const rows = surface.terminal.rows;


### PR DESCRIPTION
Ports the worthwhile quality-of-life improvements from the `dev` branch onto the current architecture (stacked on **#156** / `audit-remediation`). `dev` is a 34-commit re-architecture that shares no history with this line beyond the main base, so each item was ported feature-by-feature against this branch's pane model, not merged.

The headline win: `dev` deliberately replaced HTML5 drag-and-drop with mouse-event state machines because **Tauri's WKWebView implements HTML5 DnD unreliably** (drags stall mid-flight or never fire `dragend`). This branch carries that fix.

## Tier 1 (all included)
- **Bracketed paste** — Edit > Paste now routes through xterm so terminals get bracketed paste (`\x1b[200~…\x1b[201~`). Fixes multiline paste into Claude Code submitting on the first newline. (custom Paste `MenuItem` → `menu-paste` event → focus-routing `menu-paste-router.ts`)
- **Mouse-driven reorder engine** — replaces flaky HTML5 DnD for workspace reorder with a ghost + insert-indicator + Escape-to-cancel engine, plus a `DropGhost` slot. (`drag-reorder.ts`, `DropGhost.svelte`)
- **`dragResize` mid-drag unmount cleanup** — releases window listeners if the host unmounts mid-drag.
- **Tab overflow chevrons** — `‹`/`›` to reach tabs when the strip overflows (its scrollbar is hidden → tabs were unreachable).
- **xterm scrollbar + keyboard focus ring** — style the unstyled xterm v6 slider (reveal-on-hover, theme-dimmed); `.no-default-outline` keeps a `:focus-visible` keyboard ring (closes an a11y gap on the InputPrompt).

## Tier 2 (3 of 5 included)
- **Tab drag = merge + directional split** — drag a tab onto another pane's tab bar to **merge**, or onto a pane body to **split** with a top/bottom/left/right zone overlay. (`tab-drag.ts` + `splitPaneWithSurface`/`mergeTabToPane`)
- **Pane focus affordances** — dim inactive panes and grey the inactive tab underline so the focused split is obvious.
- **Desktop notification on attention** — when a terminal fires an attention OSC and you're not looking at it, raise an OS notification titled with the workspace name. (also wires the tauri notification plugin, which was a JS dep with no Rust side)

### Descoped from Tier 2 (with rationale)
Both depend on infrastructure the current architecture doesn't have, which `dev` rebuilt as part of its bootstrap/state re-architecture (flagged "skip / entangled" in the audit). Porting either means importing that subsystem — out of proportion and risk for a QoL PR:

- **Split-divider resize persistence** — this branch has **no live layout persistence at all** (`splitPane`/reorder don't persist either; only manual "Save Workspace" does). Making resize survive reload needs `dev`'s separate `state.json` + debounced `schedulePersist` bootstrap subsystem.
- **Inode CWD-rename detection** — the live `Workspace` model has **no root-path field** (cwd is per-surface) and no `pathMissing`/`pathInode`. `dev`'s sweep operates on `workspace.path` — which doesn't exist here. Porting needs a new workspace-root-path model + live persistence + missing-state UI.

Happy to do either as a focused follow-up if you want the persistence layer.

## Verification (local)
- `npx tsc --noEmit` — clean
- `npm test` — **386 passed** (26 files; +26 over the 360 baseline: drag-resize, drag-reorder, tab-drag, menu-paste, desktop-notification)
- `npx vite build` — ok
- `cargo check` — the paste menu change verified clean. The notification crate (`tauri-plugin-notification`) can't be fetched in this sandboxed environment, so the 3-line Rust wiring is verified by CI's `cargo check` (runs without `--locked`). `Cargo.lock` was fully resolved and committed (+507), confirming the dep is version-compatible.

## Test plan
- [ ] **Bracketed paste:** copy a multiline block, ⌘V into a terminal running Claude Code — it pastes as one block (does not submit on the first line). ⌘V into the workspace-rename / InputPrompt field still pastes normally.
- [ ] **Workspace reorder:** drag a workspace row in the sidebar — a ghost follows the cursor, a dashed slot shows the drop target, release reorders; **Escape mid-drag cancels**. Clicking a row still selects; the close ✕ and inline rename still work.
- [ ] **Tab reorder:** drag a tab within its pane's tab bar to reorder it.
- [ ] **Tab merge:** drag a tab onto another pane's tab bar — the tab moves into that pane; the source pane collapses if it's left empty.
- [ ] **Tab split:** drag a tab onto another pane's body — a top/bottom/left/right zone highlights; release splits the pane in that direction with the tab in a new pane.
- [ ] **Pane focus:** with ≥2 panes, the focused pane is full-opacity with an accent border; others are dimmed; the inactive pane's active-tab underline is grey.
- [ ] **Tab overflow:** open enough tabs to overflow the bar — `‹`/`›` chevrons appear and scroll the strip.
- [ ] **Scrollbar + focus ring:** scroll a terminal — the slider thumb is visible and brightens on hover. Tab-key focus into the InputPrompt shows a keyboard ring; mouse focus does not.
- [ ] **Desktop notification:** unfocus the window (or switch to another workspace/pane), trigger a terminal attention notification — an OS notification titled with the workspace name appears. Grant the permission prompt on first use. With the surface focused in the foreground pane, **no** OS notification fires (in-app unread dot only).
- [ ] **CI:** Frontend tests, Vite build, `cargo check`, and Rust tests all green (confirms the notification plugin compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)