### PR TITLE
chore(telem): tag OTEL telemetry with project.name=TheGnarCo/gnar-term

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "project.name=TheGnarCo/gnar-term"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a committed `.claude/settings.json` that sets the `OTEL_RESOURCE_ATTRIBUTES` env var to `project.name=TheGnarCo/gnar-term`.

This is the per-project dimension gnar-telem groups Claude Code COGS/spend by. A checked-in `.claude/settings.json` `env` entry is the right channel: the slug is a constant, it's injected at process init ahead of OTEL exporter setup, it's inherited by subagents and headless `claude -p` runs, and — being checked in — every clone emits the right tag with zero per-member setup. Without it, usage buckets as `(untagged)`.

This replaces the older retired `gnar-repo-tag` shell wrapper. The org-wide OTEL plumbing (endpoint, exporter, ingest token) stays in the Claude admin UI with `OTEL_RESOURCE_ATTRIBUTES` left unset there so this per-repo value flows through.

```json
{
  "env": {
    "OTEL_RESOURCE_ATTRIBUTES": "project.name=TheGnarCo/gnar-term"
  }
}
```

No prior `.claude/settings.json` existed (only `.claude/commands/`), so there were no sibling keys to preserve.

## Test plan

- [ ] Confirm `.claude/settings.json` is valid JSON and contains `env.OTEL_RESOURCE_ATTRIBUTES = "project.name=TheGnarCo/gnar-term"`
- [ ] Launch a `claude` session in a clone of this branch and confirm new telemetry is attributed to `TheGnarCo/gnar-term` (no longer `(untagged)`) in gnar-telem's per-project view
- [ ] Verify no leftover `gnar-repo-tag` shell rc wiring is exporting `OTEL_RESOURCE_ATTRIBUTES` (which would outrank the settings file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)